### PR TITLE
IDP: PMAP luks integration and JSON tweaks

### DIFF
--- a/bin/idp.sh
+++ b/bin/idp.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -u
+
+BINDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export PATH="$BINDIR:$PATH"
+
+msg() {
+   date +"[%T] $*"
+}
+
+err (){
+   >&2 msg "$*"
+}
+
+
+die (){
+   err "$*"
+   exit 1
+}
+
+usage()
+{
+cat <<-EOF >&2
+Usage
+  $(basename "$0") [options]
+
+Simple provisioner that uses an rpi-image-gen JSON image description to write
+the corresponding software image to a remote device running the pi-gen-micro
+fastboot gadget.
+
+Options:
+
+-f <json> [-- args] Path to the file created with image2json. Remaing args
+                    will be passed to fastboot.
+EOF
+}
+
+
+JSON=
+FARGS=
+while getopts "f:" flag ; do
+   case "$flag" in
+      f)
+         JSON="$OPTARG"
+         ;;
+      *|?)
+         usage ; exit 1
+         ;;
+   esac
+done
+[[ -z $JSON ]] && { usage ; die "Require path to JSON file" ; }
+realpath -e $JSON > /dev/null 2>&1 || die "$JSON is invalid"
+
+shift $((OPTIND - 1))
+FARGS=("$@")
+
+
+# Dependencies
+progs=()
+progs+=(fastboot)
+for p in "${progs[@]}" ; do
+   if ! command -v $p 2>&1 >/dev/null ; then
+      die "$p is not installed"
+   fi
+done
+
+
+FB() {
+if [ "${#FARGS[@]}" -eq 0 ]; then
+      fastboot "$@"
+   else
+      fastboot "${FARGS[@]}" "$@"
+   fi
+   [[ $? -eq 0 ]] || { err "fastboot: error running ${FARGS[@]} $@" ; false ; }
+}
+
+
+ASSET_DIR=$(pmap -f $JSON --get-key IGmeta.IGconf_sys_outputdir)
+[[ -d $ASSET_DIR ]] || die "JSON specified asset dir $ASSET_DIR is invalid"
+
+# Do it
+
+msg "Staging description.."
+FB stage $JSON 2>&1 || die "Unable to transfer description to device"
+
+msg "Checking if provisioning is possible.."
+FB oem idpinit 2>&1 || die "Pre-provision checks failed"
+
+msg "Initiating provisioning.."
+FB oem idpwrite || die "Error writing to device"
+
+while true; do
+    output=$(FB oem idpgetblk 2>&1)
+
+    info_resp=$(echo "$output" | grep '^(bootloader)')
+
+    # If there are no more info responses, we're done
+    if [[ -z "$info_resp" ]]; then
+        break
+    fi
+
+    # Write each image into the appointed block device
+    while read -r line; do
+        if [[ "$line" =~ ^\(bootloader\)\ ([^:]+):(.+)$ ]]; then
+            dev="${BASH_REMATCH[1]}"
+            image="${BASH_REMATCH[2]}"
+            FB flash $dev ${ASSET_DIR}/$image || die "Error writing $image to $dev"
+        fi
+    done <<< "$info_resp"
+done
+
+msg "Complete"
+
+FB oem idpdone || die "Error cleaning up"

--- a/bin/mkslot-helper
+++ b/bin/mkslot-helper
@@ -1,45 +1,12 @@
 #!/bin/bash
 
-set -u
+set -eu
 
 # Read the json provision map from arg1, extract slot info and write the fully
 # assembled slot helper to stdout with the variables it expects.
 
-# Need slotted system type
-jq -e '
-  .[] |
-  select(.attributes != null) |
-  .attributes.system_type == "slotted"
-' $1 > /dev/null || { >&2 echo "Not slotted"; exit 1;}
-
 cat ${RPI_TEMPLATES}/slot-helper.in.head
 
