### PR TITLE
Add support for configurable target type

### DIFF
--- a/sys-build.defaults
+++ b/sys-build.defaults
@@ -30,3 +30,17 @@ outputdir="${IGconf_sys_workdir}/artefacts"
 
 # Location where final images and assets will be installed to.
 deploydir="${IGconf_sys_workdir}/deploy"
+
+# The type of target created by bdebstrap to hold the device filesystem.
+# This argument is passed straight to bdebstrap via --target and can be the
+# path to a directory, the path to a tarball filename, etc. See bdebstrap(1)
+# for further details.
+# If not a directory, rpi-image-gen will terminate immediately after bdebstrap
+# execution completes for the sole reason that subsequent stages (eg post-build
+# hooks and genimage) do not support operating on anything except  a directory.
+# Custom bdebstrap hooks are unaffected by different target types because they
+# execute in bdebstrap context and always operate on the chroot regardless if
+# the target is a file or a directory.
+# Note that it's possible to specify a directory here and use a post-build hook
+# to create a file (eg tarball) as an additional artefact.
+target="${IGconf_sys_workdir}/rootfs"


### PR DESCRIPTION
In some cases it may be desirable to create a tarball of the device filesystem rather than a directory (eg for Docker image development). To support this, add a new sys build variable which can be used to specify a path to the target object that bdebstrap will create to hold the device filesystem. The value of this variable is passed directly to bdebstrap via --target and can be a path to a directory (default) or a file. If a file, rpi-image-gen will terminate after bdebstrap execution completes as later stages (eg hooks and genimage) only support operating on a directory.

To support this, rather than pinning the bdebstrap hooks to operate on a directory, pass the chroot directory from bdebstrap to the hooks instead allowing them to operate on the chroot regardless of whether the target is a file or a directory (if a file, a temporary directory will be used and deleted upon bdebtrap termination).