### PR TITLE
Initial provisioning support

### DIFF
--- a/bin/image2json
+++ b/bin/image2json
@@ -6,28 +6,29 @@ import argparse
 import os
 import copy
 import sys
+import subprocess
 
 
-VERSION = "1.4.4"
+VERSION = "2.0.0"
 
 
 IMAGE_KEYS = {"IGconf_device_class",
               "IGconf_device_variant",
               "IGconf_device_storage_type",
-              "IGconf_image_name",
               "IGconf_image_version",
               "IGconf_sys_outputdir"}
 
 
 top_template = {
     "IGversion": VERSION,
-    "meta": [],
+    "IGmeta": [],
     "attributes": {
+        "image-name": "unknown",
         "image-size": "0",
     },
     "layout": {
-        "partition-table-type": "none",
-        "partitions": []
+        "partitiontable": [],
+        "partitionimages": []
     }
 }
 
@@ -180,13 +181,14 @@ def find_images(itype, data):
     return timages
 
 
-# Returns the size of a file. If file is not an absolute path, use
+# Returns the path of a build asset. If the asset is not an absolute path, use
 # the env var as the directory of where to look.
-def get_artefact_size(file, dir_evar):
+def get_artefact_path(file, dir_evar):
     if not os.path.isabs(file):
         dir = os.getenv(dir_evar)
         if not dir:
             raise ValueError(f"Not an env var: {dir_evar}")
+            return None
 
         if not os.path.isdir(dir):
             raise FileNotFoundError(f"Dir not found: {dir}")
@@ -200,7 +202,15 @@ def get_artefact_size(file, dir_evar):
         raise FileNotFoundError(f"File not found: {fpath}")
         return None
 
-    return os.stat(fpath).st_size
+    return fpath
+
+
+# Returns the size of a build artefact file.
+def get_artefact_size(file):
+    f = get_artefact_path(file, "IGconf_sys_outputdir")
+    if f:
+        return os.stat(f).st_size
+    return None
 
 
 def get_fs_label(section):
@@ -244,20 +254,20 @@ def parse_genimage_config(config_path):
     # https://github.com/pengutronix/genimage/?tab=readme-ov-file#hdimage
     hdimage_data = find_images("hdimage", data)
     if not hdimage_data:
-        return (None,None)
+        return (None,None,None)
 
     disk_attr = {}
+    ptable = {}
 
     partitions = find_sections("partition", hdimage_data)
     images = find_sections("image", data)
     simgs = find_images("android-sparse", data)
 
-    for iname, idata in hdimage_data.items():
-        hdimage = idata.get("hdimage")
-        disk_attr["partition-table-type"] = hdimage.get("partition-table-type")
-        disk_attr["image-name"] = iname
-        disk_attr["image-size"] = idata.get("size") if idata.get("size") else "0"
-        sz = get_artefact_size(iname, "IGconf_sys_outputdir")
+    for img_name, img_data in hdimage_data.items():
+        hdimage = img_data.get("hdimage")
+        disk_attr["image-name"] = img_name
+        disk_attr["image-size"] = img_data.get("size") if img_data.get("size") else "0"
+        sz = get_artefact_size(img_name)
         if sz:
             disk_attr["image-size"] = str(sz)
 
@@ -269,10 +279,10 @@ def parse_genimage_config(config_path):
     # Associate partitions in the hdimage with their images
     for pname, pattr in partitions.items():
         if "image" in pattr:
-            iname = pattr["image"]
-            if iname in images:
+            piname = pattr["image"]
+            if piname in images:
                 # Found. Merge
-                partitions[pname] = {**images[iname], **pattr}
+                partitions[pname] = {**images[piname], **pattr}
 
                 # Tag image type
                 for t in gtypes:
@@ -288,18 +298,34 @@ def parse_genimage_config(config_path):
                 # Establish the actual size of the partition image rather than relying on
                 # the size described by the genimage config (which may be expressed in
                 # percent). The actual size is required for provisioning purposes.
-                sz = get_artefact_size(iname, "IGconf_sys_outputdir")
+                sz = get_artefact_size(piname)
                 if sz:
                     partitions[pname]["size"] = str(sz)
 
                 # If this image has a sparse derivative, tag it
