### PR TITLE
AB(emmc): write-protect the partition table

### DIFF
--- a/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
+++ b/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+[[ ${IGconf_device_storage_type:?} != emmc ]] && exit 0
+igconf isy image_ptable_protect || exit 0
+
+chroot $1 apt install mmc-utils
+
+# meta/ab-initramfs has already installed initramfs-tools
+cat <<- 'EOF' > $1/etc/initramfs-tools/hooks/ab-install-files
+#!/bin/sh
+case $1 in
+   prereqs) echo ""; exit 0;;
+esac
+. /usr/share/initramfs-tools/hook-functions
+copy_exec /usr/bin/mmc
+EOF
+chmod +x $1/etc/initramfs-tools/hooks/ab-install-files
+
+install -m 0755 -D ../device/emmc-wp.sh $1/etc/initramfs-tools/scripts/init-bottom/emmc-wp

--- a/image/gpt/ab_userdata/build.defaults
+++ b/image/gpt/ab_userdata/build.defaults
@@ -1,2 +1,6 @@
 # The image layout requires this profile
 profile=required-base
+
+# Images built for devices with eMMC storage can write protect the
+# partition table by setting this to y.
+ptable_protect=y

--- a/image/gpt/ab_userdata/device/emmc-wp.sh
+++ b/image/gpt/ab_userdata/device/emmc-wp.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+case $1 in
+   prereqs)
+      echo ""
+      exit 0
+      ;;
+esac
+
+. /scripts/functions
+
+set -e
+
+test "$(rpi-slot | sed 's/:.*//')" -eq 1 || exit 0
+
+DEV=/dev/mmcblk0
+
+# GPT entries begin at +8M. Write Protect everything prior.
+PROT_SZ_KB=$((8 * 1024))
+
+CSD=$(mmc extcsd read "$DEV")
+ERASE_GRP_SZ=$(echo "$CSD" | sed -n 's/.*HC_ERASE_GRP_SIZE *: *0x\([0-9A-Fa-f]*\).*/\1/p')
+WP_GRP_SZ=$(echo "$CSD" | sed -n 's/.*HC_WP_GRP_SIZE *: *0x\([0-9A-Fa-f]*\).*/\1/p')
+
+# Num erase groups per HC erase unit
+ERASE_GRP_SZ=$((0x$ERASE_GRP_SZ))
+
+# Num erase groups per WP group
+WP_GRP_SZ=$((0x$WP_GRP_SZ))
+
+# Each erase group is 512KB
+WP_GRP_SZ_KB=$((WP_GRP_SZ * ERASE_GRP_SZ * 512))
+
+# Num WP groups to protect region
+WP_NUM_GRP=$(( (PROT_SZ_KB + WP_GRP_SZ_KB - 1) / WP_GRP_SZ_KB))
+
+# Num blocks to protect region
+WP_NUM_BLK=$((WP_NUM_GRP * WP_GRP_SZ_KB * 2))
+
+echo "WP $ERASE_GRP_SZ $WP_GRP_SZ $WP_GRP_SZ_KB $WP_NUM_GRP $WP_NUM_BLK"
+
+# Device geom dictates the min size that can be protected. The protection
+# applied must not overrun.
+WP_BYTES=$((WP_NUM_BLK * 512))
+PROT_SZ_BYTES=$((PROT_SZ_KB * 1024))
+if [ "$WP_BYTES" -ne "$PROT_SZ_BYTES" ] ; then
+   >&2 echo "WP overrun $PROT_SZ_KB"
+   exit 1
+fi
+mmc writeprotect user set pwron 0 $WP_NUM_BLK $DEV

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -8,6 +8,7 @@ image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       align = 8M
       partition-table-type = "gpt"
+      gpt-location = 8M
    }
 
    partition config {


### PR DESCRIPTION
Write-protecting the partition table adds extra robustness. Partitions are currently aligned to 8M so pin the GPT entries to start at +8M, calculate the number of blocks needed to protect this region and lock them using Power on Write Protect via initramfs.