### PR TITLE
Variable restructuring and reorg

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -102,27 +102,27 @@ The rpi-image-gen tree structure contains individual sub-component directories, 
 
 === EXT_DIR ===
 
-If rpi-image-gen is provided with a path to an external directory on the command line it will use this directory when resolving sub-components paths for ```config/```, ```profile/```, ```image/``` and ```device/``` and it will include the ```meta/``` sub-directory of this path in the list when searching for YAML meta layers defined by the Profile. The external directory does not need to contain all sub-component directories; it may just contain custom hooks. If no external directory is provided, variable ```IGTOP``` defines the root directory for all sub-components.
+If rpi-image-gen is provided with a path to an external directory on the command line it will use this directory when resolving sub-components paths for ```config/```, ```profile/```, ```image/``` and ```device/``` and it will include the ```meta/``` sub-directory of this path in the list when searching for YAML meta layers defined by the Profile. This allows a user to provide external directories for these sub-components and for them to take precedence over the `in-tree` equivalents. The external directory does not need to contain all sub-components; it may just contain custom hooks. If no external directory is provided, variable ```IGTOP``` defines the root directory of all sub-components.
 
-=== Config ===
+=== config ===
 
-The config file is provided as an command line argument and is the first asset to be located, either from the external directory or in-tree. Once the config is loaded and parsed, sub-components for device, profile and image are searched for and their paths resolved, either from the external directory or in-tree. rpi-image-gen will always prioritise the external directory when searching. If not specified, a default config file is used. See ```./build.sh -help``` for further information.
+The config file is provided as a command line argument and is loaded from the external directory or in-tree. The config directory contains rpi-image-gen config files. Once the config file is loaded and parsed, sub-components for device, profile and image are searched for and their paths resolved, either from the external directory or in-tree. rpi-image-gen will always prioritise the external directory when searching. If not specified, a default config file is used. See ```./build.sh -help``` for further information.
 
-=== Device
+=== device
 
 A device directory contains assets which are specific to a class of hardware device. Additionally, rpi-image-gen adopts a sub-directory named ```device``` in various locations to denote the contents are related to run-time software on the device (e.g. rootfs-overlay).
 
-=== Image
+=== image
 
-The image directory contains the necessary assets with which rpi-image-gen will use to create the output disk image(s).
+The image directory contains the necessary assets with which rpi-image-gen will use to create the output disk image(s) with a particular layout.
 
-=== Meta
+=== meta
 
-The in-tree meta directory is the default location from where all YAML layers are searched. The search path for additional meta layers can be augmented by usage of an external directory and optional namespace.
+The meta directory contains YAML layers which are individual 'recipes' used for rootfs creation. The search path for additional meta layers can be augmented by usage of ```EXT_DIR``` and optional namespace.
 
-=== Profile
+=== profile
 
-The profile is a plain text file which supports comments via ```#``` and where each line contains a YAML layer. For example, if a Profile contained:
+The profile is a plain text file which supports comments via ```#``` and where each line contains a YAML layer. The profile directory contains rpi-image-gen profiles. For example, if a Profile contained:
 
 ----
 # My device layer
@@ -131,123 +131,49 @@ my/fantastic/layer
 
 ...```my/fantastic/layer.yaml``` would be searched for.
 
+=== sbom
+
+The SBOM directory contains assets specific to generation of the SBOM (see below).
+
 Other sub-component directories exist for particular purposes and the path to some of those are propagated to all layers via dedicated variables. These are mainly to assist with scripting and template generation, e.g. when creating a systemd config fragment for a network interface, creation of RPi boot firmware config files, etc.
 
 == Options
 
-The intention is for rpi-image-gen to have parity with many of the options supported by pi-gen, either as a 1-1 mapping or by functional equivalence. The following options are supported and can be specified in the Options file or in the appropriate section of the Config file. Please note there is currently no support for reading them from the environment.
+rpi-image-gen settings are aggregated as part of the input parameter assembly stage (see below) before commencing the build, and are translated into fully qualified variables with prefix ```IGconf```. Settings specific to a sub-component are denoted by a particular namespace prefix such as ```device``` or ```image```. Default settings specific to a sub-component are loaded from files named 'defaults' in the appropriate directory (e.g. ```build.defaults```). rpi-image-gen uses the appropriate sub-component namespace when reading these files which simplifies variables declared within. All of these settings are classed as 'options' or 'configuration variables' depending on the scope. A variable can be set by:
 
- * `DEVICE_CLASS` (Default: `pi5`)
+The Environment +
+The config file (```-c```) +
+The user options file (```-o```) +
+Default settings +
 
-   The device class to build for.
+Rather than listing all available options here, please refer to the following files in the tree for further details:
 
- * `DEVICE_VARIANT` (Default: ``)
+=== device/build.defaults
 
-   The device variant.
+Device configuration build-time settings, e.g. class, profile, locale +
+Auto-prefix: ```device```
 
- * `IMAGE_VERSION` (Default: `Today's date represented as YYYY-MM-DD`)
+=== image/build.defaults
 
-   Version string of the image to build.
+Default build options for all image layouts, e.g. version, compression +
+Auto-prefix: ```image```
 
- * `IMAGE_NAME` (Default: `<DEVICE_CLASS>-<DEVICE_VARIANT>-<config name>-<IMAGE_VERSION>`)
+=== sys-build.defaults
 
-   The basename of the image to build.
+Default options for the build configuration, e.g. APT key directory, output artefacts directory +
+Auto-prefix: ```sys```
 
- * `IMAGE_SUFFIX` (Default: `img`)
+=== sbom/defaults
 
-   The suffix of the generated image(s).
+Default options for SBOM generation, e.g. output format +
+Auto-prefix: ```sbom```
 
- * `IMAGE_COMPRESSION` (Default: `none`)
+=== meta/defaults
 
-   Identifier for the compression scheme used when deploying images and assets.
+Default options for all meta layers +
+Auto-prefix: ```meta```
 
