### PR TITLE
pmap fixups

### DIFF
--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -235,7 +235,7 @@
                     </td>
                     <td>Must be one of: clear, crypt</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-force" title="Click for policy and validation help">force</a>
                     </td>
                 </tr>
                 

--- a/docs/layer/image-rpios.html
+++ b/docs/layer/image-rpios.html
@@ -243,7 +243,7 @@
                     </td>
                     <td>Must be one of: clear, crypt</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-force" title="Click for policy and validation help">force</a>
                     </td>
                 </tr>
                 

--- a/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
+++ b/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
@@ -7,8 +7,8 @@ install -m 0644 -D ../device/slot.rules $1/etc/udev/rules.d/90-rpi-slot.rules
 
 
 # Install provision map
-if igconf isset image_pmap ; then
-   cp ../device/provisionmap-${IGconf_image_pmap}.json ${IGconf_image_outputdir}/provisionmap.json
+if [ -f "$IGconf_image_pmapfile" ] ; then
+   cp ${IGconf_image_pmapfile} ${IGconf_image_outputdir}/provisionmap.json
 else
    die "No pmap. Unable to generate slot mapping."
 fi

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -36,7 +36,7 @@
 #  System partitions will be provisioned encrypted (crypt).
 # X-Env-Var-pmap-Required: n
 # X-Env-Var-pmap-Valid: clear,crypt
-# X-Env-Var-pmap-Set: y
+# X-Env-Var-pmap-Set: force
 #
 # X-Env-Var-ptable_protect: $( [ "${IGconf_device_storage_type:-}" = "emmc" ] && echo y || echo n )
 # X-Env-Var-ptable_protect-Desc: Enable eMMC Power-On Write Protect of the partition

--- a/image/mbr/simple_dual/image.yaml
+++ b/image/mbr/simple_dual/image.yaml
@@ -39,6 +39,6 @@
 #  Root partition will be provisioned encrypted (crypt).
 # X-Env-Var-pmap-Required: n
 # X-Env-Var-pmap-Valid: clear,crypt
-# X-Env-Var-pmap-Set: y
+# X-Env-Var-pmap-Set: force
 # METAEND
 ---

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -38,8 +38,8 @@ cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
 
 
 # Install provision map and set UUIDs
-if igconf isset image_pmap ; then
-   cp ./device/provisionmap-${IGconf_image_pmap}.json ${IGconf_image_outputdir}/provisionmap.json
+if [ -f "$IGconf_image_pmapfile" ] ; then
+   cp ${IGconf_image_pmapfile} ${IGconf_image_outputdir}/provisionmap.json
    sed -i \
       -e "s|<CRYPT_UUID>|$CRYPT_UUID|g" ${IGconf_image_outputdir}/provisionmap.json
 fi

--- a/image/post-image.sh
+++ b/image/post-image.sh
@@ -13,7 +13,8 @@ if [ -f ${1}/genimage.cfg ] ; then
       fi
    done
 
-   [[ -n "${IGconf_image_pmapfile:-}" ]] && opts+=('-m' "${IGconf_image_pmapfile}")
+   pmap="${IGconf_image_outputdir}/provisionmap.json"
+   [[ -f "$pmap" ]] && opts+=('-m' "$pmap")
 
    # Generate description for IDP
    image2json -g ${1}/genimage.cfg "${opts[@]}" > ${1}/image.json


### PR DESCRIPTION
Fixes filesystem UUIDS missing from the PMAP file, and enforces a clear PMAP to be used until provisioning of encrypted images is functional end-to-end.