### PR TITLE
Improve 4Kn support

### DIFF
--- a/docs/layer/device-base.html
+++ b/docs/layer/device-base.html
@@ -286,7 +286,7 @@
                            
                        
                     </td>
-                    <td>Must be one of: 512, 4096</td>
+                    <td>Integer value in range 512 to 512</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/device-base.html
+++ b/docs/layer/device-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>device-base</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.2.0</span>
+        <span class="badge">v1.3.0</span>
         <p>Device defaults.</p>
     </div>
 
@@ -275,9 +275,10 @@
                 
                 <tr>
                     <td><code>IGconf_device_sector_size</code></td>
-                    <td>Logical sector size of the device storage for which
- the image is intended. The output raw image file size will be a multiple of
- this value.</td>
+                    <td>Logical sector size (in bytes) of the target storage
+ device. Used to guide image layout decisions (e.g. alignment, padding, and
+ sector-based structure placement) so the image matches the intended media.
+ Common values: 512 (for 512n/512e) or 4096 (for 4Kn).</td>
                     <td>
                        
                            
@@ -285,7 +286,7 @@
                            
                        
                     </td>
-                    <td>Storage capacity: bytes (512+) or binary units (K, M, G, T, KiB, MiB, etc.)</td>
+                    <td>Must be one of: 512, 4096</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -97,9 +97,9 @@ image boot.vfat {
 image system.ext4 {
    ext4 {
       use-mke2fs = true
-      mke2fs-conf = <MKE2FSCONF>
+      mke2fs-conf = <MKE2FS_CONF>
       label = "SYSTEM"
-      extraargs = "-U <SYSTEM_UUID>"
+      extraargs = "<MKE2FS_SYSTEM>"
    }
    size = <SYSTEM_SIZE>
    mountpoint = "/"
@@ -111,6 +111,7 @@ image data.ext4 {
    ext4 {
       use-mke2fs = true
       label = "USERDATA"
+      extraargs = "<MKE2FS_DATA>"
    }
    size = <DATA_SIZE>
    mountpoint = "/data"

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -12,6 +12,24 @@ genimg_in=$2
 . ${genimg_in}/img_uuids
 
 
+# mke2fs cmdline args
+MKE2FS_ARGS=()
+case "$IGconf_device_sector_size" in
+   4096)
+      MKE2FS_ARGS+=("-b" "-4096")
+      ;;
+esac
+
+MKE2FS_SYSTEM=("-U" "$SYSTEM_UUID")
+MKE2FS_DATA=()
+
+MKE2FS_SYSTEM+=("${MKE2FS_ARGS[@]}")
+MKE2FS_DATA+=("${MKE2FS_ARGS[@]}")
+
+MKE2FS_ARGS_SYSTEM="${MKE2FS_SYSTEM[*]}"
+MKE2FS_ARGS_DATA="${MKE2FS_DATA[*]}"
+
+
 # Set up the partition layout for tryboot support. Partition numbering
 # relates directly to the layout in genimage.cfg.in
 
@@ -34,7 +52,9 @@ cat genimage.cfg.in | sed \
    -e "s|<DATA_SIZE>|$IGconf_image_data_part_size|g" \
    -e "s|<SECTOR_SIZE>|$IGconf_device_sector_size|g" \
    -e "s|<SLOTP>|'$(readlink -ef slot-post-process.sh)'|g" \
-   -e "s|<MKE2FSCONF>|'$(readlink -ef mke2fs.conf)'|g" \
    -e "s|<BOOT_LABEL>|$BOOT_LABEL|g" \
    -e "s|<SYSTEM_UUID>|$SYSTEM_UUID|g" \
+   -e "s|<MKE2FS_CONF>|'$(readlink -ef mke2fs.conf)'|g" \
+   -e "s|<MKE2FS_SYSTEM>|$MKE2FS_ARGS_SYSTEM|g" \
+   -e "s|<MKE2FS_DATA>|$MKE2FS_ARGS_DATA|g" \
    > ${genimg_in}/genimage.cfg

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -51,8 +51,8 @@ image root.ext4 {
    ext4 {
       label = "ROOT"
       use-mke2fs = true
-      mke2fs-conf = <MKE2FSCONF>
-      extraargs = "-U <ROOT_UUID>"
+      mke2fs-conf = <MKE2FS_CONF>
+      extraargs = "<MKE2FS_EXTRAARGS>"
    }
    size = <ROOT_SIZE>
    mountpoint = "/"

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -20,6 +20,11 @@ for v in BOOT_LABEL BOOT_UUID ROOT_UUID CRYPT_UUID; do
     echo "$v=$val" >> "${IGconf_image_outputdir}/img_uuids"
 done
 
+MKE2FS_ARGS=("-U" "$ROOT_UUID")
+case $IGconf_device_sector_size in
+   4096) MKE2FS_ARGS+=("-b" "-4096") ;;
+esac
+MKE2FS_ARGS_STR="${MKE2FS_ARGS[*]}"
 
 # Write genimage template
 cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
@@ -30,7 +35,8 @@ cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
    -e "s|<ROOT_SIZE>|$IGconf_image_root_part_size|g" \
    -e "s|<SECTOR_SIZE>|$IGconf_device_sector_size|g" \
    -e "s|<SETUP>|'$(readlink -ef setup.sh)'|g" \
-   -e "s|<MKE2FSCONF>|'$(readlink -ef mke2fs.conf)'|g" \
+   -e "s|<MKE2FS_CONF>|'$(readlink -ef mke2fs.conf)'|g" \
+   -e "s|<MKE2FS_EXTRAARGS>|$MKE2FS_ARGS_STR|g" \
    -e "s|<BOOT_LABEL>|$BOOT_LABEL|g" \
    -e "s|<BOOT_UUID>|$BOOT_UUID|g" \
    -e "s|<ROOT_UUID>|$ROOT_UUID|g" \

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -59,7 +59,7 @@
 #  sector-based structure placement) so the image matches the intended media.
 #  Common values: 512 (for 512n/512e) or 4096 (for 4Kn).
 # X-Env-Var-sector_size-Required: n
-# X-Env-Var-sector_size-Valid: 512,4096
+# X-Env-Var-sector_size-Valid: int:512-512
 # X-Env-Var-sector_size-Set: y
 #
 # X-Env-Var-assetdir: /dev/null

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Device defaults.
-# X-Env-Layer-Version: 1.2.0
+# X-Env-Layer-Version: 1.3.0
 # X-Env-Layer-Requires:
 # X-Env-Layer-RequiresProvider: device
 #
@@ -54,11 +54,12 @@
 # X-Env-Var-storage_type-Set: lazy
 #
 # X-Env-Var-sector_size: 512
-# X-Env-Var-sector_size-Desc: Logical sector size of the device storage for which
-#  the image is intended. The output raw image file size will be a multiple of
-#  this value.
+# X-Env-Var-sector_size-Desc: Logical sector size (in bytes) of the target storage
+#  device. Used to guide image layout decisions (e.g. alignment, padding, and
+#  sector-based structure placement) so the image matches the intended media.
+#  Common values: 512 (for 512n/512e) or 4096 (for 4Kn).
 # X-Env-Var-sector_size-Required: n
-# X-Env-Var-sector_size-Valid: capacity
+# X-Env-Var-sector_size-Valid: 512,4096
 # X-Env-Var-sector_size-Set: y
 #
 # X-Env-Var-assetdir: /dev/null


### PR DESCRIPTION
Improves handling of the config variable that defines the target device storage sector size (basically now enforces 512 or 4096)
Encourages mkfs.ext4 to use a minimum block size of 4K if that variable indicates a 4Kn device.