### PR TITLE
fs related fixups for image layouts

### DIFF
--- a/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
+++ b/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
@@ -8,3 +8,6 @@ install -m 0644 -D ../device/slot.rules $1/etc/udev/rules.d/90-rpi-slot.rules
 # Install slot helper
 mkslot-helper < ../device/slot.pmap > $1/usr/bin/rpi-slot || exit 1
 chmod +x $1/usr/bin/rpi-slot
+
+# Hint to initramfs-tools we have an ext4 rootfs
+sed -i "s|FSTYPE=\([^ ]*\)|FSTYPE=ext4|" $1/etc/initramfs-tools/initramfs.conf

--- a/image/gpt/ab_userdata/meta/ab-userland.yaml
+++ b/image/gpt/ab_userdata/meta/ab-userland.yaml
@@ -3,3 +3,5 @@ name: ab-userland
 mmdebstrap:
   packages:
     - rpi-blockutils
+    - dosfstools
+    - e2fsprogs

--- a/image/mbr/simple_dual/bdebstrap/customize05-pkgs
+++ b/image/mbr/simple_dual/bdebstrap/customize05-pkgs
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+pkgs=(dosfstools)
+
+case $IGconf_image_rootfs_type in
+   ext4)  pkgs+=(e2fsprogs) ;;
+   btrfs) pkgs+=(btrfs-progs) ;;
+esac
+
+chroot $1 apt install -y "${pkgs[@]}"

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -16,7 +16,7 @@ EOF
             ;;
          btrfs)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-UUID=${ROOTUUID} /               btrfs defaults 0 1
+UUID=${ROOTUUID} /               btrfs defaults 0 0
 EOF
             ;;
          *)

--- a/scripts/bdebstrap/customize10-initramfs
+++ b/scripts/bdebstrap/customize10-initramfs
@@ -16,6 +16,12 @@ for dir in ${IGIMAGE}/device/initramfs-tools \
    rsync --archive --ignore-existing "${dir}/" $1/etc/initramfs-tools
 done
 
+# Hint if the image layout has declared a rootfs type. This helps ensure
+# the appropriate fsck binaries are installed.
+if igconf isset image_rootfs_type ; then
+   sed -i "s|FSTYPE=\([^ ]*\)|FSTYPE=${IGconf_image_rootfs_type}|" $1/etc/initramfs-tools/initramfs.conf
+fi
+
 # Always make sure all initramfs are updated
 cp $1/etc/initramfs-tools/update-initramfs.conf $1/etc/initramfs-tools/update-initramfs.conf.bak
 sed -i 's/^update_initramfs=.*/update_initramfs=all/' $1/etc/initramfs-tools/update-initramfs.conf


### PR DESCRIPTION
Set fs_passno to 0 for BTFS filesystems, inline with docs [1].

Install packages to support the device filesystems and ensure initramfs-tools is informed about the rootfs type so it can copy appropriate fsck binaries into the image.

initramfs-tools uses different ways to establish the rootfs type when FSTYPE=auto (the default). However, none of these sources can be relied upon at the time the initramfs is built in the hook. This results in fsck missing from the initramfs image. To combat this, if an image layout indicates a particular rootfs type, hint it to initramfs-tools via a core hook. If a layout does not, it must fixup the initramfs config itself.

[1] https://btrfs.readthedocs.io/en/latest/fsck.btrfs.html