-# Process regular partitions in slots
-while read -r role slot id ; do
-   echo "${role^^}${slot^^}=${id}"
-   echo "${role^^}${slot^^}_ENCRYPTED=n"
-done < <(jq -r '
-  .[] |
-  select(.slots != null) |
-  .slots |
-  to_entries[] |
-  .key as $slot |
-  .value.partitions[]? |
-  "\(.role) \($slot) \(.id)"
-' "$1")
-
-# Process encrypted partitions in slots
-while read -r role slot id ; do
-   echo "${role^^}${slot^^}=${id}"
-   echo "${role^^}${slot^^}_ENCRYPTED=y"
-done < <(jq -r '
-  .[] |
-  select(.slots != null) |
-  .slots |
-  to_entries[] |
-  .key as $slot |
-  .value.encrypted.partitions[]? |
-  "\(.role) \($slot) \(.id)"
-' "$1")
+pmap --file $1 --slotvars
 
 cat ${RPI_TEMPLATES}/slot-helper.in.tail

--- a/bin/pmap
+++ b/bin/pmap
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# Provisioning Map Helper
+
+import argparse
+import json
+import sys
+
+
+# Print slot mapping
+def slotvars(data):
+    # Check for slotted system_type
+    if not any(e.get("attributes", {}).get("system_type") == "slotted" for e in data):
+        sys.stderr.write("Not slotted\n")
+        sys.exit(1)
+
+    for entry in data:
+        # encrypted at the top level with slots
+        if "encrypted" in entry and "slots" in entry["encrypted"]:
+            mname = entry["encrypted"]["luks2"]["mname"]
+            slots = entry["encrypted"]["slots"]
+            for slot, slotval in slots.items():
+                for part in slotval.get("partitions", []):
+                    role = part.get("role", "")
+                    id_ = part.get("id", "")
+                    print(f"{role.upper()}{slot.upper()}={mname}{id_}")
+                    print(f"{role.upper()}{slot.upper()}_ENCRYPTED=y")
+
+        # slots at the top level with encapsulated unencrypted/encrypted
+        elif "slots" in entry:
+            slots = entry["slots"]
+            for slot, slotval in slots.items():
+                # Encrypted inside this slot
+                if "encrypted" in slotval:
+                    mname = slotval["encrypted"]["luks2"]["mname"]
+                    for part in slotval["encrypted"].get("partitions", []):
+                        role = part.get("role", "")
+                        id_ = part.get("id", "")
+                        print(f"{role.upper()}{slot.upper()}={mname}{id_}")
+                        print(f"{role.upper()}{slot.upper()}_ENCRYPTED=y")
+
+                # Unencrypted
+                for part in slotval.get("partitions", []):
+                    # Only print unencrypted if not also encrypted
+                    if "encrypted" not in slotval:
+                        role = part.get("role", "")
+                        id_ = part.get("id", "")
+                        print(f"{role.upper()}{slot.upper()}={id_}")
+                        print(f"{role.upper()}{slot.upper()}_ENCRYPTED=n")
+
+
+
+# Best effort general purpose JSON key retrieval
+def get_key(data, key_path, default=None):
+    keys = key_path.split('.')
+    val = data
+    for key in keys:
+        if isinstance(val, dict):
+            if key in val:
+                val = val[key]
+            else:
+                return default
+        elif isinstance(val, list):
+            # Try to interpret key as an integer index
+            try:
+                idx = int(key)
+                val = val[idx]
+            except (ValueError, IndexError):
+                # Optionally, search all items for the key
+                for item in val:
+                    if isinstance(item, dict) and key in item:
+                        val = item[key]
+                        break
+                else:
+                    return default
+        else:
+            return default
+    return val
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+            description='PMAP helper')
+
+    parser.add_argument("-f", "--file",
+                        help="Path to PMAP file",
+                        required=True)
+
+    parser.add_argument("-s", "--slotvars",
+                        action="store_true",
+                        help="Print slot map variables")
+
+    parser.add_argument("--get-key",
+                        help="Dot-separated key path to retrieve from PMAP JSON")
+
+    args = parser.parse_args()
+
+    with open(args.file) as f:
+        data = json.load(f)
+
+    if args.slotvars:
+        slotvars(data)
+        sys.exit(0);
+
+    if args.get_key:
+        value = get_key(data, args.get_key)
+        if value is None:
+            sys.exit(1)
+        else:
+            print(value)
+            sys.exit(0)

--- a/depends
+++ b/depends
@@ -20,4 +20,3 @@ btrfs-progs
 dctrl-tools
 uuidgen:uuid-runtime
 fdisk
-jq

--- a/device/pre-build.sh
+++ b/device/pre-build.sh
@@ -9,3 +9,11 @@ case ${IGconf_device_storage_type:?} in
       die "Unsupported device storage type: $IGconf_device_storage_type"
       ;;
 esac
+
+case ${IGconf_device_sector_size:?} in
+   512)
+      ;;
+   *)
+      die "Unsupported device sector size: $IGconf_device_storage_type"
+      ;;
+esac

