### PR TITLE
Install common initramfs hooks

### DIFF
--- a/scripts/bdebstrap/customize10-initramfs
+++ b/scripts/bdebstrap/customize10-initramfs
@@ -2,6 +2,11 @@
 
 set -eu
 
+# Install common hooks
+if [ -d $1/etc/initramfs-tools/hooks ] ; then
+   cp ../initramfs-tools/hooks/* $1/etc/initramfs-tools/hooks
+fi
+
 # Always make sure all initramfs are updated
 if [ -s $1/etc/initramfs-tools/update-initramfs.conf ] ; then
    cp $1/etc/initramfs-tools/update-initramfs.conf $1/etc/initramfs-tools/update-initramfs.conf.bak

--- a/scripts/initramfs-tools/hooks/rpi-udev-rules
+++ b/scripts/initramfs-tools/hooks/rpi-udev-rules
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+case $1 in
+prereqs)
+   echo "udev"
+   exit 0
+   ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+mkdir -p $DESTDIR/lib/udev/rules.d/
+
+for rule in /etc/udev/rules.d/*-rpi-*.rules; do
+   if [ -e "$rule" ]; then
+      cp -p "$rule" $DESTDIR/lib/udev/rules.d/
+   fi
+done
+


### PR DESCRIPTION
By installing hooks prior to generation of the initramfs, it provides rpi-image-gen the ability to customise initramfs contents if required.

Add a new hook to install rpi udev rules in the initramfs. All rules matching the naming scheme will be installed.