### PR TITLE
Add new validator type specifically for device storage purposes

### DIFF
--- a/docs/layer/device-base.html
+++ b/docs/layer/device-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>device-base</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.1.0</span>
+        <span class="badge">v1.2.0</span>
         <p>Device defaults.</p>
     </div>
 
@@ -285,7 +285,7 @@
                            
                        
                     </td>
-                    <td>Integer value in range 512 to 512</td>
+                    <td>Storage capacity: bytes (512+) or binary units (K, M, G, T, KiB, MiB, etc.)</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/variable-validation.html
+++ b/docs/layer/variable-validation.html
@@ -109,20 +109,14 @@
     <div class="section">
         <h2 id="set-policies">Set Policies</h2>
         <p>Set policies determine when and how environment variables are applied during the build process:</p>
-
-        
         <h3><span class="policy-badge policy-force">force</span> Force</h3>
         <p>Always overwrite existing environment value, regardless of what was set before.</p>
-        
         <h3><span class="policy-badge policy-immediate">immediate</span> Immediate (Default)</h3>
         <p>Set the variable if it is currently unset (first-wins strategy). This is the default behavior.</p>
-        
         <h3><span class="policy-badge policy-lazy">lazy</span> Lazy</h3>
         <p>Applied after all layers are processed (last-wins strategy). Useful for defaults that can be overridden.</p>
-        
         <h3><span class="policy-badge policy-skip">skip</span> Skip</h3>
         <p>Never set the variable. Useful for optional variables or when you want to disable a variable.</p>
-        
 
         <div class="tip">
             <strong>Policy Aliases:</strong><br>
@@ -133,202 +127,94 @@
 
     <div class="section">
         <h2>Validation Types</h2>
-
-        
         <h3>Basic Types</h3>
-        
         <div class="example">
             <strong>bool                   - Must be: true/false, 1/0, yes/no, y/n (case insensitive)</strong>
         </div>
-        
-        
-
-        
+        <h3>capacity              </h3>
+        <div class="example">
+            <strong>capacity               - Storage capacity in binary units (1024-based)</strong>
+            <br>BINARY CAPACITY UNITS:
+            <br>  capacity must be specified with binary (1024-based) units for storage devices
+            <br>    8K / 8KiB    (8 × 1024 bytes = 8,192 bytes)
+            <br>    128M / 128MiB (128 × 1024² bytes = 134,217,728 bytes)
+            <br>    4G / 4GiB    (4 × 1024³ bytes = 4,294,967,296 bytes)
+            <br>    2T / 2TiB    (2 × 1024⁴ bytes)
+            <br>  Supported units: K, M, G, T (short form)
+            <br>                   KiB, MiB, GiB, TiB (explicit binary)
+            <br>  Rejected units:  KB, MB, GB, TB (decimal 1000-based)
+            <br>PLAIN NUMBERS (no suffix):
+            <br>  Accepted with requirements:
+            <br>    Minimum: 512 (typical sector size in bytes)
+            <br>    Binary alignment: must be 512, 1024, 2048, 4096, etc.
+            <br>  Examples:
+            <br>    512
+            <br>    4MiB
+            <br>    8G
+            <br>  This validator is designed for storage device capacity where binary
+            <br>  units align with filesystem blocks, sectors, and hardware reality.
+        </div>
         <h3>value1,value2,value3 </h3>
         <div class="example">
             <strong>value1,value2,value3  - Must be one of the listed values</strong>
-            
-            
-            
             <br>  (Tip: For a single allowed value, either add a trailing comma
-            
-            
-            
             <br>        e.g. "syft," or use the keywords: prefix as shown below.)
-            
-            
-            
             <br>  Examples:
-            
-            
-            
             <br>    development,staging,production    - Environment names
-            
-            
-            
             <br>    small,medium,large               - Size options
-            
-            
-            
             <br>    debug,info,warn,error            - Log levels
-            
-            
-            
-            
-            
             <br>KEYWORDS:
-            
-            
-            
             <br>  keywords:word1,word2,word3  - Must be one of the listed alphanumeric keywords
-            
-            
-            
             <br>  Keywords can contain: letters (a-z, A-Z), numbers (0-9), underscore (_), hyphen (-)
-            
-            
-            
             <br>  Examples:
