### PR TITLE
layer: Refactor systemd into modular components

### DIFF
--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -849,8 +849,12 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
-            <a href="systemd-net-min.html">systemd-net-min</a><span class="layer-desc">- Minimal systemd suite for init, basic networking and
- time synchronisation.</span>
+            <a href="systemd-min.html">systemd-min</a><span class="layer-desc">- Core systemd components for init, SysV compatibility
+ and timesyncd, without networkd and resolved services.</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="systemd-net-min.html">systemd-net-min</a><span class="layer-desc">- Systemd networking via networkd and resolved services</span>
         </div>
         
     </div>

--- a/docs/layer/systemd-min.html
+++ b/docs/layer/systemd-min.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>systemd-min - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,10 +121,11 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
+        <h1>systemd-min</h1>
         <span class="badge">general</span>
-        <span class="badge">v2.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <span class="badge">v1.0.0</span>
+        <p>Core systemd components for init, SysV compatibility
+ and timesyncd, without networkd and resolved services.</p>
     </div>
 
     
@@ -133,18 +134,11 @@
     <div class="section">
         <h2>Relationships</h2>
         
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        
         
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
+            <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             
         </div>
         
@@ -171,7 +165,11 @@
         <p>Installs:</p>
         <ul>
             
-            <li><code>systemd-resolved</code></li>
+            <li><code>systemd</code></li>
+            
+            <li><code>systemd-sysv</code></li>
+            
+            <li><code>systemd-timesyncd</code></li>
             
         </ul>
         
@@ -186,7 +184,7 @@
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>sys-apps/systemd-min.yaml</code></p>
         
     </div>
 </body>

--- a/layer/sys-apps/systemd-min.yaml
+++ b/layer/sys-apps/systemd-min.yaml
@@ -1,0 +1,16 @@
+# METABEGIN
+# X-Env-Layer-Name: systemd-min
+# X-Env-Layer-Desc: Core systemd components for init, SysV compatibility
+#  and timesyncd, without networkd and resolved services.
+# X-Env-Layer-Version: 1.0.0
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - systemd
+    - systemd-sysv
+    - systemd-timesyncd
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-timesyncd
+    - mkdir -p $1/etc/systemd/system/getty@tty1.service.d
+    - $LAYER_HOOKS/systemd/ttyset noclear > $1/etc/systemd/system/getty@tty1.service.d/noclear.conf

--- a/layer/sys-apps/systemd-net-min.yaml
+++ b/layer/sys-apps/systemd-net-min.yaml
@@ -1,20 +1,17 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-net-min
-# X-Env-Layer-Desc: Minimal systemd suite for init, basic networking and
-#  time synchronisation.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Desc: Systemd networking via networkd and resolved services
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Requires: systemd-min
 # METAEND
 ---
 mmdebstrap:
   packages:
-    - systemd
-    - systemd-sysv
-    - systemd-timesyncd
+    - systemd-resolved
   customize-hooks:
     - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-networkd
-    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-timesyncd
-    - mkdir -p $1/etc/systemd/network $1/etc/systemd/system/getty@tty1.service.d
+    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-resolved
+    - mkdir -p $1/etc/systemd/network
     - ln -sf /dev/null $1/etc/systemd/network/99-default.link
     - ln -sf /dev/null $1/etc/systemd/network/73-usb-net-by-mac.link
     - $LAYER_HOOKS/systemd/netgen eth0 > $1/etc/systemd/network/01-eth0.network
-    - $LAYER_HOOKS/systemd/ttyset noclear > $1/etc/systemd/system/getty@tty1.service.d/noclear.conf


### PR DESCRIPTION
- systemd-min: Core init system without network management services
- systemd-net-min: Adds networkd and resolved for systemd networking

This allows users to choose between systemd native networking or alternative solutions like NetworkManager, while always having time synchronisation provided by systemd-timesyncd.