### PR TITLE
Add AB slot helpers

### DIFF
--- a/image/gpt/ab_userdata/bdebstrap/customize01-slots
+++ b/image/gpt/ab_userdata/bdebstrap/customize01-slots
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -u
+
+install -m 0644 -D ../device/slot.rules $1/etc/udev/rules.d/90-rpi-slot.rules
+install -m 0755 -D ../device/slot $1/usr/bin/slot

--- a/image/gpt/ab_userdata/device/slot
+++ b/image/gpt/ab_userdata/device/slot
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -u
+
+exec 2>/dev/null
+
+slot=$(grep -oP 'root=/dev/disk/by-label/ROOT\K[A-B]' /proc/cmdline)
+case $slot in
+   A)
+      active=A
+      other=B
+      ;;
+   B)
+      active=B
+      other=A
+      ;;
+   *)
+      exit 1
+      ;;
+esac
+
+if [ $# -eq 0 ] ; then
+   echo "$active"
+elif [ $# -eq 1 ] ; then
+   case $1 in
+      active) echo "$active" ;;
+      other) echo "$other" ;;
+      *) exit 1 ;;
+   esac
+else
+   false
+fi

--- a/image/gpt/ab_userdata/device/slot.rules
+++ b/image/gpt/ab_userdata/device/slot.rules
@@ -1,0 +1,5 @@
+IMPORT{cmdline}="root"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_LABEL_ENC}=="ROOTB", ENV{root}=="/dev/disk/by-label/ROOTA", SYMLINK+="disk/by-slot/other/ROOT"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_LABEL_ENC}=="BOOTB", ENV{root}=="/dev/disk/by-label/ROOTA", SYMLINK+="disk/by-slot/other/BOOT"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_LABEL_ENC}=="ROOTA", ENV{root}=="/dev/disk/by-label/ROOTB", SYMLINK+="disk/by-slot/other/ROOT"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_LABEL_ENC}=="BOOTA", ENV{root}=="/dev/disk/by-label/ROOTB", SYMLINK+="disk/by-slot/other/BOOT"


### PR DESCRIPTION
Install a udev rule to create aliases for the other (ie the inactive) slot partitions, and a script to assist with slot identification. Alias nodes are also present in the initramfs.