--- a/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
+++ b/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
@@ -8,6 +8,8 @@ install -m 0644 -D ../device/slot.rules $1/etc/udev/rules.d/90-rpi-slot.rules
 # Install provision map
 if igconf isset image_pmap ; then
    cp ../device/provisionmap-${IGconf_image_pmap}.json ${IGconf_sys_outputdir}/provisionmap.json
+else
+   die "No pmap. Unable to generate slot mapping."
 fi
 
 # Generate slot helper

--- a/image/gpt/ab_userdata/device/provisionmap-clear.json
+++ b/image/gpt/ab_userdata/device/provisionmap-clear.json
@@ -8,8 +8,7 @@
    {
       "partitions": [
          {
-            "name": "config",
-            "id": "1"
+            "image": "config"
          }
       ]
    },
@@ -18,7 +17,7 @@
          "A": {
             "partitions": [
                {
-                  "name": "bootA",
+                  "image": "bootA",
                   "id": "2",
                   "role": "boot"
                }
@@ -31,7 +30,7 @@
          "B": {
             "partitions": [
                {
-                  "name": "bootB",
+                  "image": "bootB",
                   "id": "3",
                   "role": "boot"
                }
@@ -44,7 +43,7 @@
          "A": {
             "partitions": [
                {
-                  "name": "systemA",
+                  "image": "systemA",
                   "id": "4",
                   "role": "system"
                }
@@ -57,7 +56,7 @@
          "B": {
             "partitions": [
                {
-                  "name": "systemB",
+                  "image": "systemB",
                   "id": "5",
                   "role": "system"
                }
@@ -68,8 +67,7 @@
    {
       "partitions": [
          {
-            "name": "data",
-            "id": "6"
+            "image": "data"
          }
       ]
    }

--- a/image/gpt/ab_userdata/device/provisionmap-dual-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-dual-crypt.json
@@ -39,29 +39,41 @@
       }
    },
    {
-      "encrypted": {
-         "luks2": {
-            "key_size": 512,
-            "cipher": "aes-xts-plain64",
-            "hash": "sha256",
-            "label": "root",
-            "mname": "cryptroot",
-            "etype": "partitioned"
-         },
-         "slots": {
-            "A": {
+      "slots": {
+         "A": {
+            "encrypted": {
+               "luks2": {
+                  "key_size": 512,
+                  "cipher": "aes-xts-plain64",
+                  "hash": "sha256",
+                  "label": "rootA",
+                  "mname": "cryptrootA",
+                  "etype": "raw"
+               },
                "partitions": [
                   {
-                     "id": "1",
                      "image": "systemA",
                      "role": "system"
                   }
                ]
-            },
-            "B": {
+            }
+         }
+      }
+   },
+   {
+      "slots": {
+         "B": {
+            "encrypted": {
+               "luks2": {
+                  "key_size": 512,
+                  "cipher": "aes-xts-plain64",
+                  "hash": "sha256",
+                  "label": "rootB",
+                  "mname": "cryptrootB",
+                  "etype": "raw"
+               },
                "partitions": [
                   {
-                     "id": "2",
                      "image": "systemB",
                      "role": "system"
                   }

--- a/image/gpt/ab_userdata/device/provisionmap-hybrid.json
+++ b/image/gpt/ab_userdata/device/provisionmap-hybrid.json
@@ -39,30 +39,34 @@
       }
    },
    {
-      "encrypted": {
-         "luks2": {
-            "key_size": 512,
-            "cipher": "aes-xts-plain64",
-            "hash": "sha256",
-            "label": "root",
-            "mname": "cryptroot",
-            "etype": "partitioned"
-         },
-         "slots": {
-            "A": {
+      "slots": {
+         "A": {
+            "partitions": [
+               {
+                  "image": "systemA",
+                  "id": "4",
+                  "role": "system"
+               }
+            ]
+         }
+      }
+   },
+   {
+      "slots": {
+         "B": {
+            "encrypted": {
+               "luks2": {
+                  "key_size": 512,
+                  "cipher": "aes-xts-plain64",
+                  "hash": "sha256",
+                  "label": "rootB",
+                  "mname": "cryptroot",
+                  "etype": "partitioned"
+               },
                "partitions": [
                   {
-                     "id": "1",
-                     "image": "systemA",
-                     "role": "system"
-                  }
-               ]
-            },
-            "B": {
-               "partitions": [
-                  {
-                     "id": "2",
                      "image": "systemB",
+                     "id": "1",
                      "role": "system"
                   }
                ]

--- a/image/mbr/simple_dual/device/provisionmap-clear.json
+++ b/image/mbr/simple_dual/device/provisionmap-clear.json
@@ -8,12 +8,10 @@
    {
       "partitions": [
          {
-            "name": "boot",
-            "id": "1"
+            "image": "boot"
          },
          {
-            "name": "root",
-            "id": "2"
+            "image": "root"
          }
       ]
    }

--- a/image/mbr/simple_dual/device/provisionmap-crypt.json
+++ b/image/mbr/simple_dual/device/provisionmap-crypt.json
@@ -8,23 +8,23 @@
    {
       "partitions": [
          {
-            "name": "boot",
-            "id": "1"
+            "image": "boot"
          }
       ]
    },
    {
       "encrypted": {
-         "luks": {
-            "version": 2,
+         "luks2": {
             "key_size": 512,
             "cipher": "aes-xts-plain64",
-            "hash": "sha256"
+            "label": "root",
+            "hash": "sha256",
+            "mname": "cryptroot",
+            "etype": "raw"
          },
          "partitions": [
             {
-               "name": "root",
-               "id": "cryptroot"
+               "image": "root"
             }
          ]
       }

--- a/templates/rpi/slot-helper.in.tail
+++ b/templates/rpi/slot-helper.in.tail
@@ -1,7 +1,12 @@
 # End auto-generated
 
+err (){
+   >&2 echo "$@"
+}
+
+
 die (){
-   >&2 echo "$*"
+   err "$@"
    exit 1
 }
 
@@ -111,7 +116,7 @@ case $bootdev in
          eval crypt=\$"${d}_ENCRYPTED"
          if [ "$crypt" = "y" ] ; then
             eval "bdev=\$${d}"
-            test -e "/dev/mapper/${bdev}" || die "bad mapper blockdev $bdev"
+            test -e "/dev/mapper/${bdev}" || err "mapped dev $bdev unavailable"
          else
             _v="k${d}"
             eval "$_v=\${bootdev}p\${$d}"


### PR DESCRIPTION
Align LUKS objects in the provisioning maps with what the IDP provisioning side expects. This may need revisiting once the cryptroot behaviour is solidified. Building with anything other than pmap=clear will currently not generate a bootable image until cryptroot has been integrated into rpi-image-gen to unlock LUKS.

Trim unused JSON objects and clean up PMAP schema.

Add a pre-build check for device sector size since it now propagates into the IDP data.

Add new shell script to provision a device via IDP and fastboot (needs an updated pi-gen-micro fastboot gadget).

Drop jq from dependencies as it was getting too unwieldy to handle the schema. Usage has been replaced with a python helper that is much easier to maintain and extend.

Add two variants of AB crypt pmap. The dual-crypt variant will likely be dropped in favour of single crypt (ie one LUKS container).

A PMAP is mandatory for AB systems because the slot map can't be generated without it.