### PR TITLE
Align all partitions to 8M

### DIFF
--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -6,6 +6,7 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
 
 image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
+      align = 8M
       partition-table-type = "gpt"
    }
 

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -6,6 +6,7 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
 
 image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
+      align = 8M
       partition-table-type = "mbr"
    }
 

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -6,6 +6,7 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
 
 image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
+      align = 8M
       partition-table-type = "mbr"
    }
 


### PR DESCRIPTION
Higher-capacity cards (particularly Raspberry Pi 128GB A2) have an 8MB preferred erase size, which is a good indication of the flash block size. Other large cards may also benefit.

Refs:
pi-gen pull/833