- * `WORK_DIR`  (Default: `<IGTOP>/work/<IMAGE_NAME>`)
-
-   Root of the directory hierarchy containing rpi-image-gen output artefacts. Note, depending on the system being built, this directory can amount to a substantial amount of consumed disk space.
-
- * `IMAGE_OUTPUTDIR` (Default: `<WORK_DIR>/artefacts`)
-
-   Location of all build product artefacts.
-
- * `IMAGE_DEPLOYDIR` (Default: `<WORK_DIR>/deploy`)
-
-   Location where final images and assets will be installed to.
-
- * `EXT_DIR`  (Default: unset)
-
-   Path to an external directory of where to search for sub-components and meta layers. This is set automatically via the the command line.
-
- * `EXT_NSDIR`  (Default: unset)
-
-   Path to an external directory namespace of where to search for addition meta layers. This is set automatically via the the command line.
-
- * `APT_KEYDIR` (Default: `<WORK_DIR>/keys`)
-
-   If a particular collection of keys are required for bdebstrap to download packages from the mirror(s) provided, set the directory containing them here. This will be passed to bdebstrap via aptopt Dir::Etc::TrustedParts. If not specified, rpi-image-gen assembles the keys it requires into this directory. This particular setting of Dir::Etc::TrustedParts will not be included in the image. If using this option, please make sure to install your key(s) into the chroot explicitly if a key contained in this directory points to a location that is not otherwise populated during chroot creation (for example by installing a keyring package).
-
- * `APT_PROXY` (Default: unset)
-
-   If you require the use of an apt proxy, set it here. This proxy setting will not be included in the image, making it safe to use an `apt-cacher` or similar package for development.
-   Also see `APT_PROXY_HTTP`.
-
- * `APT_PROXY_HTTP` (Default: unset)
-
-   If you require the use of an apt http proxy, set it here. This proxy setting will not be included in the image, making it safe to use an `apt-cacher` or similar package for development.
-   To maintain compatibility with pi-gen, this variable will inherit the value of `APT_PROXY` if that variable is set.
-
-  * `LOCALE_DEFAULT` (Default: 'en_GB.UTF-8' )
-
-   Default system locale.
-
- * `DEVICE_HOSTNAME` (Default: 'raspberrypi' )
-
-   Sets the hostname to the specified value.
-
- * `KEYBOARD_KEYMAP` (Default: 'gb' )
-
-   Default keyboard keymap.
-
-   To get the current value from a running system, run `debconf-show keyboard-configuration` and look at the `keyboard-configuration/xkb-keymap` value.
-
- * `KEYBOARD_LAYOUT` (Default: 'English (UK)' )
-   
-   Default keyboard layout.
-
-   To get the current value from a running system, run `debconf-show keyboard-configuration` and look at the `keyboard-configuration/variant` value.
-   
- * `TIMEZONE_DEFAULT` (Default: 'Europe/London' )
-
-   Default timezone. Also see `TIMEZONE_AREA` and `TIMEZONE_CITY`.
-
-   To get the current value from a running system, look in `/etc/timezone`.
-   
- * `TIMEZONE_AREA` (Default: 'Europe' )
-
-   Default timezone area. To maintain compatibility with pi-gen, this variable will inherit the first part of `TIMEZONE_DEFAULT`.
-
- * `TIMEZONE_CITY` (Default: 'London' )
-
-   Default timezone city. To maintain compatibility with pi-gen, this variable will inherit the second part of `TIMEZONE_DEFAULT`.
-
- * `FIRST_USER_NAME` (Default: `pi`)
-
-   Create a user account with this username. Please note that this user will *NOT* currently be renamed on the first boot.
-   
- * `FIRST_USER_PASS` (Default: unset)
-
-   Password for the first user. If unset, the account is locked.
-
- * `SBOM_OUTPUT_FORMAT` (Default: spdx-json)
-
-   The output format of the SBOM.
-
- * `DEVICE_OPTIONS` (Default: options)
-
-   The name of the file in the device directory that contains configuration variables specific to that device.
-
- * `IMAGE_OPTIONS` (Default: options)
-
-   The name of the file in the image layout directory that contains configuration variables specific to that layout.
+Meta layers can also provide their own specific default settings. Files declaring these defaults are located alongside their corresponding YAML layer and are loaded if the profile contains the associated layer.
 
 == Execution Flow
 
@@ -257,21 +183,40 @@ The three main stages of execution in rpi-image-gen are described below.
 
 Before commencing creation of the rootfs, the configuration of the system is assembled and translated into a set of environment variables established from different sources in the following order:
 
-* Default settings
-* Config file settings
-* Device and Image option file settings
-* User option file settings
+* User option file settings (scope: explicit set and unset [see Note1 below])
+* Config file settings (scope: aggregate, set and unset)
+* System wide default settings (scope: aggregate, set and unset)
+* Selected Device and Image settings (scope: aggregate, set and unset)
+* User option file settings (scope: explicit set and unset)
 
