### PR TITLE
Add python3-debian to dependencies, update readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ rpi-image-gen is a tool for creating custom software images for Raspberry Pi dev
 git clone https://github.com/raspberrypi/rpi-image-gen.git
 cd rpi-image-gen
 sudo ./install_deps.sh
-./rpi-image-gen build -c ./config/bookworm-minbase.cfg
+./rpi-image-gen build -c ./config/bookworm-minbase.yaml
 ----
 
 The device image will be in `./work/image-deb12-arm64-min/deb12-arm64-min.img`

--- a/depends
+++ b/depends
@@ -20,6 +20,7 @@ dctrl-tools
 uuidgen:uuid-runtime
 fdisk
 python3-yaml
+python3-debian
 # doc gen only
 # python3-markdown
 # asciidoctor


### PR DESCRIPTION
python3-debian was missing from the dependency list. This is needed for the deb822 parsing of layer metadata.
The Quick Start readme section refers to a .cfg file but it has been migrated to .yaml.

Fixes #87