### PR TITLE
layer: rpi-generic64 should declare device-base as a dep

### DIFF
--- a/layer/rpi/device/family-generic64.yaml
+++ b/layer/rpi/device/family-generic64.yaml
@@ -3,8 +3,8 @@
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Generic Raspberry Pi device common with v8 kernel, boot
 #  firmware supporting all devices, and wlan/BT firmware.
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: rpi-boot-firmware,rpi-linux-v8
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-linux-v8
 # METAEND
 ---
 mmdebstrap:


### PR DESCRIPTION
rpi-generic64 is a general purpose layer that supports all 64bit capable devices. It should pull in device-base as a dependency. Doing so means it can be used in isolation by device layers.

Fixes #90