### PR TITLE
Another compat change

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -270,14 +270,14 @@ Via the Options file or a supported Config file section, it is possible to defin
 Environment
 
 ----
-IGconf_device_user1name=pi
+IGconf_device_user1=pi
 ----
 
 Config
 
 ----
 [device]
-user1name=rasp
+user1=rasp
 
 [sys]
 flavour=debug
@@ -290,7 +290,7 @@ Options
 
 ----
 sys_debug_port=
-sys_debug_user=$IGconf_user1name
+sys_debug_user=$IGconf_user1
 sys_debugger=disabled
 ----
 

--- a/device/build.defaults
+++ b/device/build.defaults
@@ -12,8 +12,8 @@ hostname=raspberrypi
 # Optional filename in a device specific directory providing additional settings
 options=defaults
 
-# A user account with this username will be available on the device
-user1name=pi
+# A user account with this name will be created on the device
+user1=pi
 
 # Password required to log into the above account. If empty, the account will be locked.
 user1pass=

--- a/examples/custom_layers/acme.options
+++ b/examples/custom_layers/acme.options
@@ -3,6 +3,6 @@ acme_keydir=/path/to/dir
 # Empty lines are supported
 
 device_hostname=acme-devhost
-device_user1name=acmedev
+device_user1=acmedev
 device_user1pass=roadrunner
 acme_dev_server=build.acme.org

--- a/examples/custom_layers/acme/meta/acme-sdk-v1.yaml
+++ b/examples/custom_layers/acme/meta/acme-sdk-v1.yaml
@@ -10,15 +10,15 @@ mmdebstrap:
     # cp $IGconf_acme_keydir/acme.gpg.key | gpg --dearmor > $1/etc/apt/trusted.gpg.d/acme.gpg
   customize-hooks:
     # Could perform ops here after the chroot is set up and all packages got installed, eg
-  - cp $IGconf_ext_nsdir/setup-functions $1/home/$IGconf_device_user1name
+  - cp $IGconf_ext_nsdir/setup-functions $1/home/$IGconf_device_user1
   - |-
     chroot $1 bash -- <<- EOCHROOT
-    source /home/$IGconf_device_user1name/setup-functions
-    install_secrets $IGconf_device_user1name $IGconf_acme_dev_server
-    touch /home/$IGconf_device_user1name/acme.INSTALLED
+    source /home/$IGconf_device_user1/setup-functions
+    install_secrets $IGconf_device_user1 $IGconf_acme_dev_server
+    touch /home/$IGconf_device_user1/acme.INSTALLED
     EOCHROOT
   cleanup-hooks:
-    - shred --verbose -u --zero $1/home/$IGconf_device_user1name/setup-functions
+    - shred --verbose -u --zero $1/home/$IGconf_device_user1/setup-functions
   packages:
     - bash
     # xxx

--- a/examples/nested_image/my.options
+++ b/examples/nested_image/my.options
@@ -1,2 +1,2 @@
-device_user1name=nested
+device_user1=nested
 device_user1pass=image

--- a/examples/setoptions/my.options
+++ b/examples/setoptions/my.options
@@ -1,7 +1,7 @@
 # Comments are supported
 DEVICE_HOSTNAME=frobulator
 # All variables will be translated to lower case and made available to hooks
-device_user1name=pilot
+device_user1=pilot
 dEvIcE_UsER1pASs=removeme
 # Variables set in the .cfg file can be overridden
 IMAGE_NAME=mydevice

--- a/examples/slim/meta/slim-customisations.yaml
+++ b/examples/slim/meta/slim-customisations.yaml
@@ -2,9 +2,9 @@
 name: example-slim
 mmdebstrap:
   customize-hooks:
-    - chroot $1 sh -c "useradd -m -s /bin/bash -u 4000 $IGconf_device_user1name"
+    - chroot $1 sh -c "useradd -m -s /bin/bash -u 4000 $IGconf_device_user1"
     - |-
       if [ -n "$IGconf_device_user1pass" ] ; then
