### PR TITLE
Add device SSH support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -275,6 +275,12 @@ while read -r line; do
 done < "${IGPROFILE}"
 
 
+# Auto-selected layers
+if igconf_isy device_ssh_user1 ; then
+   layer_push net-misc/openssh-server
+fi
+
+
 # hook execution
 runh()
 {

--- a/device/build.defaults
+++ b/device/build.defaults
@@ -34,3 +34,7 @@ timezone="Europe/London"
 
 # The profile used to construct the device root filesystem
 profile=
+
+# If y, automatically include net-misc/openssh-server in the profile to enable
+# SSH access to the device via user1.
+ssh_user1=n

--- a/meta/net-misc/openssh-server.defaults
+++ b/meta/net-misc/openssh-server.defaults
@@ -1,0 +1,19 @@
+# Controls /home/$IGconf_device_user1/.ssh/authorized_keys
+# By default, authorized_keys will be created empty.
+# If set to a valid file path, the contents of the file is used to populate
+# authorized_keys.
+# If set to a non-empty string that's not a valid file path, the contents of
+# the variable is used to populate authorized_keys.
+# Since it's possible to pass variables via the environment, one way to specify
+# this in build scripts could be as follows:
+#  IGconf_meta_ssh_pubkey_user1=$(< /path/to/.ssh/id_rsa.pub) build.sh <args>
+ssh_pubkey_user1=
+
+# Applies sshd settings via /etc/ssh/sshd_config.d/
+# If n, default sshd settings are in place which means password authentication
+# is enabled.
+# If y, only SSH public key authentication is enabled. Challenge Response,
+# Password and Kerberos authentication are disabled. If alternative sshd
+# settings are required, consider using a device or image rootfs-overlay, or
+# custom bdebstrap hook.
+sshd_pubkey_only=n

--- a/meta/net-misc/openssh-server.yaml
+++ b/meta/net-misc/openssh-server.yaml
@@ -1,0 +1,29 @@
+---
+name: openssh server
+mmdebstrap:
+  packages:
+    - openssh-server
+  customize-hooks:
+    - mkdir -p $1/home/${IGconf_device_user1}/.ssh
+    - |-
+      if [ -z ${IGconf_meta_ssh_pubkey_user1+x} ]; then
+         touch $1/home/${IGconf_device_user1}/.ssh/authorized_keys
+      elif [ -f "$IGconf_meta_ssh_pubkey_user1" ] ; then
+         cat $IGconf_meta_ssh_pubkey_user1 > $1/home/${IGconf_device_user1}/.ssh/authorized_keys
+      else
+         echo "$IGconf_meta_ssh_pubkey_user1" > $1/home/${IGconf_device_user1}/.ssh/authorized_keys
+      fi
+    - |-
+      if igconf is_y meta_sshd_pubkey_only ; then
+         mkdir -p $1/etc/ssh/sshd_config.d
+         cat <<- 'EOCHROOT' > $1/etc/ssh/sshd_config.d/01pubkey-only.conf
+      PermitRootLogin no
+      ChallengeResponseAuthentication no
+      PasswordAuthentication no
+      GSSAPIAuthentication no
+      UsePAM yes
+      PubkeyAuthentication yes
+      AuthenticationMethods publickey
+      EOCHROOT
+      fi
+    - $BDEBSTRAP_HOOKS/enable-units "$1" ssh

--- a/scripts/bdebstrap/customize50-user-mgmt
+++ b/scripts/bdebstrap/customize50-user-mgmt
@@ -7,3 +7,11 @@ set -u
 if igconf isy meta_docker_trust_user1 ; then
    chroot $1 sh -c "adduser $IGconf_device_user1 docker"
 fi
+
+if igconf isval meta_ssh_pubkey_user1 ; then
+   chroot $1 bash -- <<- EOCHROOT
+   chown -R ${IGconf_device_user1}:${IGconf_device_user1} /home/${IGconf_device_user1}/.ssh
+   chmod 0700 /home/${IGconf_device_user1}/.ssh
+   chmod 0600 /home/${IGconf_device_user1}/.ssh/authorized_keys
+EOCHROOT
+fi


### PR DESCRIPTION
Add new meta layer and default settings to install, configure and document openssh-server customisation for the server daemon and client connection. Refer to net-misc/openssh-server.defaults for details.

Add new device config option which can be used to automatically pull in the new layer. Refer to device/build.defaults for details.

These changes bring parity with pi-gen regarding ssh capability.