-            
-            
-            
             <br>    keywords:frontend,backend,database     - Application components
-            
-            
-            
             <br>    keywords:cpu-intensive,io-bound        - Workload types
-            
-            
-            
             <br>    keywords:dev,test,staging,prod         - Environment shortcuts
-            
-            
-            
         </div>
-        
         <h3>int                   </h3>
         <div class="example">
             <strong>int                    - Must be a valid integer</strong>
-            
-            
-            
             <br>  int:MIN-MAX           - Integer within range (inclusive)
-            
-            
-            
             <br>  Examples:
-            
-            
-            
             <br>    int:1-100           - Integer from 1 to 100
-            
-            
-            
             <br>    int:1024-65535      - Port numbers
-            
-            
-            
             <br>    int:0-255           - Byte values
-            
-            
-            
         </div>
-        
         <h3>regex:PATTERN        </h3>
         <div class="example">
             <strong>regex:PATTERN         - Must match regular expression</strong>
-            
-            
-            
             <br>  Examples:
-            
-            
-            
             <br>    regex:^[a-zA-Z0-9.-]+$     - Hostname format
-            
-            
-            
             <br>    regex:^[0-9]{3}-[0-9]{2}$  - Format like 123-45
-            
-            
-            
             <br>    regex:^(http|https)://     - URLs starting with http/https
-            
-            
-            
         </div>
-        
         <h3>size                  </h3>
         <div class="example">
             <strong>size                   - Size with optional unit (bytes, k/m/g/s) or percentage</strong>
-            
-            
-            
-            
-            
             <br>SIZES:
-            
-            
-            
             <br>  size can be specified in one of the following formats
-            
-            
-            
             <br>    12345        (bytes)
-            
-            
-            
             <br>    20k / 20K    (kilobytes, multiples of 1024)
-            
-            
-            
             <br>    128M / 128m  (megabytes)
-            
-            
-            
             <br>    1G / 4g      (gigabytes)
-            
-            
-            
             <br>    512s         (sectors, multiples of 512)
-            
-            
-            
             <br>    50%          (percentage; any positive integer)
-            
-            
-            
         </div>
-        
         <h3>string                </h3>
         <div class="example">
             <strong>string                 - Must be a non-empty string (required)</strong>
-            
-            
-            
             <br>  string-or-unset        - Must be non-empty string or unset (null)
-            
-            
-            
             <br>  string-or-empty        - Must be any string (may be empty) but not unset
-            
-            
-            
         </div>
-        
     </div>
 
     <div class="section">
         <h2>Placeholders</h2>
         <p>Auto-substituted in variable values:</p>
         <div class="example">
-            
             <strong><code>${FILENAME}</code></strong> - layer metadata file name<br>
-            
             <strong><code>${DIRECTORY}</code></strong> - directory containing the file<br>
-            
             <strong><code>${FILEPATH}</code></strong> - absolute path to the file<br>
-            
             <em>Escape with <code>\${NAME}</code> to keep the literal text.</em>
         </div>
     </div>

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Device defaults.
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 1.2.0
 # X-Env-Layer-Requires:
 # X-Env-Layer-RequiresProvider: device
 #
@@ -58,7 +58,7 @@
 #  the image is intended. The output raw image file size will be a multiple of
 #  this value.
 # X-Env-Var-sector_size-Required: n
-# X-Env-Var-sector_size-Valid: int:512-512
+# X-Env-Var-sector_size-Valid: capacity
 # X-Env-Var-sector_size-Set: y
 #
 # X-Env-Var-assetdir: /dev/null

--- a/templates/docs/html/variable-validation.html
+++ b/templates/docs/html/variable-validation.html
@@ -110,10 +110,10 @@
         <h2 id="set-policies">Set Policies</h2>
         <p>Set policies determine when and how environment variables are applied during the build process:</p>
 
-        {% for policy in validation.set_policies %}
-        <h3><span class="policy-badge policy-{{ policy.class }}">{{ policy.name }}</span> {{ policy.name.title() }}{% if policy.name == 'immediate' %} (Default){% endif %}</h3>
+        {%- for policy in validation.set_policies %}
+        <h3><span class="policy-badge policy-{{ policy.class }}">{{ policy.name }}</span> {{ policy.name.title() }}{% if policy.name == 'immediate' %} (Default){%- endif %}</h3>
         <p>{{ policy.description }}</p>
