### PR TITLE
AB: enforce boot‑disk–backed device eligibility

### DIFF
--- a/docs/layer/rpi-ab-slot-mapper.html
+++ b/docs/layer/rpi-ab-slot-mapper.html
@@ -161,6 +161,14 @@
 </div>
 </div>
 <div class="sect1">
+<h2 id="_supported_block_devices">Supported Block Devices</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Only eligible block devices are considered for slot assignment. An eligible block device is one which is 'boot‑disk–backed'. A device is considered boot‑disk–backed if its block‑device lineage (sysfs slaves chain) ultimately resolves to the boot disk’s kernel device (<code>$BOOT_DEV</code>, e.g., <code>mmcblk0</code> or <code>nvme0n1</code>). For non‑DM devices, this means the device is a partition of the boot disk. For DM devices, this means the device has the boot disk as an ancestor.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_why_two_schemes">Why two schemes?</h2>
 <div class="sectionbody">
 <div class="paragraph">

--- a/layer/rpi/device/ab-slots.adoc
+++ b/layer/rpi/device/ab-slots.adoc
@@ -14,6 +14,10 @@ This layer is intended to be reusable across different A/B image layouts. It mak
 
 Devices booting from SD, eMMC and NVMe are supported.
 
+== Supported Block Devices
+
+Only eligible block devices are considered for slot assignment. An eligible block device is one which is 'boot‑disk–backed'. A device is considered boot‑disk–backed if its block‑device lineage (sysfs slaves chain) ultimately resolves to the boot disk’s kernel device (`$BOOT_DEV`, e.g., `mmcblk0` or `nvme0n1`). For non‑DM devices, this means the device is a partition of the boot disk. For DM devices, this means the device has the boot disk as an ancestor.
+
 == Why two schemes?
 
 Hardware and images vary:

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-label
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-label
@@ -22,12 +22,14 @@ udev_fmt=0
 
 ID_PART_ENTRY_NAME=${ID_PART_ENTRY_NAME-}
 DEVNAME=${DEVNAME-}
+DM_NAME=${DM_NAME-}
 
 
-while getopts "d:l:u" opt; do
+while getopts "d:l:m:u" opt; do
    case $opt in
       d) DEVNAME="$OPTARG";;
       l) ID_PART_ENTRY_NAME="$OPTARG";;
+      m) DM_NAME="$OPTARG";;
       u) udev_fmt=1;;
       *) ;;
    esac
@@ -66,7 +68,7 @@ suffix=""; alt_suffix=""
 case "$BOOT_LABEL" in
    boot*_a|boot-a|boota|boota*) suffix="${BOOT_LABEL#boot}"; alt_suffix="${suffix%a}b" ;;
    boot*_b|boot-b|bootb|bootb*) suffix="${BOOT_LABEL#boot}"; alt_suffix="${suffix%b}a" ;;
-   *) die "bad boot label $BOOT_LABEL";;
+   *) die "bad boot device label '$BOOT_LABEL'";;
 esac
 
 ACTIVE_BOOT="boot${suffix}"
@@ -75,7 +77,49 @@ ALT_BOOT="boot${alt_suffix}"
 ALT_SYS="system${alt_suffix}"
 
 
-# Process incoming
+# Slow-path (supports DM devices)
+# Walk sysfs to check if a device is on the boot device.
+on_bootdev() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   # Try fast path
+   is_boot_kname "$dev" "$boot" && return 0
+
+   d="/sys/class/block/$dev/slaves"
+   [ -d "$d" ] || return 1
+
+   for s in "$d"/*; do
+      [ -e "$s" ] || continue
+      sname=${s##*/}
+      on_bootdev "$sname" "$boot" && return 0
+   done
+
+   return 1
+}
+
+
+# Fast-path (non-DM)
+# Check if a kernel name is a boot device partition.
+is_boot_kname() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   case "$dev" in
+      "$boot"p[0-9]*) return 0 ;;
+   esac
+   return 1
+}
+
+
+# To be considered for a slot, the incoming device must be on the boot device.
+if [ -n "$DM_NAME" ]; then
+   on_bootdev "$DEVNAME" "$BOOT_DEV" || exit 1
+else
+   is_boot_kname "$DEVNAME" "$BOOT_DEV" || exit 1
+fi
+
+
 case "$ID_PART_ENTRY_NAME" in
    "$ACTIVE_BOOT")       slot="active/boot" ;;
    "$ACTIVE_SYS")     slot="active/system" ;;

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-static
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-static
@@ -153,13 +153,52 @@ read_static_map() {
 read_static_map || die "Unable to load configuration from slot map"
 
 
-# Process incoming. If DM name is provided construct mapper alias, else use dev
+# Slow-path (supports DM devices)
+# Walk sysfs to check if a device is on the boot device.
+on_bootdev() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   # Try fast path
+   is_boot_kname "$dev" "$boot" && return 0
+
+   d="/sys/class/block/$dev/slaves"
+   [ -d "$d" ] || return 1
+
+   for s in "$d"/*; do
+      [ -e "$s" ] || continue
+      sname=${s##*/}
+      on_bootdev "$sname" "$boot" && return 0
+   done
+
+   return 1
+}
+
+
+# Fast-path (non-DM)
+# Check if a kernel name is a boot device partition.
+is_boot_kname() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   case "$dev" in
+      "$boot"p[0-9]*) return 0 ;;
+   esac
+   return 1
+}
+
+
+# To be considered for a slot, the incoming device must be on the boot device.
+# If a DM name is provided, construct mapper alias, else use raw device.
 alias=""
 if [ -n "$DM_NAME" ]; then
+   on_bootdev "$DEVNAME" "$BOOT_DEV" || exit 1
    alias="/dev/mapper/${DM_NAME}"
 else
+   is_boot_kname "$DEVNAME" "$BOOT_DEV" || exit 1
    alias="$DEVNAME"
 fi
+
 
 slot=""
 case "$alias" in

--- a/layer/rpi/device/slot-mapper/udev/rules.d/slot.rules
+++ b/layer/rpi/device/slot-mapper/udev/rules.d/slot.rules
@@ -1,4 +1,4 @@
-# Boot devices with GPT label
+# Boot devices with GPT label (non-DM)
 SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
@@ -8,11 +8,12 @@ SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION==
   SYMLINK+="$env{SLOT}"
 
 # DM with GPT label
-SUBSYSTEM=="block", KERNEL=="dm-*", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
-  IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME}", \
+SUBSYSTEM=="block", KERNEL=="dm-*", ENV{ID_PART_ENTRY_NAME}=="?*", ENV{DM_NAME}=="?*", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME} -m $env{DM_NAME}", \
   SYMLINK+="$env{SLOT}"
 
-# Boot devices without GPT label
+
+# Boot devices without GPT label (non-DM)
 SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-static -u -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"


### PR DESCRIPTION
Restrict slot candidates to devices backed by the boot disk. This excludes devices on other disks, even if labelled for slots.

Only block devices whose lineage resolves to the boot disk are considered for slot assignment:
- Non‑DM: must be a partition on the boot disk.
- DM: sysfs slaves chain must resolve to a partition on the boot disk.

Devices on other disks are ignored even if they have slot‑compatible GPT labels. Docs updated.