### PR TITLE
core: Support build without /sbin in $PATH

### DIFF
--- a/bin/image2json
+++ b/bin/image2json
@@ -322,7 +322,7 @@ def parse_genimage_config(config_path):
     img_path = get_artefact_path(img_name, "IGconf_image_outputdir")
     try:
         res = subprocess.run(
-                ["sfdisk", "--verify", "--json", img_path],
+                ["/usr/sbin/sfdisk", "--verify", "--json", img_path],
                 capture_output=True,
                 text=True,
                 check=True

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -456,7 +456,7 @@ generate_images() {
       for cfg in "${IGconf_image_outputdir}"/genimage*.cfg; do
          [[ -f $cfg ]] || continue
          runenv "${ctx[FINALENV]}" \
-            podman unshare env genimage \
+            podman unshare env PATH=/sbin:$PATH genimage \
             --rootpath   "$IGconf_target_path" \
             --tmppath    "${ctx[TMPDIR]}/genimage" \
             --inputpath  "$IGconf_image_outputdir" \


### PR DESCRIPTION
On Debian /sbin is not in $PATH by default. Add it so the tools are
found.

genimage calls sbin/mkdosfs and other tools in sbin.