### PR TITLE
mbr/simple_dual: switch to using filesystem UUIDs

### DIFF
--- a/depends
+++ b/depends
@@ -18,3 +18,4 @@ python-is-python3
 dbus-user-session
 btrfs-progs
 dctrl-tools
+uuidgen:uuid-runtime

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -26,18 +26,19 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
 image boot.vfat {
    vfat {
       label = "BOOT"
-      extraargs = "-s 4 -S 512"
+      extraargs = "-s 4 -S 512 -i <BOOT_UUID>"
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"
-   exec-pre = "<SETUP> BOOT"
+   exec-pre = "<SETUP> BOOT <BOOT_UUID> <ROOT_UUID>"
 }
 
 image root.btrfs {
    btrfs {
       label = "ROOT"
+      extraargs = "-U <ROOT_UUID>"
    }
    size = <ROOT_SIZE>
    mountpoint = "/"
-   exec-pre = "<SETUP> ROOT"
+   exec-pre = "<SETUP> ROOT <BOOT_UUID> <ROOT_UUID>"
 }

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -26,11 +26,11 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
 image boot.vfat {
    vfat {
       label = "BOOT"
-      extraargs = "-s 4 -S 512"
+      extraargs = "-s 4 -S 512 -i <BOOT_UUID>"
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"
-   exec-pre = "<SETUP> BOOT"
+   exec-pre = "<SETUP> BOOT <BOOT_UUID> <ROOT_UUID>"
 }
 
 image root.ext4 {
@@ -38,8 +38,9 @@ image root.ext4 {
       label = "ROOT"
       use-mke2fs = true
       mke2fs-conf = <MKE2FSCONF>
+      extraargs = "-U <ROOT_UUID>"
    }
    size = <ROOT_SIZE>
    mountpoint = "/"
-   exec-pre = "<SETUP> ROOT"
+   exec-pre = "<SETUP> ROOT <BOOT_UUID> <ROOT_UUID>"
 }

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -5,6 +5,11 @@ set -eu
 rootfs=$1
 genimg_in=$2
 
+echo "BOOT_UUID=\"$(uuidgen | sed 's/-.*//')"\" > ${genimg_in}/fs_uuids
+echo "ROOT_UUID=\"$(uuidgen)"\" >> ${genimg_in}/fs_uuids
+. ${genimg_in}/fs_uuids
+
+
 cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
    -e "s|<IMAGE_DIR>|$IGconf_sys_outputdir|g" \
    -e "s|<IMAGE_NAME>|$IGconf_image_name|g" \
@@ -13,4 +18,6 @@ cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
    -e "s|<ROOT_SIZE>|$IGconf_image_root_part_size|g" \
    -e "s|<SETUP>|'$(readlink -ef setup.sh)'|g" \
    -e "s|<MKE2FSCONF>|'$(readlink -ef mke2fs.conf)'|g" \
+   -e "s|<BOOT_UUID>|$BOOT_UUID|g" \
+   -e "s|<ROOT_UUID>|$ROOT_UUID|g" \
    > ${genimg_in}/genimage.cfg

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -2,19 +2,21 @@
 
 set -eu
 
-DISKLABEL=$1
+LABEL="$1"
+BOOTUUID="${2:0:4}-${2:4:4}"
+ROOTUUID="$3"
 
-case $DISKLABEL in
+case $LABEL in
    ROOT)
       case $IGconf_image_rootfs_type in
          ext4)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-/dev/disk/by-label/ROOT /               ext4 rw,relatime,errors=remount-ro 0 1
+UUID=${ROOTUUID} /               ext4 rw,relatime,errors=remount-ro 0 1
 EOF
             ;;
          btrfs)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-/dev/disk/by-label/ROOT /               btrfs defaults 0 1
+UUID=${ROOTUUID} /               btrfs defaults 0 1
 EOF
             ;;
          *)
@@ -22,12 +24,12 @@ EOF
       esac
 
       cat << EOF >> $IMAGEMOUNTPATH/etc/fstab
-/dev/disk/by-label/BOOT /boot/firmware  vfat rw,noatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro 0 2
+UUID=${BOOTUUID^^} /boot/firmware  vfat rw,noatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro 0 2
 EOF
       image2json -g $OUTPUTPATH/genimage.cfg -f $IMAGEMOUNTPATH/etc/fstab > $OUTPUTPATH/image.json
       ;;
    BOOT)
-      sed -i "s|root=\([^ ]*\)|root=\/dev\/disk\/by-label\/ROOT|" $IMAGEMOUNTPATH/cmdline.txt
+      sed -i "s|root=\([^ ]*\)|root=UUID=${ROOTUUID}|" $IMAGEMOUNTPATH/cmdline.txt
       ;;
    *)
       ;;


### PR DESCRIPTION
Rather than labels, use filesystem UUIDs for mounting and identification in this image layout.
Using UUIDs has a number of advantages including identification being transparent across LVM, LUKS, raw block device, etc.

Add uuid-runtime to dependencies.