### PR TITLE
Initial image layout documentation and fixups

### DIFF
--- a/config/generic64-apt-simple.cfg
+++ b/config/generic64-apt-simple.cfg
@@ -3,6 +3,8 @@
 
 [image]
 layout=mbr/simple_dual
+boot_part_size=200%
+root_part_size=300%
 name=deb12-arm64-min
 
 [system]

--- a/examples/custom_layers/config/acme-integration.cfg
+++ b/examples/custom_layers/config/acme-integration.cfg
@@ -5,6 +5,8 @@ board=pi5
 
 [image]
 layout=mbr/simple_dual
+boot_part_size=200%
+root_part_size=300%
 name=acme-developer
 compression=zstd
 

--- a/examples/debstore/config/deb12-store.cfg
+++ b/examples/debstore/config/deb12-store.cfg
@@ -3,6 +3,8 @@ board=pi5
 
 [image]
 layout=mbr/simple_dual
+boot_part_size=200%
+root_part_size=300%
 name=debstore-test
 
 [system]

--- a/image/README.adoc
+++ b/image/README.adoc
@@ -1,0 +1,58 @@
+= Image Layouts
+
+This directory contains the 'in-tree' image layouts supported by rpi-image-gen.
+
+[cols="1,1"]
+|===
+|Name |Description
+
+|mbr/simple_dual
+|Raspberry Pi OS style
+
+|gpt/ab_userdata *(Beta)*
+|AB capable with a data partition retained across rotations
+
+|===
+
+For detailed information about a particular layout, including configuration options, please refer to documentation within the appropriate layout sub-directory.
+
+== Notes
+
+Unless otherwise stated, the following apply to all layouts:
+
+* `Size`
+
+Sizes are specified in units supported by ```genimage``` (https://github.com/pengutronix/genimage).
+
+* `Default Size`
+
+Each partition image encapsulated in the final disk image has a default size. Typically this is 100% of the filesystem that is created and filled, which means there is no headroom if the filesystem is intended to be writable. The rpi-image-gen configuration attributes (i.e. the config or options file) must declare appropriate sizes for all partitions if the default sizes are not suitable. 100% is likely a suitable size if the partition contains a read-only filesystem such as squashfs.
+
+* `mke2fs.conf`
+
+rpi-image-gen layouts instruct ```genimage``` to use the Host mke2fs to create Extended File Systems (e.g. ext4). In order to ensure these filesystems are created consistently, ```genimage``` will use a particular ```mke2fs.conf``` when creating the image. Additional options may also be passed to mke2fs depending on the layout.
+
+* `vfat`
+
+When creating FAT filesystems, different options may be passed to ```mkdosfs(8)``` by genimage depending on the layout.
+
+* `Configuration Options`
+
+Variables that allow customisation of a layout should be declared in either the Config or Options files in as described in the rpi-image-gen documentation. For example:
+
+Variable ```image_boot_part_size``` can be set by:
+
+Config
+
+----
+[image]
+boot_part_size=200%
+----
+
+or:
+
+Options
+
+----
+image_boot_part_size=200%
+----

--- a/image/mbr/simple_dual/README.adoc
+++ b/image/mbr/simple_dual/README.adoc
@@ -1,0 +1,43 @@
+= mbr/simple_dual
+
+== Description
+
+Similar to Raspberry Pi OS, this layout has an MBR partition table containing two partitions.
+
+== Partitions
+
+[cols="1,1,1,1,1"]
+|===
+|Filesystem |Label |Attributes |Default Size |Description
+
+|vfat
+|BOOT
+|[1]
+|100%
+|Boot firmware
+
+|ext4
+|ROOT
+|[1]
+|100%
+|Root filesystem
+
+|===
+
+[1] Refer to ```genimage.cfg.in```
+
+== Configuration Options
+
+[cols="1,1"]
+|===
+|Variable |Description
+
+|image_boot_part_size
+|Size of the boot partition image
+
+|image_root_part_size
+|Size of the root partition image
+
+|===
+
+

--- a/image/mbr/simple_dual/genimage.cfg.in
+++ b/image/mbr/simple_dual/genimage.cfg.in
@@ -26,6 +26,7 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
 image boot.vfat {
    vfat {
       label = "BOOT"
+      extraargs = "-s 4 -S 512"
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"
@@ -34,8 +35,9 @@ image boot.vfat {
 
 image root.ext4 {
    ext4 {
-      use-mke2fs = true
       label = "ROOT"
+      use-mke2fs = true
+      mke2fs-conf = <MKE2FSCONF>
    }
    size = <ROOT_SIZE>
    mountpoint = "/"

--- a/image/mbr/simple_dual/mke2fs.conf
+++ b/image/mbr/simple_dual/mke2fs.conf
@@ -1,0 +1,45 @@
+[defaults]
+	base_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr
+	default_mntopts = acl,user_xattr
+	enable_periodic_fsck = 0
+	blocksize = 4096
+	inode_size = 256
+	inode_ratio = 16384
+
+[fs_types]
+	ext3 = {
+		features = has_journal
+	}
+	ext4 = {
+		features = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize
+	}
+	small = {
+		blocksize = 1024
+		inode_ratio = 4096
+	}
+	floppy = {
+		blocksize = 1024
+		inode_ratio = 8192
+	}
+	big = {
+		inode_ratio = 32768
+	}
+	huge = {
+		inode_ratio = 65536
+	}
+	news = {
+		inode_ratio = 4096
+	}
+	largefile = {
+		inode_ratio = 1048576
+		blocksize = -1
+	}
+	largefile4 = {
+		inode_ratio = 4194304
+		blocksize = -1
+	}
+	hurd = {
+	     blocksize = 4096
+	     inode_size = 128
+	     warn_y2038_dates = 0
+	}

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -5,18 +5,15 @@ set -eu
 rootfs=$1
 genimg_in=$2
 
-# Generate the config for genimage to ingest:
-# FIXME - sizes should be easily configurable
-FW_SIZE=200%
-ROOT_SIZE=300%
-
-SETUP=$(readlink -f setup.sh)
+: "${IGconf_image_boot_part_size:=100%}"
+: "${IGconf_image_root_part_size:=100%}"
 
 cat genimage.cfg.in | sed \
    -e "s|<IMAGE_DIR>|$IGconf_image_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
-   -e "s|<FW_SIZE>|$FW_SIZE|g" \
-   -e "s|<ROOT_SIZE>|$ROOT_SIZE|g" \
-   -e "s|<SETUP>|'$SETUP'|g" \
+   -e "s|<FW_SIZE>|$IGconf_image_boot_part_size|g" \
+   -e "s|<ROOT_SIZE>|$IGconf_image_root_part_size|g" \
+   -e "s|<SETUP>|'$(readlink -ef setup.sh)'|g" \
+   -e "s|<MKE2FSCONF>|'$(readlink -ef mke2fs.conf)'|g" \
    > ${genimg_in}/genimage.cfg

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
-set -u
+set -eu
 
 DISKLABEL=$1
 


### PR DESCRIPTION
Add documentation to the top level image subdirectory which lists all in-tree layouts as well as common informative points.

Each image layout must contain documentation which describes it, along with clear information about partitions, filesystems and configuration options available to the user.

Since we use mke2fs from the host when creating extN filesystems, we should ensure consistency of creation which means telling genimage to use a mke2fs.conf of our choice rather than /etc/mke2fs.conf from the host.

mbr/simple_dual
 Add documentation
 Set default partition sizes
 Clean up scripts
 Add mke2fs.conf

Update examples which use mbr/simple_dual to set the partition sizes they require.