-                for sname, sattr in simgs.items():
-                    simg = sattr.get("android-sparse")
-                    if iname == simg.get("image"):
+                for sname, sdata in simgs.items():
+                    simg = sdata.get("android-sparse")
+                    if piname == simg.get("image"):
                         partitions[pname]["simage"] = sname
 
+    # Read the partition table from the image
+    img_path = get_artefact_path(img_name, "IGconf_sys_outputdir")
+    try:
+        res = subprocess.run(
+                ["sfdisk", "--verify", "--json", img_path],
+                capture_output=True,
+                text=True,
+                check=True
+        )
+    except Exception as e:
+        raise RuntimeError(f"{e} Failed to read partition table from {img_path}")
 
-    return (disk_attr, partitions)
+    # Nodes are don't care
+    ptable = json.loads(res.stdout)
+    for p in ptable["partitiontable"]["partitions"]:
+        p.pop("node", None)
+
+    return (disk_attr, partitions, ptable)
 
 
 # Read all fstabs and store in a dict using UUID or label if we can,
@@ -416,7 +442,7 @@ if __name__ == '__main__':
     genimage_file = args.genimage;
 
     # Base info
-    attributes, genimage_partitions = parse_genimage_config(genimage_file)
+    attributes, genimage_partitions, ptable = parse_genimage_config(genimage_file)
 
     # fstab is optional
     if args.fstab:
@@ -426,10 +452,10 @@ if __name__ == '__main__':
     else:
         partition_json = genimage_partitions
 
-    top_template["meta"] = get_image_meta()
+    top_template["IGmeta"] = get_image_meta()
     top_template["attributes"]["image-name"] = os.path.basename(attributes.get("image-name"))
     top_template["attributes"]["image-size"] = attributes.get("image-size")
-    top_template["layout"]["partition-table-type"] = attributes.get("partition-table-type")
-    top_template["layout"]["partitions"] = partition_json
+    top_template["layout"]["partitiontable"] = ptable["partitiontable"]
+    top_template["layout"]["partitionimages"] = partition_json
 
     print(json.dumps(top_template, indent=4))

--- a/bin/image2json
+++ b/bin/image2json
@@ -28,7 +28,8 @@ top_template = {
     },
     "layout": {
         "partitiontable": [],
-        "partitionimages": []
+        "partitionimages": [],
+        "provisionmap": []
     }
 }
 
@@ -438,6 +439,11 @@ if __name__ == '__main__':
                         nargs="*",
                         required=False)
 
+    parser.add_argument("-m", "--provisionmap",
+                        help="Path to the JSON provisioning map",
+                        type=argparse.FileType('r'),
+                        required=False)
+
     args = parser.parse_args()
     genimage_file = args.genimage;
 
@@ -457,5 +463,8 @@ if __name__ == '__main__':
     top_template["attributes"]["image-size"] = attributes.get("image-size")
     top_template["layout"]["partitiontable"] = ptable["partitiontable"]
     top_template["layout"]["partitionimages"] = partition_json
+    if args.provisionmap:
+        with args.provisionmap as f:
+            top_template["layout"]["provisionmap"] = json.load(f)
 
     print(json.dumps(top_template, indent=4))

--- a/bin/image2json
+++ b/bin/image2json
@@ -8,7 +8,7 @@ import copy
 import sys
 
 
