### PR TITLE
Add kiosk example

### DIFF
--- a/examples/webkiosk/README.md
+++ b/examples/webkiosk/README.md
@@ -1,0 +1,26 @@
+Build an image which automatically boots into kiosk mode to run an web application on Wayland.
+
+This is a very simple system which uses the default config plus a custom hook to:
+
+* Install a set of packages over and above those provided by the base which are needed to run the kiosk
+* Install and enable a systemd service to automatically run the kiosk at boot up
+
+```text
+examples/webkiosk/
+|-- bdebstrap
+|   `-- customize01
+|-- kiosk.service.tpl
+`-- README.md
+```
+
+Note: This relies on the base provided by the in-tree configuration file ```generic64-apt-simple.cfg```. To deploy a production kiosk system it is envisaged that a specific config file and profile would be used, therefore giving full control over the base system to the developer.
+
+```bash
+./build.sh -c generic64-apt-simple -D ./examples/kiosk/
+```
+
+Since images are created with user login disabled by default, if you need to be able to log into this system via the console you'll need to specify a password in an options file like this:
+
+```bash
+./build.sh -c generic64-apt-simple -D ./examples/kiosk/ -o ./examples/setoptions/my.options
+```

--- a/examples/webkiosk/bdebstrap/customize01
+++ b/examples/webkiosk/bdebstrap/customize01
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# pkgs we need for our kiosk (cage from Debian is old and expects xwayland #293)
+chroot $1 apt install -y cage xwayland chromium
+
+# We'll run chromium like this
+APP="/usr/bin/chromium-browser https://raspberrypi.com https://time.is/London --kiosk --noerrdialogs --disable-infobars --no-first-run --ozone-platform=wayland --enable-features=OverlayScrollbar --start-maximized"
+
+# Write out our systemd kiosk service
+cat ../kiosk.service.tpl | sed \
+   -e "s|<KIOSK_USER>|$IGconf_first_user_name|g" \
+   -e "s|<KIOSK_RUNDIR>|\/home\/$IGconf_first_user_name|g" \
+   -e "s|<KIOSK_APP>|$APP|g" \
+   > $1/etc/systemd/system/kiosk.service
+
+# Enable the kiosk service so it starts automatically
+$BDEBSTRAP_HOOKS/enable-units "$1" kiosk

--- a/examples/webkiosk/kiosk.service.tpl
+++ b/examples/webkiosk/kiosk.service.tpl
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kiosk Wayland Session
+After=multi-user.target
+
+[Service]
+User=<KIOSK_USER>
+TTYPath=/dev/tty1
+Environment="XDG_RUNTIME_DIR=<KIOSK_RUNDIR>"
+Restart=always
+ExecStart=/usr/bin/cage -- <KIOSK_APP>
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This example helps to illustrate:
 * Installing pkgs into the chroot (customize stage)
 * Creating a systemd service to run an app for the kiosk
 * Enabling the service so it runs at boot

The example uses all other defaults (ie board and image layout).
