### PR TITLE
Fix AB emmc partition table protection, update docs

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -296,6 +296,45 @@ During configuration processing, variables are expanded using:
 There may be a need to handle non-alphanumeric characters in config files and/or command line arguments. Best practices advise encapsulating the text for a more robust approach, even if it's not always technically necessary. For YAML files, use single quotes for literal strings. For example `password: 'Fo0bar!!'`. For INI files, quote values containing special characters. For example `password = "Fo0bar!!"`. For command line arguments, use single quotes to preserve the literal text. For example `rpi-image-gen build -c <args> -- IGconf_device_user1pass='Fo0bar!!'`.
 ====
 
+=== Conditional Variables
+
+The expansion of variables during configuration processing means it's possible to use conditional expressions to assign variables based on other variables via _parameter expansion_. This provides quite a powerful feature for adapting configuration based characteristics or other settings.
+
+For example:
+
+[source,yaml]
+----
+# METABEGIN
+# X-Env-Layer-Name: image-rescue
+# X-Env-Layer-Requires: image-base,device-base
+# X-Env-Layer-Provides: image
+#
+# X-Env-VarRequires: IGconf_device_storage_type
+#
+# X-Env-VarPrefix: image
+#
+# X-Env-Var-ptable_protect: $( ["${IGconf_device_storage_type}" = "emmc"] && echo y || echo n )
+# X-Env-Var-ptable_protect-Desc: Enable eMMC Power-On Write Protection of the partition table
+# X-Env-Var-ptable_protect-Required: n
+# X-Env-Var-ptable_protect-Valid: string
+# X-Env-Var-ptable_protect-Set: y
+# METAEND
+----
+
+This results in `IGconf_image_ptable_protect=y` if `IGconf_device_storage_type=emmc`, else `IGconf_image_ptable_protect=n`. Because configuration variable validation operates on literal values prior to expansion, this will only pass validation if the variable being assigned is a derivative of type `X-Env-Var-X-Valid: string`.
+
+[WARNING]
+====
+Care must be taken when using parameter expansion if input variables to the expression are optional. Due to the strict expansion rules, variables referenced in conditional expressions are recommended to use the `:-` fallback syntax to avoid errors.
+====
+
+[source,yaml]
+----
+# X-Env-VarOptional: IGconf_device_storage_type
+# X-Env-Var-ptable_protect: $( ["${IGconf_device_storage_type:-}" = "emmc"] && echo y || echo n )
+----
+
+References: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html[GNU Bash Manual,window=_blank]
 
 == Configuration Loading
 

--- a/image/gpt/ab_userdata/device/emmc-wp.sh
+++ b/image/gpt/ab_userdata/device/emmc-wp.sh
@@ -11,7 +11,12 @@ esac
 
 set -e
 
-test "$(rpi-slot | sed 's/:.*//')" -eq 1 || exit 0
+# rpi-slot gives us the boot device details by reporting:
+# boot:<device type>:<partition number>
+# blk:<device node>:<UUID>
+# Only issue the protection op if booting from emmc (device type 1).
+set -- $(rpi-slot 2>/dev/null | sed -n '/^boot:/{s/:/ /g; p; q}')
+[ "$2" = 1 ] || exit 0
 
 DEV=/dev/mmcblk0
 

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -44,7 +44,6 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       align = 8M
       partition-table-type = "gpt"
-      gpt-location = 8M
       fill = true
    }
 

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -4,9 +4,11 @@
 # X-Env-Layer-Desc: Rotational OTA and AB support with GPT.
 #  This layout supports redundancy of os and system slot components and
 #  provides seperate boot and user data partitions.
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: image-base
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Requires: image-base,device-base
 # X-Env-Layer-Provides: image
+#
+# X-Env-VarRequires: IGconf_device_storage_type
 #
 # X-Env-VarPrefix: image
 #
@@ -35,6 +37,15 @@
 # X-Env-Var-pmap-Required: n
 # X-Env-Var-pmap-Valid: clear,crypt
 # X-Env-Var-pmap-Set: y
+#
+# X-Env-Var-ptable_protect: $( [ "${IGconf_device_storage_type:-}" = "emmc" ] && echo y || echo n )
+# X-Env-Var-ptable_protect-Desc: Enable eMMC Power-On Write Protect of the partition
+#  table. If enabled, the first 8MB of the boot storage device will be
+#  protected. Applies to eMMC only.
+# X-Env-Var-ptable_protect-Required: n
+# X-Env-Var-ptable_protect-Valid: string
+# X-Env-Var-ptable_protect-Set: y
+#
 # METAEND
 ---
 mmdebstrap:


### PR DESCRIPTION
This PR protects the entire Primary GPT for AB systems if built for eMMC storage.
It also ensures parity between the partition table created in the image and that created via IDP.
Docs updated to describe how to use parameter expansion to conditionally set variables.