-VERSION = "1.2.4"
+VERSION = "1.3.4"
 
 
 IMAGE_KEYS = {"IGconf_device_class",
@@ -20,7 +20,7 @@ IMAGE_KEYS = {"IGconf_device_class",
 
 
 top_template = {
-    "version": VERSION,
+    "IGversion": VERSION,
     "meta": [],
     "attributes": {
         "image-size": "0",
@@ -180,6 +180,29 @@ def find_images(itype, data):
     return timages
 
 
+# Returns the size of a file. If file is not an absolute path, use
+# the env var as the directory of where to look.
+def get_artefact_size(file, dir_evar):
+    if not os.path.isabs(file):
+        dir = os.getenv(dir_evar)
+        if not dir:
+            raise ValueError(f"Not an env var: {dir_evar}")
+
+        if not os.path.isdir(dir):
+            raise FileNotFoundError(f"Dir not found: {dir}")
+            return None
+
+        fpath = os.path.join(dir, file)
+    else:
+        fpath = file
+
+    if not os.path.isfile(fpath):
+        raise FileNotFoundError(f"File not found: {fpath}")
+        return None
+
+    return os.stat(fpath).st_size
+
+
 def get_fs_label(section):
     label = section.get("label")
     if label:
@@ -229,6 +252,9 @@ def parse_genimage_config(config_path):
             hdimage = idata.get("hdimage")
             disk_attr["partition-table-type"] = hdimage.get("partition-table-type")
             disk_attr["image-size"] = idata.get("size") if idata.get("size") else "0"
+            sz = get_artefact_size(iname, "IGconf_sys_outputdir")
+            if sz:
+                disk_attr["image-size"] = str(sz)
 
     # https://github.com/pengutronix/genimage?tab=readme-ov-file#the-image-configuration-options
     gtypes = ["android-sparse", "btrfs", "cpio", "cramfs", "ext2", "ext3",
@@ -253,6 +279,13 @@ def parse_genimage_config(config_path):
                             attr = IMAGE_PROCESSORS[t](s)
                             if attr:
                                 partitions[pname].update(attr)
+
+                # Establish the actual size of the partition image rather than relying on
+                # the size described by the genimage config (which may be expressed in
+                # percent). The actual size is required for provisioning purposes.
+                sz = get_artefact_size(iname, "IGconf_sys_outputdir")
+                if sz:
+                    partitions[pname]["size"] = str(sz)
 
                 # If this image has a sparse derivative, tag it
                 for sname, sattr in simgs.items():

--- a/bin/image2json
+++ b/bin/image2json
@@ -8,7 +8,7 @@ import copy
 import sys
 
 
-VERSION = "1.3.4"
+VERSION = "1.4.4"
 
 
 IMAGE_KEYS = {"IGconf_device_class",
@@ -60,13 +60,13 @@ def map_genimage(key, value):
     gmap = {
         # https://github.com/pengutronix/genimage#the-image-section
         "partition-type-uuid":{
-            ("L", "linux"):       "0fc63daf-8483-4772-8e79-3d69d8477de4",
-            ("S", "swap"):        "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
-            ("H", "home"):        "933ac7e1-2eb4-4f13-b844-0e14e2aef915",
-            ("U", "esp", "uefi"): "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
-            ("R", "raid"):        "a19d880f-05fc-4d3b-a006-743f0f84911e",
-            ("V", "lvm"):         "e6d6d379-f507-44c2-a23c-238f2a3df928",
-            ("F", "fat32"):       "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
+            ("L", "linux"):       "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            ("S", "swap"):        "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F",
+            ("H", "home"):        "933AC7E1-2EB4-4F13-B844-0E14E2AEF915",
+            ("U", "esp", "uefi"): "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            ("R", "raid"):        "A19D880F-05FC-4D3B-A006-743F0F84911E",
+            ("V", "lvm"):         "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+            ("F", "fat32"):       "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
         }
     }
     if key in gmap:
@@ -240,28 +240,33 @@ IMAGE_PROCESSORS = {
 def parse_genimage_config(config_path):
     data = confuse2dict(config_path, {"exec-pre", "exec-post"}, map_genimage)
 
-    images = find_sections("image", data)
-    partitions = find_sections("partition", data)
-    simgs = find_images("android-sparse", data)
+    # Anchor to hdimage as it's the root container of a disk image
+    # https://github.com/pengutronix/genimage/?tab=readme-ov-file#hdimage
+    hdimage_data = find_images("hdimage", data)
+    if not hdimage_data:
+        return (None,None)
 
     disk_attr = {}
 
-    # Anchor to hdimage parent for top level attributes
-    for iname, idata in images.items():
-        if "hdimage" in idata:
-            hdimage = idata.get("hdimage")
-            disk_attr["partition-table-type"] = hdimage.get("partition-table-type")
-            disk_attr["image-size"] = idata.get("size") if idata.get("size") else "0"
-            sz = get_artefact_size(iname, "IGconf_sys_outputdir")
-            if sz:
-                disk_attr["image-size"] = str(sz)
+    partitions = find_sections("partition", hdimage_data)
+    images = find_sections("image", data)
+    simgs = find_images("android-sparse", data)
+
+    for iname, idata in hdimage_data.items():
+        hdimage = idata.get("hdimage")
+        disk_attr["partition-table-type"] = hdimage.get("partition-table-type")
+        disk_attr["image-name"] = iname
+        disk_attr["image-size"] = idata.get("size") if idata.get("size") else "0"
+        sz = get_artefact_size(iname, "IGconf_sys_outputdir")
+        if sz:
+            disk_attr["image-size"] = str(sz)
 
     # https://github.com/pengutronix/genimage?tab=readme-ov-file#the-image-configuration-options
     gtypes = ["android-sparse", "btrfs", "cpio", "cramfs", "ext2", "ext3",
               "ext4", "f2fs", "file", "FIT", "fip", "flash", "iso", "jffs2",
               "qemu", "rauc", "squashfs," "tar", "ubi", "vfat"]
 
-    # Associate partitions with their images
+    # Associate partitions in the hdimage with their images
     for pname, pattr in partitions.items():
         if "image" in pattr:
             iname = pattr["image"]
@@ -422,6 +427,7 @@ if __name__ == '__main__':
         partition_json = genimage_partitions
 
     top_template["meta"] = get_image_meta()
+    top_template["attributes"]["image-name"] = os.path.basename(attributes.get("image-name"))
     top_template["attributes"]["image-size"] = attributes.get("image-size")
     top_template["layout"]["partition-table-type"] = attributes.get("partition-table-type")
     top_template["layout"]["partitions"] = partition_json

--- a/bin/mkslot-helper
+++ b/bin/mkslot-helper
@@ -2,14 +2,21 @@
 
 set -u
 
-# Read the slot partition map from stdin (or arg1) and write the
-# fully assembled helper to stdout.
+# Read the json provision map from arg1, extract slot info and write the fully
+# assembled slot helper to stdout with the variables it expects.
+
+jq -e '.system_type == "slotted"' $1 > /dev/null || { >&2 echo "Not slotted"; exit 1;}
 
 cat ${RPI_TEMPLATES}/slot-helper.in.head
 
-pmap=${1--}
-while IFS= read -r line; do
-  printf '%s\n' "$line"
-done < <(cat -- "$pmap")
+while read -r role slot id ; do
+   echo "${role^^}${slot^^}=${id}"
+   echo "${role^^}${slot^^}_ENCRYPTED=n"
+done < <(jq -r '.slots | to_entries[] | .key as $slot | .value.partitions[]? | "\(.role) \($slot) \(.id)"' "$1")
+
+while read -r role slot id ; do
+   echo "${role^^}${slot^^}=${id}"
+   echo "${role^^}${slot^^}_ENCRYPTED=y"
+done < <(jq -r '.slots | to_entries[] | .key as $slot | .value.encrypted.partitions[]? | "\(.role) \($slot) \(.id)"' "$1")
 
 cat ${RPI_TEMPLATES}/slot-helper.in.tail

--- a/depends
+++ b/depends
@@ -20,3 +20,4 @@ btrfs-progs
 dctrl-tools
 uuidgen:uuid-runtime
 fdisk
+jq

--- a/depends
+++ b/depends
@@ -19,3 +19,4 @@ dbus-user-session
 btrfs-progs
 dctrl-tools
 uuidgen:uuid-runtime
+fdisk

--- a/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
+++ b/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
@@ -1,12 +1,15 @@
 #!/bin/sh
 
-set -u
+set -eu
 
 # Install slot rules
 install -m 0644 -D ../device/slot.rules $1/etc/udev/rules.d/90-rpi-slot.rules
 
-# Install slot helper
-mkslot-helper < ../device/slot.pmap > $1/usr/bin/rpi-slot || exit 1
+# Install provision map - TODO select clear/crypt?
+cp ../device/provisionmap.json ${IGconf_sys_outputdir}/provisionmap.json
+
+# Generate slot helper
+mkslot-helper ${IGconf_sys_outputdir}/provisionmap.json > $1/usr/bin/rpi-slot
 chmod +x $1/usr/bin/rpi-slot
 
 # Hint to initramfs-tools we have an ext4 rootfs

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -1,0 +1,64 @@
+{
+   "PMAPversion": "1.0.0",
+   "system_type": "slotted",
+   "slots": {
+      "A": {
+         "partitions": [
+            {
+               "name": "bootA",
+               "id": 2,
+               "role": "boot"
+            }
+         ],
+         "encrypted": {
+            "luks": {
+               "version": 2,
+               "key_size": 512,
+               "cipher": "aes-xts-plain64",
+               "hash": "sha256"
+            },
+            "partitions": [
+               {
+                  "name": "systemA",
+                  "id": "cryptrootA",
+                  "role": "system"
+               }
+            ]
+         }
+      },
+      "B": {
+         "partitions": [
+            {
+               "name": "bootB",
+               "id": 3,
+               "role": "boot"
+            }
+         ],
+         "encrypted": {
+            "luks": {
+               "version": 2,
+               "key_size": 512,
+               "cipher": "aes-xts-plain64",
+               "hash": "sha256"
+            },
+            "partitions": [
+               {
+                  "name": "systemB",
+                  "id": "cryptrootB",
+                  "role": "system"
+               }
+            ]
+         }
+      }
+   },
+   "partitions": [
+      {
+         "name": "config",
+         "id": "1"
+      },
+      {
+         "name": "data",
+         "id": "6"
+      }
+   ]
+}

--- a/image/gpt/ab_userdata/device/provisionmap.json
+++ b/image/gpt/ab_userdata/device/provisionmap.json
@@ -1,0 +1,44 @@
+{
+   "PMAPversion": "1.0.0",
+   "system_type": "slotted",
+   "slots": {
+      "A": {
+         "partitions": [
+            {
+               "name": "bootA",
+               "id": 2,
+               "role": "boot"
+            },
+            {
+               "name": "systemA",
+               "id": 4,
+               "role": "system"
+            }
+         ]
+      },
+      "B": {
+         "partitions": [
+            {
+               "name": "bootB",
+               "id": 3,
+               "role": "boot"
+            },
+            {
+               "name": "systemB",
+               "id": 5,
+               "role": "system"
+            }
+         ]
+      }
+   },
+   "partitions": [
+      {
+         "name": "config",
+         "id": "1"
+      },
+      {
+         "name": "data",
+         "id": "6"
+      }
+   ]
+}

--- a/image/gpt/ab_userdata/device/slot.pmap
+++ b/image/gpt/ab_userdata/device/slot.pmap
@@ -1,5 +1,0 @@
-# genimage.cfg.in
-BOOTA=2
-BOOTB=3
-SYSTEMA=4
-SYSTEMB=5

--- a/image/gpt/ab_userdata/device/slot.rules
+++ b/image/gpt/ab_userdata/device/slot.rules
@@ -1,2 +1,3 @@
 SUBSYSTEM=="block", KERNEL=="mmcblk*p*[0-9]", IMPORT{program}="/usr/bin/rpi-slot -u %k", SYMLINK+="$env{SLOT}"
 SUBSYSTEM=="block", KERNEL=="nvme*n*p*[0-9]", IMPORT{program}="/usr/bin/rpi-slot -u %k", SYMLINK+="$env{SLOT}"
+SUBSYSTEM=="block", KERNEL=="dm-*", ENV{DM_NAME}=="*", IMPORT{program}="/usr/bin/rpi-slot -u %E{DM_NAME}", SYMLINK+="$env{SLOT}"

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -54,7 +54,6 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       bootable = true
    }
 
-   # <slot.pmap>
    partition bootA {
       in-partition-table = true
       image = bootA.vfat
@@ -80,7 +79,6 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       image = systemB.ext4
       partition-type-uuid = L
    }
-   # </slot.pmap>
 
    partition data {
       in-partition-table = true

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -1,10 +1,46 @@
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
+image <IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
    android-sparse {
-      image = <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>
+      image = <IMAGE_NAME>.<IMAGE_SUFFIX>
    }
 }
 
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
+image config.sparse {
+   android-sparse {
+      image = config.vfat
+   }
+}
+
+image bootA.sparse {
+   android-sparse {
+      image = bootA.vfat
+   }
+}
+
+image bootB.sparse {
+   android-sparse {
+      image = bootB.vfat
+   }
+
+}
+image systemA.sparse {
+   android-sparse {
+      image = systemA.ext4
+   }
+}
+
+image systemB.sparse {
+   android-sparse {
+      image = systemB.ext4
+   }
+}
+
+image data.sparse {
+   android-sparse {
+      image = data.ext4
+   }
+}
+
+image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       align = 8M
       partition-table-type = "gpt"

--- a/image/gpt/ab_userdata/slot-post-process.sh
+++ b/image/gpt/ab_userdata/slot-post-process.sh
@@ -14,7 +14,7 @@ case $COMP in
 LABEL=USERDATA                  /data          ext4 rw,relatime,nofail 0 2
 LABEL=BOOTFS                    /bootfs        vfat defaults,rw 0 2
 EOF
-      image2json -g $OUTPUTPATH/genimage.cfg -f $IMAGEMOUNTPATH/etc/fstab > $OUTPUTPATH/image.json
+      cp $IMAGEMOUNTPATH/etc/fstab $OUTPUTPATH
       ;;
    BOOT)
       sed -i "s|root=\([^ ]*\)|root=\/dev\/ram0|" $IMAGEMOUNTPATH/cmdline.txt

--- a/image/mbr/simple_dual/device/provisionmap-crypt.json
+++ b/image/mbr/simple_dual/device/provisionmap-crypt.json
@@ -1,0 +1,24 @@
+{
+  "PMAPversion": "1.0.0",
+  "system_type": "flat",
+  "partitions": [
+    {
+      "name": "boot",
+      "id": 1
+    }
+  ],
+  "encrypted": {
+     "luks": {
+        "version": 2,
+        "key_size": 512,
+        "cipher": "aes-xts-plain64",
+        "hash": "sha256"
+     },
+     "partitions": [
+        {
+           "name": "root",
+           "id": "cryptroot"
+        }
+     ]
+  }
+}

--- a/image/mbr/simple_dual/device/provisionmap.json
+++ b/image/mbr/simple_dual/device/provisionmap.json
@@ -1,0 +1,14 @@
+{
+  "PMAPversion": "1.0.0",
+  "system_type": "flat",
+  "partitions": [
+    {
+      "name": "boot",
+      "id": 1
+    },
+    {
+      "name": "root",
+      "id": 2
+    }
+  ]
+}

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -1,10 +1,22 @@
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
+image <IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
    android-sparse {
-      image = <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>
+      image = <IMAGE_NAME>.<IMAGE_SUFFIX>
    }
 }
 
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
+image boot.vfat.sparse {
+   android-sparse {
+      image = boot.vfat
+   }
+}
+
+image root.btrfs.sparse {
+   android-sparse {
+      image = root.btrfs
+   }
+}
+
+image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       align = 8M
       partition-table-type = "mbr"

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -1,10 +1,22 @@
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
+image <IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
    android-sparse {
-      image = <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>
+      image = <IMAGE_NAME>.<IMAGE_SUFFIX>
    }
 }
 
-image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
+image boot.vfat.sparse {
+   android-sparse {
+      image = boot.vfat
+   }
+}
+
+image root.ext4.sparse {
+   android-sparse {
+      image = root.ext4
+   }
+}
+
+image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       align = 8M
       partition-table-type = "mbr"

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -5,6 +5,9 @@ set -eu
 rootfs=$1
 genimg_in=$2
 
+# Install provision map - TODO select clear/crypt?
+cp ./device/provisionmap.json ${IGconf_sys_outputdir}/provisionmap.json
+
 echo "BOOT_UUID=\"$(uuidgen | sed 's/-.*//')"\" > ${genimg_in}/fs_uuids
 echo "ROOT_UUID=\"$(uuidgen)"\" >> ${genimg_in}/fs_uuids
 . ${genimg_in}/fs_uuids

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -26,7 +26,7 @@ EOF
       cat << EOF >> $IMAGEMOUNTPATH/etc/fstab
 UUID=${BOOTUUID^^} /boot/firmware  vfat rw,noatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,errors=remount-ro 0 2
 EOF
-      image2json -g $OUTPUTPATH/genimage.cfg -f $IMAGEMOUNTPATH/etc/fstab > $OUTPUTPATH/image.json
+      cp $IMAGEMOUNTPATH/etc/fstab $OUTPUTPATH
       ;;
    BOOT)
       sed -i "s|root=\([^ ]*\)|root=UUID=${ROOTUUID}|" $IMAGEMOUNTPATH/cmdline.txt

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+
 deploydir=$1
 
 case ${IGconf_image_compression} in
@@ -12,7 +13,19 @@ case ${IGconf_image_compression} in
       ;;
 esac
 
-shopt -s nullglob
+
+if [ -f ${IGconf_sys_outputdir}/genimage.cfg ] ; then
+   fstabs=()
+   opts=()
+   fstabs+=("${IGconf_sys_outputdir}"/fstab*)
+   for f in "${fstabs[@]}" ; do
+      if [ -f "$f" ] ; then
+         opts+=('-f' $f)
+      fi
+   done
+   image2json -g ${IGconf_sys_outputdir}/genimage.cfg "${opts[@]}" > ${IGconf_sys_outputdir}/image.json
+fi
+
 
 files=()
 files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix})