-The config file uses .ini file syntax (https://en.wikipedia.org/wiki/INI_file) to set ```key=value``` pairs. +
-The options file is a shell fragment containing ```key=value``` pairs.
+The config file uses .ini file syntax (https://en.wikipedia.org/wiki/INI_file) to set ```key=value``` pairs inside a section. +
+The user options file, and files containing default settings, are shell fragments containing declarative ```key=value``` pairs. +
 
-rpi-image-gen adopts a system-wide prefix for all variables it exposes to YAML layers and hooks. The prefix is ```IGconf```. In addition, when reading the config file, a variable declared in a section has the section name included in its prefix when it's translated. Sections not specifically read will be ignored. Variables set from the options file will be prefixed and translated as-is. Translation includes the variable name being converted to lower case.
+Both file types support comments, and empty lines are ignored.
 
-Loading of Device and Image option files will set their configuration variables to default values only if a variable is not already set. The User option file can override any variable set previously.
+The loading of defaults settings or the config file will only set a variable if it is unset, i.e. their assignments are 'aggregated'. The user options file can override any variable. For example, if variable ```IGconf_image_name``` was set in the Environment it would not be set by the loading of image defaults or the config file. It would, however, be set if the user options file assigned ```image_name``` to a non-empty string. If the user options file assigned it as empty it would be unset. When the declarative syntax is parsed, it does not support setting a variable to be empty. If a variable is assigned as empty it will be treated as being unset. Because of this, the user options file is re-read at the end of parsing to ensure it is able to override any previously set variables to be unset if necessary.
+
+As mentioned above, rpi-image-gen automatically applies a global prefix for all variables it parses from files and it applies a scope specific prefix to variables declared in config files and defaults. This 'translation' of variable parsing ensures variables automatically adhere to their defined scope. Unsupported config file sections are ignored. Variables set from the options file will be ```IGconf``` prefixed and translated as-is. Translation includes the variable name being converted to lower case. A variable is said to be 'fully qualified' after parsing and when prefixed with ```IGconf```. All fully qualified variables are propagated and made available to YAML layers and hooks via their execution environment.
+
+**Note1:** rpi-image-gen variables set from the Environment must be fully qualified otherwise they will be ignored. For example, to set the Device Class from the Environment, set variable ```IGconf_device_class``` accordingly. To set it from the user options file, assign variable ```device_class```.
+
+**Note2:** Exceptions to this are the individual ```meta``` layer default files which are loaded at the same time as their corresponding YAML layer.
 
 Understanding how to set and create variables is an important part of using rpi-image-gen because it forms the foundation of user customisation.
 
-==== Example
+==== Sections
+
+The following sections are supported when parsing a config file:
+
+* device
+* image
+* sys
+* sbom
+* meta
+
+Variables declared outside the scope of these sections will not be read. 
+
+==== Example 1
 These are equivalent: +
 
 Default
@@ -295,7 +240,7 @@ DEVICE_CLASS=pi5
 
 Processing the input sources and aggregating the variables this way allows the setting of a variable to override a previous setting. This may be particularly useful where customisation may only require the modification of a small number of variables compared with what was set previously. Furthermore, rpi-image-gen evaluates each variable after translation which means that variables set previously can be used to set other variables.
 
-==== Example
+==== Example 2
 
 Default
 
@@ -315,46 +260,46 @@ Yields:
 IGconf_image_suffix=pi5.bin
 ----
 
-The rpi-image-gen options file serves the same purpose as the pi-gen config file. It is envisaged that pi-gen users can use the same file to reflect their customisations when creating an image with rpi-image-gen, although at the current time support for an identical set of options is incomplete.
-
-After processing the sources, all ```IGconf``` variables are included in the environment of subsequent stages. This means that YAML layers and hooks have access to all ```IGconf``` variables.
-
 [TIP]
 --
 Via the Options file or a supported Config file section, it is possible to define new custom variables. rpi-image-gen does not 'filter' variables or perform any sort of manipulation of their values/contents. The propagation of all variables, including user defined custom variables, may be beneficial to YAML layers and hooks.
 --
 
-==== Example
+==== Example 3
 
-Default
+Environment
 
 ----
-IGconf_first_user_name=pi
+IGconf_device_user1name=pi
 ----
 
 Config
 
 ----
-[system]
+[device]
+user1name=rasp
+
+[sys]
 flavour=debug
 debugger=autoattach
+debug_port=8080
 
 ----
 
 Options
 
 ----
-system_debug_port=8080
-system_debug_user=$IGconf_first_user_name
+sys_debug_port=
+sys_debug_user=$IGconf_user1name
+sys_debugger=disabled
 ----
 
 Yields
 
 ----
-IGconf_system_flavour=debug
-IGconf_system_debugger=autoattach
-IGconf_system_debug_port=8080
-IGconf_system_debug_user=pi
+IGconf_sys_flavour=debug
+IGconf_sys_debugger=disabled
+IGconf_sys_debug_user=pi
 ----
 
 [TIP]
@@ -362,20 +307,20 @@ IGconf_system_debug_user=pi
 It's possible to include a Config file from another Config file provided both exist in the same directory. This may be useful in cases where there is a common configuration shared across variants. Rather than duplicating parts of a Config file in others, a common configuration can be included and any overrides or additional settings applied afterwards.
 --
 
-==== Example
+==== Example 4
 
 Common configuration fragment ```base.cfg```
 
 ----
 [device]
 class=edge01
+profile=v1
 
 [image]
 layout=ROTA
 default_slot=A
 
-[system]
-profile=v1
+[sys]
 safe_boot=y
 boot_scheme=2
 ----
@@ -390,11 +335,11 @@ resize=false
 appdata_size=1G
 ----
 
-**Note:** Files must be included _outside_ a config section. Including files from the Options file is not supported.
+**Note:** Files must be included _outside_ a config section. Including files from the user options file is not supported.
 
 === Root File System Construction 
 
-After assembling the environment variables from the input sources, rpi-image-gen reads the Profile and validates the path of each YAML layer before assembling each layer as an argument to bdebstrap. A layer must adhere to `bdebstrap` YAML syntax. Please refer to the bdebstrap man page for further details. It's also worth pointing out that if authoring shell expressions in YAML, it may be necessary to adopt usage of particular block scalar styles to achieve newlines inside a block. For example:
+After assembling the environment variables from the input sources, rpi-image-gen reads the Profile and validates the path of each YAML layer before reading its default settings (if present) and assembling each layer as an argument to bdebstrap. A layer must adhere to `bdebstrap` YAML syntax. Please refer to the bdebstrap man page for further details. It's also worth pointing out that if authoring shell expressions in YAML, it may be necessary to adopt usage of particular block scalar styles to achieve newlines inside a block. For example:
 
 ----
   - |-
@@ -410,7 +355,7 @@ A number of 'core hooks' are installed via bdebstrap command line arguments. The
 
 rpi-image-gen runs bdebstrap in a new Linux namespace via ```podman unshare```. This is required so that bdebstrap creates files with the correct ownership information, which is particularly important when creating a chroot that contains a user account. See podman-unshare(1) and user_namespaces(7) for further details.
 
-Before bdebstrap invokes mmdebstrap to begin creation of the chroot, it writes the fully aggregated and merged YAML to ```$IGconf_image_outputdir``` as ```config.yaml```. This is an incredibly useful file because it's essentially the 'recipe' for generating the chroot. It also creates a file called ```manifest``` in the same directory which lists all the packages that were installed in the chroot. 
+Before bdebstrap invokes mmdebstrap to begin creation of the chroot, it writes the fully aggregated and merged YAML to ```$IGconf_sys_outputdir``` as ```config.yaml```. This is an incredibly useful file because it's essentially the 'recipe' for generating the chroot. It also creates a file called ```manifest``` in the same directory which lists all the packages that were installed in the chroot. 
 
 The mmdebstrap execution is not regarded as in the scope of this document. mmdebstrap follows the rules governed by its design and by the configuration provided to it by bdebstrap. In turn, the vast majority of bdebstrap configuration is derived from the YAML layers provided to it by rpi-image-gen. From this point of view, rpi-image-gen could be regarded as a thin toolkit wrapper with which to design a system purely from YAML constructs and a set of environment variables. The application of both these things, once understood, is very powerful and provides the means to create a completely customised rootfs.
 
@@ -440,7 +385,7 @@ mmdebstrap:
 
 === SBOM
 
-A SBOM should be a reproducible and immutable artefact of the build. Generation of it takes place at the end of the post-build stage after all other hooks have run, and immediately before ```genimage``` invocation. It is not advised to perform any operation on the rootfs that could affect the data encapsulated by the SBOM after it has been generated. The SBOM is generated using ```syft``` (https://github.com/anchore/syft) which will be downloaded if not installed on the host. The SBOM is written to the image output directory (```IGconf_image_outputdir```) and its output format is configurable via the ```SBOM_OUTPUT_FORMAT``` variable which can be set via the Config or Options file. The output format is currently the only option available to the user.
+A SBOM should be a reproducible and immutable artefact of the build. Generation of it takes place at the end of the post-build stage after all other hooks have run, and immediately before ```genimage``` invocation. It is not advised to perform any operation on the rootfs that could affect the data encapsulated by the SBOM after it has been generated. The SBOM is generated using ```syft``` (https://github.com/anchore/syft) which will be downloaded if not installed on the host. The SBOM is written to the image output directory (```IGconf_sys_outputdir```) and its output format is configurable via the ```SBOM_OUTPUT_FORMAT``` variable which can be set via the Config or Options file. The output format is currently the only option available to the user.
 
 For example, these are equivalent: +
 
@@ -548,4 +493,4 @@ Only one of these hooks is executed. The device pre-image hook has priority. If 
 
    Image layout owned post-image operations.
 
-Only one of these hooks is executed. The device post-image hook has priority. If it exists, it will be executed. If it doesn't and the image layout post-image hook exists, that will be executed. If neither exist, a default post-image hook will be executed. It is the responsibility of the post-image hook to perform all operations required to deploy artefacts to ```IMAGE_DEPLOY_DIR``` (```IGconf_image_deploy_dir```), for example compressing image and SBOM.
+Only one of these hooks is executed. The device post-image hook has priority. If it exists, it will be executed. If it doesn't and the image layout post-image hook exists, that will be executed. If neither exist, a default post-image hook will be executed. It is the responsibility of the post-image hook to perform all operations required to deploy artefacts to ```IGconf_sys_deploydir```, for example compressing image and SBOM.

--- a/bin/igconf
+++ b/bin/igconf
@@ -26,6 +26,7 @@ check_y()
          ;;
       esac
    done
+   return 0
 }
 
 check_n()
@@ -40,6 +41,7 @@ check_n()
          ;;
       esac
    done
+   return 0
 }
 
 
@@ -64,6 +66,10 @@ case "$op" in
    is_set)
       check_set "${vars[@]}"
       exit $?
+      ;;
+   is_nset)
+      check_set "${vars[@]}"
+      exit $((1 - $?))
       ;;
    *)
       ;;

