### PR TITLE
apt: Purge in the chroot by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -213,6 +213,9 @@ for v in $(compgen -A variable -X '!IGconf*') ; do
          ENV_ROOTFS+=('--aptopt' "Dir::Etc::TrustedParts ${!v}")
          ENV_ROOTFS+=('--env' ${v}="${!v}")
          ;;
+      IGconf_sys_apt_get_purge)
+         if igconf_isy $v ; then ENV_ROOTFS+=('--aptopt' "APT::Get::Purge true") ; fi
+         ;;
       IGconf_ext_dir|IGconf_ext_nsdir )
          ENV_ROOTFS+=('--env' ${v}="${!v}")
          ENV_POST_BUILD+=(${v}="${!v}")

--- a/sys-build.defaults
+++ b/sys-build.defaults
@@ -5,6 +5,9 @@
 # `apt-cacher` or similar package for development.
 apt_proxy_http=
 
+# If y, APT operations in the chroot will purge by default. Refer to apt-get(8)
+apt_get_purge=y
+
 # Root of the directory hierarchy containing rpi-image-gen build artefacts.
 # Note, depending on the system being built, this directory can amount to a
 # substantial amount of consumed disk space.


### PR DESCRIPTION
Removing configuration files for packages which are removed in the chroot during installation is likely the best default behaviour.

Example: install dracut after initramfs-tools.

Without purge, the initramfs-tools config dir hierarchy is retained but update-initramfs not present. This causes rpi-image-gen's core initramfs builder hook to fail because it uses the presence of /etc/initramfs-tools/update-initramfs.conf in the chroot to decide whether to invoke update-initramfs or not.

With purge, the initramfs-tools config dir hierarchy is not retained so the hook doesn't run.

The latter is the expected behaviour because the package is not installed.