### PR TITLE
Add image profile support and use it for AB

### DIFF
--- a/image/build.defaults
+++ b/image/build.defaults
@@ -12,5 +12,12 @@ compression=none
 # Optional file in an image layout directory providing additional settings
 options=defaults
 
+# Optional file in an image layout directory under sub-directory profile/
+# This is treated as additional profile and it's specified layers will be
+# aggregated into the configuration. A layout may require a profile in
+# order to support certain functionality (eg particular packages needed).
+# A layout may define this in its options file.
+profile=
+
 # The base name for all generated images
 name="${IGconf_device_class}-${IGconf_device_variant}-${IGconf_image_version}"

--- a/image/gpt/ab_userdata/bdebstrap/customize04-pkgs
+++ b/image/gpt/ab_userdata/bdebstrap/customize04-pkgs
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -u
-
-chroot $1 apt install -y sed coreutils initramfs-tools

--- a/image/gpt/ab_userdata/defaults
+++ b/image/gpt/ab_userdata/defaults
@@ -1,3 +1,6 @@
 # Partition sizes
 boot_part_size=100%
 system_part_size=100%
+
+# Profile
+profile=required-base

--- a/image/gpt/ab_userdata/meta/ab-initramfs.yaml
+++ b/image/gpt/ab_userdata/meta/ab-initramfs.yaml
@@ -1,0 +1,7 @@
+---
+name: ab-initramfs
+mmdebstrap:
+  packages:
+    - sed
+    - coreutils
+    - initramfs-tools

--- a/image/gpt/ab_userdata/meta/ab-userland.yaml
+++ b/image/gpt/ab_userdata/meta/ab-userland.yaml
@@ -1,0 +1,5 @@
+---
+name: ab-userland
+mmdebstrap:
+  packages:
+    - rpi-blockutils

--- a/image/gpt/ab_userdata/profile/required-base
+++ b/image/gpt/ab_userdata/profile/required-base
@@ -1,0 +1,3 @@
+# Dedicated profile for this image layout
+
+ab-initramfs

--- a/image/gpt/ab_userdata/profile/required-base
+++ b/image/gpt/ab_userdata/profile/required-base
@@ -1,3 +1,4 @@
 # Dedicated profile for this image layout
 
 ab-initramfs
+ab-userland


### PR DESCRIPTION
This adds support for a separate profile which may be be defined by an image layout. Use a dedicated profile for AB to define the required packages needed for it's functionality and group these into initramfs and userland layer components.