--- a/bin/image2json
+++ b/bin/image2json
@@ -8,14 +8,14 @@ import copy
 import sys
 
 
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 
 IMAGE_KEYS = {"IGconf_device_class",
               "IGconf_device_variant",
               "IGconf_image_name",
               "IGconf_image_version",
-              "IGconf_image_outputdir"}
+              "IGconf_sys_outputdir"}
 
 
 top_template = {

--- a/config/generic64-apt-ab.cfg
+++ b/config/generic64-apt-ab.cfg
@@ -6,5 +6,5 @@ name=deb12-arm64-min
 boot_part_size=200%
 root_part_size=300%
 
-[system]
+[device]
 profile=bookworm/apt-min64

--- a/config/generic64-apt-simple.cfg
+++ b/config/generic64-apt-simple.cfg
@@ -7,5 +7,5 @@ boot_part_size=200%
 root_part_size=300%
 name=deb12-arm64-min
 
-[system]
+[device]
 profile=bookworm/apt-min64

--- a/config/raspbian-bookworm-v7-apt.cfg
+++ b/config/raspbian-bookworm-v7-apt.cfg
@@ -4,5 +4,5 @@
 layout=mbr/simple_dual
 name=raspian-deb12-min
 
-[system]
+[device]
 profile=raspbian/bookworm-v7-apt-min

--- a/device/build.defaults
+++ b/device/build.defaults
@@ -1,0 +1,36 @@
+# rpi-image-gen device build defaults
+
+# Device class
+class=pi5
+
+# Device variant
+variant=none
+
+# Default hostname
+hostname=raspberrypi
+
+# Optional filename in a device specific directory providing additional settings
+options=defaults
+
+# A user account with this username will be available on the device
+user1name=pi
+
+# Password required to log into the above account. If empty, the account will be locked.
+user1pass=
+
+# Default locale
+locale1="en_GB.UTF-8"
+
+# Default keymap
+keyboard_keymap=gb
+
+# Default keyboard layout
+# debconf-show keyboard-configuration keyboard-configuration/xkb-keymap
+keyboard_layout="English (UK)"
+
+# Default timezone
+# /etc/timezone
+timezone="Europe/London"
+
+# The profile used to construct the device root filesystem
+profile=

--- a/examples/custom_layers/acme.options
+++ b/examples/custom_layers/acme.options
@@ -3,6 +3,6 @@ acme_keydir=/path/to/dir
 # Empty lines are supported
 
 device_hostname=acme-devhost
-first_user_name=acmedev
-first_user_pass=roadrunner
+device_user1name=acmedev
+device_user1pass=roadrunner
 acme_dev_server=build.acme.org

--- a/examples/custom_layers/acme/meta/acme-sdk-v1.yaml
+++ b/examples/custom_layers/acme/meta/acme-sdk-v1.yaml
@@ -10,15 +10,15 @@ mmdebstrap:
     # cp $IGconf_acme_keydir/acme.gpg.key | gpg --dearmor > $1/etc/apt/trusted.gpg.d/acme.gpg
   customize-hooks:
     # Could perform ops here after the chroot is set up and all packages got installed, eg
-  - cp $IGconf_ext_nsdir/setup-functions $1/home/$IGconf_first_user_name
+  - cp $IGconf_ext_nsdir/setup-functions $1/home/$IGconf_device_user1name
   - |-
     chroot $1 bash -- <<- EOCHROOT
-    source /home/$IGconf_first_user_name/setup-functions
-    install_secrets $IGconf_first_user_name $IGconf_acme_dev_server
-    touch /home/$IGconf_first_user_name/acme.INSTALLED
+    source /home/$IGconf_device_user1name/setup-functions
+    install_secrets $IGconf_device_user1name $IGconf_acme_dev_server
+    touch /home/$IGconf_device_user1name/acme.INSTALLED
     EOCHROOT
   cleanup-hooks:
-    - shred --verbose -u --zero $1/home/$IGconf_first_user_name/setup-functions
+    - shred --verbose -u --zero $1/home/$IGconf_device_user1name/setup-functions
   packages:
     - bash
     # xxx

--- a/examples/custom_layers/config/acme-integration.cfg
+++ b/examples/custom_layers/config/acme-integration.cfg
@@ -2,6 +2,7 @@
 
 [device]
 class=pi5
+profile=deb12-acme
 
 [image]
 layout=mbr/simple_dual
@@ -9,6 +10,3 @@ boot_part_size=200%
 root_part_size=300%
 name=acme-developer
 compression=zstd
-
-[system]
-profile=deb12-acme

--- a/examples/custom_layers/meta/example-developer/essential.yaml
+++ b/examples/custom_layers/meta/example-developer/essential.yaml
@@ -8,7 +8,7 @@ mmdebstrap:
 #  customize-hooks:
     # Could perform ops here after the chroot is set up and packages installed, e.g.
     #   mkdir -p $1/usr/local/assets
-    #   $IGconf_ext_dir/template-gen $IGconf_locale_default $IGconf_device_hostname > $1/usr/local/assets/my.template
+    #   $IGconf_ext_dir/template-gen $IGconf_device_locale1 $IGconf_device_hostname > $1/usr/local/assets/my.template
 #  cleanup-hooks:
     # Could perform chroot ops here when cleaning up
   packages:

--- a/examples/debstore/config/deb12-store.cfg
+++ b/examples/debstore/config/deb12-store.cfg
@@ -1,11 +1,9 @@
 [device]
 class=pi5
+profile=local-deb-installer
 
 [image]
 layout=mbr/simple_dual
 boot_part_size=200%
 root_part_size=300%
 name=debstore-test
-
-[system]
-profile=local-deb-installer

--- a/examples/debstore/my.options
+++ b/examples/debstore/my.options
@@ -1,3 +1,3 @@
-first_user_pass=removeme
+device_user1pass=removeme
 # Location of our debs
 debstore=${IGconf_ext_dir}/pkgs

--- a/examples/nested_image/config/nested.cfg
+++ b/examples/nested_image/config/nested.cfg
@@ -2,5 +2,5 @@
 layout=embedded_squashfs
 name=nested-example
 
-[system]
+[device]
 profile=bookworm/apt-min64

--- a/examples/nested_image/image/embedded_squashfs/pre-image.sh
+++ b/examples/nested_image/image/embedded_squashfs/pre-image.sh
@@ -22,7 +22,7 @@ ROOT_SIZE=200%
 WRITER=$(readlink -f writer.sh)
 
 cat main.cfg.in | sed \
-   -e "s|<IMAGE_DIR>|$IGconf_image_outputdir|g" \
+   -e "s|<IMAGE_DIR>|$IGconf_sys_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<FW_SIZE>|$FW_SIZE|g" \

--- a/examples/nested_image/my.options
+++ b/examples/nested_image/my.options
@@ -1,2 +1,2 @@
-first_user_name=nested
-first_user_pass=image
+device_user1name=nested
+device_user1pass=image

--- a/examples/setoptions/my.options
+++ b/examples/setoptions/my.options
@@ -1,7 +1,7 @@
 # Comments are supported
 DEVICE_HOSTNAME=frobulator
 # All variables will be translated to lower case and made available to hooks
-first_user_name=pilot
-FIRST_USER_PASS=removeme
+device_user1name=pilot
+dEvIcE_UsER1pASs=removeme
 # Variables set in the .cfg file can be overridden
 IMAGE_NAME=mydevice

--- a/examples/slim/config/pi5-slim.cfg
+++ b/examples/slim/config/pi5-slim.cfg
@@ -1,9 +1,7 @@
 [device]
 class=mypi5
+profile=v8-svelte
 
 [image]
 layout=compact
 name=deb12-slim
-
-[system]
-profile=v8-svelte

--- a/examples/slim/image/compact/pre-image.sh
+++ b/examples/slim/image/compact/pre-image.sh
@@ -9,7 +9,7 @@ FW_SIZE=100%
 ROOT_SIZE=100%
 
 cat genimage.cfg.in | sed \
-   -e "s|<IMAGE_DIR>|$IGconf_image_outputdir|g" \
+   -e "s|<IMAGE_DIR>|$IGconf_sys_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<FW_SIZE>|$FW_SIZE|g" \

--- a/examples/slim/meta/slim-customisations.yaml
+++ b/examples/slim/meta/slim-customisations.yaml
@@ -2,9 +2,9 @@
 name: example-slim
 mmdebstrap:
   customize-hooks:
-    - chroot $1 sh -c "useradd -m -s /bin/bash -u 4000 $IGconf_first_user_name"
+    - chroot $1 sh -c "useradd -m -s /bin/bash -u 4000 $IGconf_device_user1name"
     - |-
-      if [ -n "$IGconf_first_user_pass" ] ; then
-         chroot $1 sh -c "echo ${IGconf_first_user_name}:${IGconf_first_user_pass} | chpasswd"
+      if [ -n "$IGconf_device_user1pass" ] ; then
+         chroot $1 sh -c "echo ${IGconf_device_user1name}:${IGconf_device_user1pass} | chpasswd"
       fi
     - chroot $1 usermod --pass='*' root

--- a/examples/slim/my.options
+++ b/examples/slim/my.options
@@ -1,1 +1,1 @@
-FIRST_USER_PASS=removeme
+DEVICE_USER1PASS=removeme

--- a/examples/webkiosk/bdebstrap/customize01
+++ b/examples/webkiosk/bdebstrap/customize01
@@ -8,8 +8,8 @@ APP="/usr/bin/chromium-browser https://raspberrypi.com https://time.is/London --
 
 # Write out our systemd kiosk service
 cat ../kiosk.service.tpl | sed \
-   -e "s|<KIOSK_USER>|$IGconf_first_user_name|g" \
-   -e "s|<KIOSK_RUNDIR>|\/home\/$IGconf_first_user_name|g" \
+   -e "s|<KIOSK_USER>|$IGconf_device_user1name|g" \
+   -e "s|<KIOSK_RUNDIR>|\/home\/$IGconf_device_user1name|g" \
    -e "s|<KIOSK_APP>|$APP|g" \
    > $1/etc/systemd/system/kiosk.service
 

--- a/image/README.adoc
+++ b/image/README.adoc
@@ -14,7 +14,7 @@ This directory contains the 'in-tree' image layouts supported by rpi-image-gen.
 
 |===
 
-For detailed information about a particular layout, including configuration options, please refer to documentation within the appropriate layout sub-directory.
+For detailed information about a particular layout, including configuration options and defaults, please refer to documentation within the appropriate layout sub-directory.
 
 == Notes
 
@@ -57,4 +57,4 @@ Options
 image_boot_part_size=200%
 ----
 
-The options file in the appropriate image layout sub-directory defines the default values of the supported configuration variables.
+Each image layout sub-directory contains a file which specifies the default values of its supported configuration variables.

--- a/image/build.defaults
+++ b/image/build.defaults
@@ -1,0 +1,16 @@
+# rpi-image-gen image defaults
+
+# Version string of the image to build
+version=$(date +%Y-%m-%d)
+
+# The base suffix of the generated image(s)
+suffix=img
+
+# Identifier for the compression scheme used when deploying images and assets
+compression=none
+
+# Optional file in an image layout directory providing additional settings
+options=defaults
+
+# The base name for all generated images
+name="${IGconf_device_class}-${IGconf_device_variant}-${IGconf_image_version}"

--- a/image/gpt/ab_userdata/defaults
+++ b/image/gpt/ab_userdata/defaults
@@ -1,3 +1,3 @@
-# Default partition sizes
+# Partition sizes
 boot_part_size=100%
 root_part_size=100%

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -17,7 +17,7 @@ boot_partition=3
 EOF
 
 cat genimage.cfg.in | sed \
-   -e "s|<IMAGE_DIR>|$IGconf_image_outputdir|g" \
+   -e "s|<IMAGE_DIR>|$IGconf_sys_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<FW_SIZE>|$IGconf_image_boot_part_size|g" \

--- a/image/mbr/simple_dual/defaults
+++ b/image/mbr/simple_dual/defaults
@@ -1,6 +1,6 @@
-# Default partition sizes
+# Partition sizes
 boot_part_size=100%
 root_part_size=100%
 
-# Default root filesystem type
+# Root filesystem type
 rootfs_type=ext4

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -6,7 +6,7 @@ rootfs=$1
 genimg_in=$2
 
 cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
-   -e "s|<IMAGE_DIR>|$IGconf_image_outputdir|g" \
+   -e "s|<IMAGE_DIR>|$IGconf_sys_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<FW_SIZE>|$IGconf_image_boot_part_size|g" \

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -15,9 +15,9 @@ esac
 shopt -s nullglob
 
 files=()
-files+=("${IGconf_image_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix})
-files+=("${IGconf_image_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix}.sparse)
-files+=("${IGconf_image_outputdir}/${IGconf_image_name}"*.sbom)
+files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix})
+files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix}.sparse)
+files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.sbom)
 
 msg "Deploying image and SBOM"
 

