### PR TITLE
initramfs: skip unnecessary image generation, reduce build time

### DIFF
--- a/meta/rpi/arm64/linux-image-2712.yaml
+++ b/meta/rpi/arm64/linux-image-2712.yaml
@@ -1,10 +1,9 @@
 ---
 name: rpi-linux-2712
+env:
+  INITRD: "No"
 mmdebstrap:
   architectures:
     - arm64
   packages:
-    - initramfs-tools
     - linux-image-rpi-2712
-  customize-hooks:
-    - sed -i 's/^update_initramfs=.*/update_initramfs=no/' $1/etc/initramfs-tools/update-initramfs.conf

--- a/meta/rpi/arm64/linux-image-v8.yaml
+++ b/meta/rpi/arm64/linux-image-v8.yaml
@@ -1,10 +1,9 @@
 ---
 name: rpi-linux-v8
+env:
+  INITRD: "No"
 mmdebstrap:
   architectures:
     - arm64
   packages:
-    - initramfs-tools
     - linux-image-rpi-v8
-  customize-hooks:
-    - sed -i 's/^update_initramfs=.*/update_initramfs=no/' $1/etc/initramfs-tools/update-initramfs.conf

--- a/meta/rpi/armhf/linux-image-v7l.yaml
+++ b/meta/rpi/armhf/linux-image-v7l.yaml
@@ -1,7 +1,7 @@
 ---
-name: rpi-linux-v7
+name: rpi-linux-v7l
 env:
   INITRD: "No"
 mmdebstrap:
   packages:
-    - linux-image-rpi-v7
+    - linux-image-rpi-v7l

--- a/scripts/bdebstrap/customize10-initramfs
+++ b/scripts/bdebstrap/customize10-initramfs
@@ -22,8 +22,10 @@ if igconf isset image_rootfs_type ; then
    sed -i "s|FSTYPE=\([^ ]*\)|FSTYPE=${IGconf_image_rootfs_type}|" $1/etc/initramfs-tools/initramfs.conf
 fi
 
-# Always make sure all initramfs are updated
-cp $1/etc/initramfs-tools/update-initramfs.conf $1/etc/initramfs-tools/update-initramfs.conf.bak
-sed -i 's/^update_initramfs=.*/update_initramfs=all/' $1/etc/initramfs-tools/update-initramfs.conf
-chroot $1 update-initramfs -u
-mv -f $1/etc/initramfs-tools/update-initramfs.conf.bak $1/etc/initramfs-tools/update-initramfs.conf
+# Create all images if kernel postinst was instructed to not generate, else
+# update
+if [ "${INITRD:-}" = "No" ]; then
+   chroot $1 update-initramfs -c -k all
+else
+   chroot $1 update-initramfs -u -k all
+fi


### PR DESCRIPTION
It's inconvenient to have initramfs images built more than once, particularly on platforms running on emulation where usage of compressed modules is very slow.

Unfortunately, this can happen quite easily. Setting update_initramfs=no in update-initramfs.conf prevents images getting (re)generated, but only after this file modification has been made. If update-initramfs.conf is created before initramfs-tools has been installed, it clashes with pkg install unless dpkg opts dictate otherwise.

It's possible to dpkg-divert update-initramfs by making it a stub and reinstating it later to generate images, but this is not ideal either.

A simple way to reduce build time and avoid unnecessary initramfs image generation is to set a variable referenced by the kernel pkg postinst scripts which skips creation of the initramfs image altogether. This means that suqsequent calls to update the initramfs image (-u) are nops because there is no image to update. At the end of the build in a customize hook, invoke creation (-c) of all initramfs image(s).

This mechanism ensures the initramfs image for a kernel is only generated once.

The YAML layer for each RPi kernel sets variable INITRD via the env, therefore propagating it to the whole build. A more targeted approach would be to run a script in the layer to pass the variable to a chroot operation invoking apt to install the kernel pkg. This would only work if apt is available in the chroot, which it isn't if using a minimal profile.

Fixes #38

Remove unnecessary listing of initramfs-tools in RPi kernel layers. This was only there to allow fixup of update-initramfs.conf in light of not using dpkg(1) options to retain non-distribution config files.

Additionally, add a v7l layer as it was missing.