@@ -22,6 +35,7 @@ files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.sbom)
 msg "Deploying image and SBOM"
 
 for f in "${files[@]}" ; do
+   [[ -f "$f" ]] || continue
    case ${IGconf_image_compression} in
       zstd)
          zstd -v -f $f --sparse --output-dir-flat $deploydir

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -23,6 +23,10 @@ if [ -f ${IGconf_sys_outputdir}/genimage.cfg ] ; then
          opts+=('-f' $f)
       fi
    done
+
+   if [ -f ${IGconf_sys_outputdir}/provisionmap.json ] ; then
+      opts+=('-m' ${IGconf_sys_outputdir}/provisionmap.json)
+   fi
    image2json -g ${IGconf_sys_outputdir}/genimage.cfg "${opts[@]}" > ${IGconf_sys_outputdir}/image.json
 fi
 

--- a/templates/rpi/slot-helper.in.tail
+++ b/templates/rpi/slot-helper.in.tail
@@ -108,11 +108,17 @@ test -e /sys/class/block/$bootdev || die "bad base blockdev"
 case $bootdev in
    mmc*|nvme*)
       for d in BOOTA BOOTB SYSTEMA SYSTEMB ; do
-         _v="k${d}"
-         eval "$_v=\${bootdev}p\${$d}"
-         eval "bdev=\$$_v"
-         # shellcheck disable=SC2154
-         test -e "/sys/class/block/${bdev}" || die "bad pmap blockdev $bdev"
+         eval crypt=\$"${d}_ENCRYPTED"
+         if [ "$crypt" = "y" ] ; then
+            eval "bdev=\$${d}"
+            test -e "/dev/mapper/${bdev}" || die "bad mapper blockdev $bdev"
+         else
+            _v="k${d}"
+            eval "$_v=\${bootdev}p\${$d}"
+            eval "bdev=\$$_v"
+            # shellcheck disable=SC2154
+            test -e "/sys/class/block/${bdev}" || die "bad blockdev $bdev"
+         fi
       done
       ;;
    *);;