--- a/meta/app-container/docker/engine-bookworm.defaults
+++ b/meta/app-container/docker/engine-bookworm.defaults
@@ -1,0 +1,6 @@
+# Set this to y to make usr1name a member of the docker group
+# and therefore able to run containers (and applications) without
+# requiring root privileges.
+# Enabling this has security implications.
+# https://docs.docker.com/engine/security/#docker-daemon-attack-surface
+docker_trust_usr1name=n

--- a/meta/app-container/docker/engine-bookworm.yaml
+++ b/meta/app-container/docker/engine-bookworm.yaml
@@ -1,6 +1,5 @@
 ---
 name: docker-engine
-description: https://docs.docker.com/engine/install/debian/
 mmdebstrap:
   architectures:
     - arm64
@@ -10,7 +9,7 @@ mmdebstrap:
     - mkdir -p $1/usr/share/keyrings/
     - curl -fsSL https://download.docker.com/linux/debian/gpg -o $1/usr/share/keyrings/docker.asc
     - chmod a+r $1/usr/share/keyrings/docker.asc
-    - cp -p $1/usr/share/keyrings/docker.asc $IGconf_apt_keydir
+    - cp -p $1/usr/share/keyrings/docker.asc $IGconf_sys_apt_keydir
   packages:
     - docker-ce
     - docker-ce-cli
