### PR TITLE
SBOM: Update syft to 1.22.0 and add yaml config

### DIFF
--- a/sbom/defaults
+++ b/sbom/defaults
@@ -1,4 +1,11 @@
 # rpi-image-gen sbom defaults
 
-# Default format for the SBOM
-output_format="spdx-json"
+# Configuration file containg the settings syft will use to scan
+# and output the SBOM. The following options are explicitly specified
+# when syft is invoked:
+# source:
+#   name
+#   version
+#   base-path
+# Ref: https://github.com/anchore/syft/wiki/Configuration
+syft_config=syft.yaml

--- a/sbom/gen.sh
+++ b/sbom/gen.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
+# shellcheck disable=SC2154
 
 set -eu
 
 rootfs=$1
 outdir=$2
 
-SYFT_VER=v1.19.0
+SYFT_VER=v1.22.0
 
 # If host has syft, use it
 if ! hash syft 2>/dev/null; then
    curl -sSfL https://raw.githubusercontent.com/anchore/syft/${SYFT_VER}/install.sh \
-      | sh -s -- -b ${IGconf_sys_workdir}/host/bin
+      | sh -s -- -b "${IGconf_sys_workdir}"/host/bin
 fi
 
 SYFT=$(syft --version 2>/dev/null) || die "syft is unusable"
 
+if igconf isset sbom_syft_config ; then
+   SYFTCFG=$(realpath -e "$IGconf_sbom_syft_config") || die "Invalid syft config"
+else
+   die "No syft config"
+fi
+
 msg "SBOM: $SYFT scanning $rootfs"
 
-podman unshare syft scan dir:"$rootfs" \
+podman unshare syft -c "$SYFTCFG"  scan dir:"$rootfs" \
    --base-path "$rootfs" \
    --source-name "$IGconf_image_name" \
    --source-version "${IGconf_image_version}" \
-   --output ${IGconf_sbom_output_format}="${outdir}/${IGconf_image_name}.sbom"
+   > "${outdir}/${IGconf_image_name}.sbom"

--- a/sbom/syft.yaml
+++ b/sbom/syft.yaml
@@ -1,0 +1,21 @@
+file:
+  metadata:
+    selection: all
+    digests:
+      - sha256
+
+output:
+  - spdx-json
+
+format:
+    pretty: true
+
+source:
+  file:
+    digests:
+      - sha256
+
+package:
+  cataloger:
+    scope:
+      - squashed


### PR DESCRIPTION
Add a file to hold the settings syft will use to generate the SBOM. The path to this file is held in a new config variable.

Remove the config variable holding the output format that the SBOM was generated in. This is no longer needed since the output format is now defined in the config file.

A config file is always provided to syft for its scan.