-         chroot $1 sh -c "echo ${IGconf_device_user1name}:${IGconf_device_user1pass} | chpasswd"
+         chroot $1 sh -c "echo ${IGconf_device_user1}:${IGconf_device_user1pass} | chpasswd"
       fi
     - chroot $1 usermod --pass='*' root

--- a/examples/webkiosk/bdebstrap/customize01
+++ b/examples/webkiosk/bdebstrap/customize01
@@ -8,8 +8,8 @@ APP="/usr/bin/chromium-browser https://raspberrypi.com https://time.is/London --
 
 # Write out our systemd kiosk service
 cat ../kiosk.service.tpl | sed \
-   -e "s|<KIOSK_USER>|$IGconf_device_user1name|g" \
-   -e "s|<KIOSK_RUNDIR>|\/home\/$IGconf_device_user1name|g" \
+   -e "s|<KIOSK_USER>|$IGconf_device_user1|g" \
+   -e "s|<KIOSK_RUNDIR>|\/home\/$IGconf_device_user1|g" \
    -e "s|<KIOSK_APP>|$APP|g" \
    > $1/etc/systemd/system/kiosk.service
 

--- a/meta/app-container/docker/engine-bookworm.defaults
+++ b/meta/app-container/docker/engine-bookworm.defaults
@@ -1,6 +1,6 @@
-# Set this to y to make usr1name a member of the docker group
+# Set this to y to make device_user1 a member of the docker group
 # and therefore able to run containers (and applications) without
 # requiring root privileges.
 # Enabling this has security implications.
 # https://docs.docker.com/engine/security/#docker-daemon-attack-surface
-docker_trust_usr1name=n
+docker_trust_user1=n

--- a/meta/rpi/user-credentials.yaml
+++ b/meta/rpi/user-credentials.yaml
@@ -4,21 +4,21 @@ mmdebstrap:
   packages:
     - sudo
   customize-hooks:
-    - chroot $1 sh -c "if ! id -u $IGconf_device_user1name >/dev/null 2>&1; then
-        adduser --disabled-password --gecos \"\"  $IGconf_device_user1name;
+    - chroot $1 sh -c "if ! id -u $IGconf_device_user1 >/dev/null 2>&1; then
+        adduser --disabled-password --gecos \"\"  $IGconf_device_user1;
         fi"
     - |-
       if [ -n "$IGconf_device_user1pass" ] ; then
-         chroot $1 sh -c "echo ${IGconf_device_user1name}:${IGconf_device_user1pass} | chpasswd"
+         chroot $1 sh -c "echo ${IGconf_device_user1}:${IGconf_device_user1pass} | chpasswd"
       fi
     - chroot $1 usermod --pass='*' root
     - chroot $1 sh -c "for GRP in input spi i2c gpio; do
          groupadd -f -r \$GRP;
       done"
     - chroot $1 sh -c "for GRP in adm dialout cdrom audio users sudo video games plugdev input spi i2c gpio ; do
-         adduser $IGconf_device_user1name \$GRP;
+         adduser $IGconf_device_user1 \$GRP;
       done"
-    - sed "s/^pi /$IGconf_device_user1name /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+    - sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
     - mkdir -p $1/etc/profile.d
     - |-
       cat <<- 'EOCHROOT' > $1/etc/profile.d/01local.sh

--- a/scripts/bdebstrap/customize50-user-mgmt
+++ b/scripts/bdebstrap/customize50-user-mgmt
@@ -4,6 +4,6 @@ set -u
 
 # User role and management operations
 
-if igconf is_y meta_docker_trust_usr1name ; then
-   chroot $1 sh -c "adduser $IGconf_device_user1name docker"
+if igconf is_y meta_docker_trust_user1 ; then
+   chroot $1 sh -c "adduser $IGconf_device_user1 docker"
 fi


### PR DESCRIPTION
Hopefully the last.. Pedantic but worthwhile.

In the interests of keeping configuration variables as short as possible, rename IGconf_device_user1name to IGconf_device_user1. This user account can be granted functionality via different variables which themselves need to be associated to this user, so it makes sense to try and keep the identifier for the user name as short as possible.

Fix typo in docker meta variable, and rename (usr1name -> user1).