@@ -24,6 +23,4 @@ mmdebstrap:
       deb [arch=arm64 signed-by=/usr/share/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable
       EOF
     - sed -i '/download\.docker\.com/d' $1/etc/apt/sources.list
-    # https://docs.docker.com/engine/security/#docker-daemon-attack-surface
-    #- chroot $1 sh -c "groupadd -f -r docker"
-    #- chroot $1 sh -c "adduser $IGconf_first_user_name docker"
+    - chroot $1 sh -c "groupadd -f -r docker"

--- a/meta/app-misc/ca-certificates.yaml
+++ b/meta/app-misc/ca-certificates.yaml
@@ -1,6 +1,5 @@
 ---
 name: ca-certs
-description: Common CA Certificate files
 mmdebstrap:
   packages:
     - ca-certificates

--- a/meta/debian/bookworm/arm64/base-apt-multi.yaml
+++ b/meta/debian/bookworm/arm64/base-apt-multi.yaml
@@ -11,17 +11,17 @@ mmdebstrap:
     - deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
     - deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
   essential-hooks:
-    - echo tzdata tzdata/Areas select "$IGconf_timezone_area"
+    - echo tzdata tzdata/Areas select "$IGconf_device_timezone_area"
         | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/$IGconf_timezone_area select "$IGconf_timezone_city"
+    - echo tzdata tzdata/Zones/$IGconf_device_timezone_area select "$IGconf_device_timezone_city"
         | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default"
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
+    - echo locales locales/default_environment_locale select "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_keyboard_layout"
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_device_keyboard_layout"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_keyboard_keymap"
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_device_keyboard_keymap"
         | chroot $1 debconf-set-selections
   aptopts:
     - APT::Install-Suggests "false"

--- a/meta/debian/bookworm/arm64/base-apt.yaml
+++ b/meta/debian/bookworm/arm64/base-apt.yaml
@@ -11,17 +11,17 @@ mmdebstrap:
     - deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
     - deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
   essential-hooks:
-    - echo tzdata tzdata/Areas select "$IGconf_timezone_area"
+    - echo tzdata tzdata/Areas select "$IGconf_device_timezone_area"
         | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/$IGconf_timezone_area select "$IGconf_timezone_city"
+    - echo tzdata tzdata/Zones/$IGconf_device_timezone_area select "$IGconf_device_timezone_city"
         | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default"
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
+    - echo locales locales/default_environment_locale select "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_keyboard_layout"
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_device_keyboard_layout"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_keyboard_keymap"
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_device_keyboard_keymap"
         | chroot $1 debconf-set-selections
   aptopts:
     - APT::Install-Suggests "false"

--- a/meta/debian/bookworm/arm64/base-slim.yaml
+++ b/meta/debian/bookworm/arm64/base-slim.yaml
@@ -31,17 +31,17 @@ mmdebstrap:
     - mkdir -p $1/bin
     - ln -s bash $1/bin/sh
   essential-hooks:
-    - echo tzdata tzdata/Areas select "$IGconf_timezone_area"
+    - echo tzdata tzdata/Areas select "$IGconf_device_timezone_area"
         | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/$IGconf_timezone_area select "$IGconf_timezone_city"
+    - echo tzdata tzdata/Zones/$IGconf_device_timezone_area select "$IGconf_device_timezone_city"
         | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default"
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
+    - echo locales locales/default_environment_locale select "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_keyboard_layout"
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_device_keyboard_layout"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_keyboard_keymap"
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_device_keyboard_keymap"
         | chroot $1 debconf-set-selections
   aptopts:
     - APT::Install-Suggests "false"

--- a/meta/defaults
+++ b/meta/defaults
@@ -1,0 +1,2 @@
+# rpi-image-gen meta defaults
+

--- a/meta/raspbian/bookworm/base-apt.yaml
+++ b/meta/raspbian/bookworm/base-apt.yaml
@@ -23,17 +23,17 @@ mmdebstrap:
   packages:
     - raspbian-archive-keyring
   essential-hooks:
-    - echo tzdata tzdata/Areas select "$IGconf_timezone_area"
+    - echo tzdata tzdata/Areas select "$IGconf_device_timezone_area"
         | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/$IGconf_timezone_area select "$IGconf_timezone_city"
+    - echo tzdata tzdata/Zones/$IGconf_device_timezone_area select "$IGconf_device_timezone_city"
         | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default"
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
+    - echo locales locales/default_environment_locale select "$IGconf_device_locale1"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_keyboard_layout"
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_device_keyboard_layout"
         | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_keyboard_keymap"
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_device_keyboard_keymap"
         | chroot $1 debconf-set-selections
   customize-hooks:
     - test -f $1/usr/share/keyrings/raspbian-archive-keyring.gpg || false

--- a/meta/rpi/user-credentials.yaml
+++ b/meta/rpi/user-credentials.yaml
@@ -4,21 +4,21 @@ mmdebstrap:
   packages:
     - sudo
   customize-hooks:
-    - chroot $1 sh -c "if ! id -u $IGconf_first_user_name >/dev/null 2>&1; then
-        adduser --disabled-password --gecos \"\"  $IGconf_first_user_name;
+    - chroot $1 sh -c "if ! id -u $IGconf_device_user1name >/dev/null 2>&1; then
+        adduser --disabled-password --gecos \"\"  $IGconf_device_user1name;
         fi"
     - |-
-      if [ -n "$IGconf_first_user_pass" ] ; then
-         chroot $1 sh -c "echo ${IGconf_first_user_name}:${IGconf_first_user_pass} | chpasswd"
+      if [ -n "$IGconf_device_user1pass" ] ; then
+         chroot $1 sh -c "echo ${IGconf_device_user1name}:${IGconf_device_user1pass} | chpasswd"
       fi
     - chroot $1 usermod --pass='*' root
     - chroot $1 sh -c "for GRP in input spi i2c gpio; do
          groupadd -f -r \$GRP;
       done"
     - chroot $1 sh -c "for GRP in adm dialout cdrom audio users sudo video games plugdev input spi i2c gpio ; do
-         adduser $IGconf_first_user_name \$GRP;
+         adduser $IGconf_device_user1name \$GRP;
       done"
-    - sed "s/^pi /$IGconf_first_user_name /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+    - sed "s/^pi /$IGconf_device_user1name /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
     - mkdir -p $1/etc/profile.d
     - |-
       cat <<- 'EOCHROOT' > $1/etc/profile.d/01local.sh

--- a/sbom/defaults
+++ b/sbom/defaults
@@ -1,0 +1,4 @@
+# rpi-image-gen sbom defaults
+
+# Default format for the SBOM
+output_format="spdx-json"

--- a/sbom/gen.sh
+++ b/sbom/gen.sh
@@ -10,7 +10,7 @@ SYFT_VER=v1.19.0
 # If host has syft, use it
 if ! hash syft 2>/dev/null; then
    curl -sSfL https://raw.githubusercontent.com/anchore/syft/${SYFT_VER}/install.sh \
-      | sh -s -- -b ${IGconf_work_dir}/host/bin
+      | sh -s -- -b ${IGconf_sys_workdir}/host/bin
 fi
 
 SYFT=$(syft --version 2>/dev/null) || die "syft is unusable"

--- a/scripts/bdebstrap/cleanup01
+++ b/scripts/bdebstrap/cleanup01
@@ -4,8 +4,8 @@ set -eu
 
 # Remove the apt proxy if it was added
 if [ -s $1/etc/apt/apt.conf.d/99mmdebstrap ] ; then
-   if [[ ! -z ${IGconf_apt_proxy_http+z} ]] ; then
-      sed -i "\|Acquire\:\:http.*$IGconf_apt_proxy_http|d" $1/etc/apt/apt.conf.d/99mmdebstrap
+   if [[ ! -z ${IGconf_sys_apt_proxy_http+z} ]] ; then
+      sed -i "\|Acquire\:\:http.*$IGconf_sys_apt_proxy_http|d" $1/etc/apt/apt.conf.d/99mmdebstrap
    fi
 fi
 

--- a/scripts/bdebstrap/customize50-user-mgmt
+++ b/scripts/bdebstrap/customize50-user-mgmt
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -u
+
+# User role and management operations
+
+if igconf is_y meta_docker_trust_usr1name ; then
+   chroot $1 sh -c "adduser $IGconf_device_user1name docker"
+fi

--- a/scripts/bdebstrap/essential01
+++ b/scripts/bdebstrap/essential01
@@ -5,5 +5,5 @@ set -eu
 # Dir::Etc::TrustedParts for keys was only valid for pkg download at chroot creation
 # Removing it in essential means customize can use apt in the chroot.
 if [ -s $1/etc/apt/apt.conf.d/99mmdebstrap ] ; then
-   sed -i "\|Dir\:\:Etc\:\:TrustedParts.*$IGconf_apt_keydir|d" $1/etc/apt/apt.conf.d/99mmdebstrap
+   sed -i "\|Dir\:\:Etc\:\:TrustedParts.*$IGconf_sys_apt_keydir|d" $1/etc/apt/apt.conf.d/99mmdebstrap
 fi

--- a/scripts/common
+++ b/scripts/common
@@ -207,7 +207,22 @@ ensure_loopdev_partitions() {
 export -f ensure_loopdev_partitions
 
 
-# .ini file section parser reading key value pairs into the env as shell variables.
+# If a variable is unset, or set to the empty string, initialise it
+assignv() {
+   local var="$1"
+   local val="$2"
+   if [ -z "${!var+x}" ] || [ -z "${!var-x}" ] ; then
+      if [[ "$val" =~ ^$ ]] ; then
+         eval unset "${var}"
+      else
+         eval "${var}"="$val"
+      fi
+   fi
+}
+
+
+# .ini file section parser reading key value pairs into the env as shell variables
+# initialising them only if their fully qualified equivalent is not set.
 # key names will be prefixed with section name and converted to lower case, e.g.
 #
 # [mysection]
@@ -218,7 +233,7 @@ export -f ensure_loopdev_partitions
 # IGconf_mysection_foo=zzz
 # IGconf_mysection_bar=yyy
 #
-read_config_section() {
+merge_config_section() {
    local section=$1
    local cfg=$2
    local attrs=$(crudini --get --format=sh $cfg $section 2>/dev/null)
@@ -226,20 +241,16 @@ read_config_section() {
       while IFS="=" read -r key value ; do
          [[ "$key" =~ ^#.*$ ]] && continue
          [[ "$key" =~ ^$ ]] && continue
-         if [[ ! -n "$value" ]] ; then
-            eval unset IGconf_"${section,,}"_"${key,,}"
-         else
-            eval IGconf_"${section,,}"_"${key,,}"="$value"
-         fi
+         local var=IGconf_"${section}"_"${key,,}"
+         assignv "$var" "$value"
       done < <(printf '%s\n' "$attrs")
    fi
 }
-export -f read_config_section
 
 
-# Read a config file. Included config files will be read from the directory of
-# the current config file.
-read_config() {
+# Read a config file and aggregate settings. Included config files will be read
+# from the directory of the current config file.
+aggregate_config() {
    local cfg=$(realpath -m "$1" 2>/dev/null)
    test -s "$cfg" || die "Invalid config: $cfg"
    while read -r w1 w2; do
@@ -248,19 +259,20 @@ read_config() {
     case $w1 in
        include)
          [[ $(basename $cfg) ==  $(basename $w2) ]] && die "Recursive include: $cfg"
-         read_config "$(dirname $cfg)/$w2"
+         aggregate_config "$(dirname $cfg)/$w2"
          ;;
        *)
          ;;
     esac
    done < "$cfg"
 
-   read_config_section image "$cfg"
-   read_config_section system "$cfg"
-   read_config_section device "$cfg"
-   read_config_section sbom "$cfg"
+   merge_config_section device "$cfg"
+   merge_config_section image "$cfg"
+   merge_config_section sys "$cfg"
+   merge_config_section sbom "$cfg"
+   merge_config_section meta "$cfg"
 }
-export -f read_config
+export -f aggregate_config
 
 
 # shell variable list parser reading key value pairs into the env. key names
@@ -273,7 +285,7 @@ export -f read_config
 # IGconf_foo=zzz
 # IGconf_bar=yyy
 #
-read_options() {
+apply_options() {
    if [[ $# -eq 1 && -f $1 ]] ; then
       local attrs=$(cat $1)
    else
@@ -289,12 +301,12 @@ read_options() {
       fi
    done < <(printf '%s\n' "$attrs")
 }
-export -f read_options
-
+export -f apply_options
 
 
 # shell variable list parser with prefix that reads key value pairs into the env
-# as above, but only if the key is not already set in the env.
+# as above, but only if the fully qualified IGconf key is not set or set to the
+# empty string.
 aggregate_options() {
    if [[ $# -eq 2 && -f $2 ]] ; then
       local attrs=$(cat $2)
@@ -306,13 +318,7 @@ aggregate_options() {
       [[ "$key" =~ ^#.*$ ]] && continue
       [[ "$key" =~ ^$ ]] && continue
       local var=IGconf_"${section}"_"${key,,}"
-      if [ -z ${!var+x} ]; then
-         if [[ "$value" =~ ^$ ]] ; then
-            true # already unset
-         else
-            eval "${var}"="$value"
-         fi
-      fi
+      assignv "$var" "$value"
    done < <(printf '%s\n' "$attrs")
 }
 export -f aggregate_options

--- a/sys-build.defaults
+++ b/sys-build.defaults
@@ -1,0 +1,29 @@
+# rpi-image-gen system build configuration defaults
+
+# If you require the use of an APT HTTP proxy, set it using this. The proxy
+# setting will not be included in the image, making it safe to use an
+# `apt-cacher` or similar package for development.
+apt_proxy_http=
+
+# Root of the directory hierarchy containing rpi-image-gen build artefacts.
+# Note, depending on the system being built, this directory can amount to a
+# substantial amount of consumed disk space.
+workdir="${IGTOP}/work/${IGconf_image_name}"
+
+# If a particular collection of keys are required for bdebstrap to download
+# packages from the mirror(s) provided, set the directory containing them here.
+# This will be passed to bdebstrap via aptopt Dir::Etc::TrustedParts. If not
+# specified, rpi-image-gen sets this directory and assembles the keys it
+# requires into it.
+# This particular setting of Dir::Etc::TrustedParts will not be included in the
+# image. If using this option, please make sure to install your key(s) into the
+# chroot explicitly if a key contained in this directory points to a location
+# that is not otherwise populated during chroot creation (for example by
+# installing a keyring package).
+apt_keydir=
+
+# Location of all build product artefacts.
+outputdir="${IGconf_sys_workdir}/artefacts"
+
+# Location where final images and assets will be installed to.
+deploydir="${IGconf_sys_workdir}/deploy"


### PR DESCRIPTION
This is a backward incompatible change.

Relocate all default settings/options and variable definitions to scope specific files (e.g. device/build.defaults). This has the major advantage of there now only ever being one source of truth for all variables available for customisation. The names, default values and descriptions now exist in scope specific files which vastly improves documentation, maintenance and usability. These default files are read by rpi-image-gen.

Unlike before, all of the in-tree variables now exist in a defined namespace particular to their scope of use in rpi-image-gen. External variables can be defined as before (no change).

Also unlike before, variables can now be set from the Environment which may improve usability.

Several variables have been renamed and moved scope as part of the reorg with signifficant updates across many files:

IGconf_apt_proxy       -> removed
IGconf_keyboard_keymap -> IGconf_device_keyboard_keymap
IGconf_keyboard_layout -> IGconf_device_keyboard_layout
IGconf_locale_default  -> IGconf_device_locale1
IGconf_timezone_default-> IGconf_device_timezone
IGconf_system_profile  -> IGconf_device_profile
IGconf_first_user_name -> IGconf_device_user1name
IGconf_first_user_pass -> IGconf_device_user1pass
IGconf_apt_keydir      -> IGconf_sys_apt_keydir
IGconf_apt_proxy_http  -> IGconf_sys_apt_proxy_http
IGconf_image_deploydir -> IGconf_sys_deploydir
IGconf_image_outputdir -> IGconf_sys_outputdir
IGconf_work_dir        -> IGconf_sys_workdir

The list of supported option variables has been removed from the top level readme. Details about any option can be found in the appropriate defaults file.

In addition to the above, support has been added for a layer to provide it's own (specific) default settings via a dedicated file. This is parsed in the same way as other default settings. These files are optional will be loaded if present when the corresponding YAML layer is read from the profile.

Add docker engine default settings to support adding the local user to the docker group if required. New core bdebstrap hook has been added to handle user management in the chroot.

Remove description from docker and ca-certs YAML as bdebstrap does not support this field and emits a warning.