### PR TITLE
Correct output image file size

### DIFF
--- a/device/build.defaults
+++ b/device/build.defaults
@@ -38,3 +38,7 @@ ssh_user1=n
 
 # The storage type used by the device. Supported values are sd, emmc or nvme.
 storage_type=sd
+
+# Logical sector size for the uncompressed full image. The output fill size
+# will be a multiple of this value to ensure compatability with other tools
+sector_size=512

--- a/device/build.defaults
+++ b/device/build.defaults
@@ -39,6 +39,6 @@ ssh_user1=n
 # The storage type used by the device. Supported values are sd, emmc or nvme.
 storage_type=sd
 
-# Logical sector size for the uncompressed full image. The output fill size
-# will be a multiple of this value to ensure compatability with other tools
+# Logical sector size of the device storage for which the image is intended. 
+# The output raw image file size will be a multiple of this value.
 sector_size=512

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -39,7 +39,7 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
 image boot.vfat {
    vfat {
       label = "BOOT"
-      extraargs = "-s 4 -S 512 -i <BOOT_UUID>"
+      extraargs = "-s 4 -S <SECTOR_SIZE> -i <BOOT_UUID>"
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -39,7 +39,7 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
 image boot.vfat {
    vfat {
       label = "BOOT"
-      extraargs = "-s 4 -S 512 -i <BOOT_UUID>"
+      extraargs = "-s 4 -S <SECTOR_SIZE> -i <BOOT_UUID>"
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -19,6 +19,7 @@ cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<FW_SIZE>|$IGconf_image_boot_part_size|g" \
    -e "s|<ROOT_SIZE>|$IGconf_image_root_part_size|g" \
+   -e "s|<SECTOR_SIZE>|$IGconf_device_sector_size|g" \
    -e "s|<SETUP>|'$(readlink -ef setup.sh)'|g" \
    -e "s|<MKE2FSCONF>|'$(readlink -ef mke2fs.conf)'|g" \
    -e "s|<BOOT_UUID>|$BOOT_UUID|g" \

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -37,8 +37,8 @@ for f in "${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix} 
    files+=($f)
    [[ -f "$f" ]] || continue
    
-   # Ensure for rpi-imager that the image size is a multiple of 512 bytes
-   truncate -s %512 $f
+   # Ensure that the output image is a multiple of the selected sector size
+   truncate -s %${IGconf_device_sector_size} $f
 done
 
 files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix}.sparse)

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -32,7 +32,15 @@ fi
 
 
 files=()
-files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix})
+
+for f in "${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix} ; do
+   files+=($f)
+   [[ -f "$f" ]] || continue
+   
+   # Ensure for rpi-imager that the image size is a multiple of 512 bytes
+   truncate -s %512 $f
+done
+
 files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.${IGconf_image_suffix}.sparse)
 files+=("${IGconf_sys_outputdir}/${IGconf_image_name}"*.sbom)
 


### PR DESCRIPTION
Ensure for rpi-imager that all generated images have a size that is a multiple of 512 bytes.

See #50 