--- a/templates/rpi/slot-helper.in.tail
+++ b/templates/rpi/slot-helper.in.tail
@@ -6,11 +6,15 @@ die (){
 }
 
 
-# defaults
-: "${BOOTA:=99}"
-: "${BOOTB:=99}"
-: "${SYSTEMA:=99}"
-: "${SYSTEMB:=99}"
+: "${BOOTA:?}"
+: "${BOOTB:?}"
+: "${SYSTEMA:?}"
+: "${SYSTEMB:?}"
+
+: "${BOOTA_ENCRYPTED:?}"
+: "${BOOTB_ENCRYPTED:?}"
+: "${SYSTEMA_ENCRYPTED:?}"
+: "${SYSTEMB_ENCRYPTED:?}"
 
 
 prefix=disk/by-slot


### PR DESCRIPTION
This PR adds support for more attributes to the JSON image description, including partition table information and a _provisioning map_. The provisioning map is intended to serve as an input to rpi-sb-provisioner to describe how a device should have the partition table and respective image assets written to it for a given configuration. The provisioning maps are currently standalone JSON files which exist under the appropriate image layout directory and contain the initial version of the JSON describing how a provisioning system can lookup and utilise information from the JSON ```partitionimages[]``` and ```partitiontable[]``` arrays to provision a device.

There are two types of map proposed:

```slotted``` describes an 'AB' system
```flat``` describes a simple RPiOS style system

There are also two flavours of provision map for each in-tree layout:

```provisionmap.json``` describes the layout without any encrypted filesystems
```provisionmap-crypt.json``` describes the layout with encrypted filesystems for root

In an AB system, the provisioning map is used as an input for the udev slot helper to create the pre-defined static mapping of block device nodes to slot sub-components under ```/dev/disk/by-slot/```. This has been extended to include Device Mapper (dm) udev events which are required if a slot has an encrypted sub-component (eg system / rootfs).
