### PR TITLE
Initial JSON export of attributes

### DIFF
--- a/bin/image2json
+++ b/bin/image2json
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+
+import json
+import re
+import argparse
+import os
+import copy
+import sys
+
+
+VERSION = "1.0.0"
+
+
+IMAGE_KEYS = {"IGconf_target_board",
+              "IGconf_image_name",
+              "IGconf_image_version",
+              "IGconf_image_outputdir"}
+
+
+top_template = {
+    "version": VERSION,
+    "meta": [],
+    "layout": {
+        "partition-table-type": "none",
+        "partitions": []
+    }
+}
+
+
+partition_template =  {
+    "name": "default",
+    "partition-type": None,
+    "in-partition-table": "false",
+    "fstab": {}
+}
+
+
+# mke2fs specifies the UUID with -U
+def get_extfs_uuid(extraargs):
+    match = re.search(r"-U\s+([a-fA-F0-9\-]+)", extraargs)
+    return match.group(1).lower() if match else None
+
+
+# mkdosfs specifies volume ID with -i
+def get_vfat_uuid(extraargs):
+    match = re.search(r"-i\s+([a-fA-F0-9\-]+)", extraargs)
+    if match:
+        uuid = match.group(1).upper()
+        return f"{uuid[:4]}-{uuid[4:]}"
+    return None
+
+
+
+# Read genimage config in two passes - first image then partitions. Then merge
+# them using the image referenced by the partition if there is one.
+def parse_genimage_config(config_path):
+    with open(config_path, "r") as f:
+        config_text = f.read()
+
+    sections = re.split(r"(\bimage\b|\bpartition\b) (\S+) {", config_text)
+    images = {}
+    partitions = []
+    ptable_type = "none"
+
+    # First Pass: parse image sections and store all attributes, exclude don't cares
+    for i in range(1, len(sections), 3):
+        section_type, section_name, content = sections[i:i+3]
+        attributes = parse_attributes(content, {"exec-pre", "exec-post"})
+
+        # Detect image type
+        # https://github.com/pengutronix/genimage#the-image-configuration-options
+        img_block = re.search(r"(\w+) {\s*(.*?)\s*}", content, re.DOTALL)
+        if img_block:
+            img_type, img_content = img_block.groups()
+            img_attributes = parse_attributes(img_content)
+            img_attributes["type"] = img_type  # store type
+
+            # extraargs specifies additional attributes, eg uuid
+            if "extraargs" in img_attributes:
+                match img_attributes["type"]:
+                    case "ext2"|"ext3"|"ext4"|"btrfs":
+                        fs_uuid = get_extfs_uuid(img_attributes["extraargs"])
+                    case "vfat":
+                        fs_uuid = get_vfat_uuid(img_attributes["extraargs"])
+                    case _:
+                        pass
+                if fs_uuid:
+                    img_attributes["uuid"] = fs_uuid
+
+            # Store attributes
+            attributes.update(img_attributes)
+
+        if img_attributes["type"] == "hdimage" and img_attributes["partition-table-type"]:
+            ptable_type = img_attributes["partition-table-type"]
+
+        if section_type == "image":
+            images[section_name] = attributes  # store attr for second pass
+
+    # Second Pass: parse partitions and merge attributes
+    for i in range(1, len(sections), 3):
+        section_type, section_name, content = sections[i:i+3]
+        if section_type != "partition":
+            continue  # skip images (already processed)
+
+        content = content.split("}", 1)[0].strip()
+        attributes = parse_attributes(content)
+        attributes["name"] = section_name
+
+        # Merge attributes from the associated image
+        if "image" in attributes and attributes["image"] in images:
+            inherited_image = images[attributes["image"]]
+            attributes.update({k: v for k, v in inherited_image.items() if k not in attributes})
+
+        new_partition = copy.deepcopy(partition_template)
+        merged = {**new_partition, **attributes}
+        partitions.append(merged)
+
+    return (ptable_type, partitions)
+
+
+# Extract key value pairs from a section, support multi-word values, nested {} sub-sections not supported
+def parse_attributes(content, exclude_keys=None):
+    if exclude_keys is None:
+        exclude_keys = set() # Default - no exclusions
+
+    attributes = {}
+    for match in re.finditer(r"^\s*([\w-]+)\s*=\s*(\"[^\"]*\"|'[^']*'|[^#\n]+)", content, re.MULTILINE):
+        key, value = match.groups()
+        if key in exclude_keys:
+            continue # skip excluded
+
+        # Map attributes here as needed
+        value = value.strip().strip('"').strip("'") # Remove quotes if present
+        mapped_value = value
+
+        match key.lower():
+            case "partition-type-uuid":
+                # https://github.com/pengutronix/genimage#the-image-section
+                match value.upper():
+                    case "L" | "linux":
+                        mapped_value = "0fc63daf-8483-4772-8e79-3d69d8477de4"
+                    case "S" | "swap":
+                        mapped_value = "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"
+                    case "H" | "home":
+                        mapped_value = "933ac7e1-2eb4-4f13-b844-0e14e2aef915"
+                    case "U" | "esp" | "uefi":
+                        mapped_value = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+                    case "R" | "raid":
+                        mapped_value = "a19d880f-05fc-4d3b-a006-743f0f84911e"
+                    case "V" | "lvm":
+                        mapped_value = "e6d6d379-f507-44c2-a23c-238f2a3df928"
+                    case "F" | "fat32":
+                        mapped_value = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
+                    case _:
+                        pass
+            case _:
+                pass
+
+        attributes[key.strip()] = mapped_value
+    return attributes
+
+
+# Read all fstabs extracting mount options using UUID or label
+def parse_fstab(fstab_paths):
+    fstab_data = {}
+    for fstab_path in fstab_paths:
+        try:
+            with open(fstab_path, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("#") or line == "":
+                        continue  # skip comments or empty
+
+                    parts = line.split()
+                    #if len(parts) < 4:
+                    #    continue  # skip unusable
+                    if len(parts) == 4:
+                        device, mountpoint, fstype, options = parts[:4]
+                        freq = "0"
+                        passn = "0"
+                    elif len(parts) == 5:
+                        device, mountpoint, fstype, options, freq = parts[:5]
+                        passn = "0"
+                    elif len(parts) == 6:
+                        device, mountpoint, fstype, options, freq, passn = parts[:6]
+                    else:
+                        continue  # skip unusable
+
+                    mount_options = options.split(",")
+
+                    # Supported fs_spec:
+                    if device.startswith(("UUID=", "LABEL=", "PARTUUID=", "PARTLABEL=")):
+                        deviceid = device.split("=", 1)[1]
+                    elif device.startswith(("/dev/disk/by-label/", "/dev/disk/by-uuid/")):
+                        deviceid = device.rsplit("/", 1)[-1]
+                    else:
+                        continue # skip unsupported
+
+                    # This will overwrite previous settings if the device exists in multiple fstabs
+                    fstab_data[deviceid] = {"fs_spec": device,
+                                            "fs_file": mountpoint,
+                                            "fs_vfstype": fstype,
+                                            "fs_mntops": mount_options,
+                                            "fs_freq": freq,
+                                            "fs_passno": passn}
+
+        except FileNotFoundError:
+            sys.exit('invalid fstab: %s' % fstab_path)
+
+    return fstab_data
+
+
+# Use a label or uuid to associate a genimage partition with an fstab device entry to
+# establish mount point and mount options. If a match is found, the fstab section of
+# the partition is populated.
+def merge_configs(genimage_partitions, fstab_data):
+    for partition in genimage_partitions:
+        label = partition.get("label")
+        uuid = partition.get("uuid")
+
+        if label and label in fstab_data:
+            partition["fstab"] = fstab_data[label]
+        elif uuid and uuid in fstab_data:
+            partition["fstab"] = fstab_data[uuid]
+        else:
+            pass
+
+    return genimage_partitions
+
+
+
+def get_env_vars(prefix=None):
+    if prefix:
+        return {key: value for key,value in os.environ.items() if key.startswith(prefix)}
+    return dict(os.environ)
+
+
+# Returns IG config vars we want to bake into the json
+def get_image_meta():
+    vars = get_env_vars()
+    image_vars = {}
+    for key, value in vars.items():
+        if key in IMAGE_KEYS:
+            image_vars[key] = value
+
+    return image_vars
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+            description='JSON layout generator')
+
+    parser.add_argument("-g", "--genimage",
+                        help="Path to genimage config file",
+                        required=True)
+
+    parser.add_argument("-f", "--fstab",
+                        help="Paths to one or more fstab files",
+                        nargs="*",
+                        required=False)
+
+    args = parser.parse_args()
+    genimage_file = args.genimage;
+
+    # Base info
+    partition_table_type, genimage_partitions = parse_genimage_config(genimage_file)
+
+    # fstab is optional
+    if args.fstab:
+        fstab_files = args.fstab
+        fstab_data = parse_fstab(fstab_files)
+        partition_json = merge_configs(genimage_partitions, fstab_data)
+    else:
+        partition_json = genimage_partitions
+
+    top_template["meta"] = get_image_meta()
+    top_template["layout"]["partition-table-type"] = partition_table_type
+    top_template["layout"]["partitions"] = partition_json
+
+    print(json.dumps(top_template, indent=4))

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -10,6 +10,7 @@ case $DISKLABEL in
 /dev/disk/by-label/ROOT /               ext4 rw,relatime,errors=remount-ro 0 1
 /dev/disk/by-label/BOOT /boot/firmware  vfat rw,noatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro 0 2
 EOF
+      image2json -g $OUTPUTPATH/genimage.cfg -f $IMAGEMOUNTPATH/etc/fstab > $OUTPUTPATH/image.json
       ;;
    BOOT)
       sed -i "s|root=\([^ ]*\)|root=\/dev\/disk\/by-label\/ROOT|" $IMAGEMOUNTPATH/cmdline.txt


### PR DESCRIPTION
Add new python script which parses a genimage config and an optional list of fstab files, aggregating partition level attributes, images and run-time options. This is intended to provide a structured and defined description of assets generated by rpi-image-gen and an input source for rpi-sb-provisioner.