-        {% endfor %}
+        {%- endfor %}
 
         <div class="tip">
             <strong>Policy Aliases:</strong><br>
@@ -125,37 +125,37 @@
     <div class="section">
         <h2>Validation Types</h2>
 
-        {% if validation.basic_types %}
+        {%- if validation.basic_types %}
         <h3>Basic Types</h3>
-        {% for type in validation.basic_types %}
+        {%- for type in validation.basic_types %}
         <div class="example">
             <strong>{{ type.description }}</strong>
         </div>
-        {% endfor %}
-        {% endif %}
+        {%- endfor %}
+        {%- endif %}
 
-        {% for type in validation.advanced_types %}
+        {%- for type in validation.advanced_types %}
         <h3>{{ type.title.split(' - ')[0] if ' - ' in type.title else type.name.title() + ' Types' }}</h3>
         <div class="example">
             <strong>{{ type.title }}</strong>
-            {% if type.details %}
-            {% for detail in type.details %}
-            {% if detail.strip() %}
+            {%- if type.details %}
+            {%- for detail in type.details %}
+            {%- if detail.strip() %}
             <br>{{ detail }}
-            {% endif %}
-            {% endfor %}
-            {% endif %}
+            {%- endif %}
+            {%- endfor %}
+            {%- endif %}
         </div>
-        {% endfor %}
+        {%- endfor %}
     </div>
 
     <div class="section">
         <h2>Placeholders</h2>
         <p>Auto-substituted in variable values:</p>
         <div class="example">
-            {% for placeholder in validation.placeholders %}
+            {%- for placeholder in validation.placeholders %}
             <strong><code>{{ placeholder.name }}</code></strong> - {{ placeholder.description }}<br>
-            {% endfor %}
+            {%- endfor %}
             <em>Escape with <code>\${NAME}</code> to keep the literal text.</em>
         </div>
     </div>

--- a/test/layer/valid-all-types.yaml
+++ b/test/layer/valid-all-types.yaml
@@ -27,6 +27,18 @@
 # X-Env-VarRequires-Valid: regex:^/.*,string
 # X-Env-VarOptional: EDITOR,LANG
 # X-Env-VarOptional-Valid: string,string
+# X-Env-Var-headroom: 200%
+# X-Env-Var-headroom-Desc: Size with percentage support
+# X-Env-Var-headroom-Valid: size
+# X-Env-Var-storageA: 8GiB
+# X-Env-Var-storageA-Desc: Storage device capacity (binary prefix)
+# X-Env-Var-storageA-Valid: capacity
+# X-Env-Var-storageB: 1T
+# X-Env-Var-storageB-Desc: Storage device capacity
+# X-Env-Var-storageB-Valid: capacity
+# X-Env-Var-storageC: 512
+# X-Env-Var-storageC-Desc: Storage device capacity (digit)
+# X-Env-Var-storageC-Valid: capacity
 # METAEND
 
 application:

--- a/test/layer/validation-failures.yaml
+++ b/test/layer/validation-failures.yaml
@@ -16,6 +16,15 @@
 # X-Env-Var-required-Required: true
 # X-Env-VarRequires: NONEXISTENT_VAR
 # X-Env-VarRequires-Valid: string
+# X-Env-Var-storageA: 8GB
+# X-Env-Var-storageA-Desc: Invalid capacity (1000 based)
+# X-Env-Var-storageA-Valid: capacity
+# X-Env-Var-storageB: 100%
+# X-Env-Var-storageB-Desc: Invalid capacity (size type)
+# X-Env-Var-storageB-Valid: capacity
+# X-Env-Var-storageC: 511
+# X-Env-Var-storageC-Desc: Invalid capacity (below min without prefix)
+# X-Env-Var-storageC-Valid: capacity
 # METAEND
 
 test:


### PR DESCRIPTION
The new `capacity` type is specifically for use when describing device storage, whether it be plain numbers (eg sector size) or 1024-based capacity with units (eg 8G). Syntax adheres to that used by coreutils to describe 1024-based units, eg K, MiB, G etc. 1000-based units like GB are rejected. 
Device base layer updated to use the new type for variable `IGconf_device_sector_size`. No change to default value (512).
Documentation and test harness updated.