### PR TITLE
AB: immutable root with per-slot /var, shared identity, logs, and home

### DIFF
--- a/bin/systemd-major
+++ b/bin/systemd-major
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") <chroot-path>" >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+root="$1"
+[ -d "$root" ] || { echo "error: chroot path not found: $root" >&2; exit 2; }
+
+# Try to run systemd --version inside the chroot and extract the major number.
+# Requires privileges to chroot into <root>.
+ver="$(
+  chroot "$root" /bin/sh -eu -c '
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    for b in /usr/lib/systemd/systemd /lib/systemd/systemd systemd; do
+      if [ "$b" = systemd ]; then
+        command -v systemd >/dev/null 2>&1 || continue
+        cmd=systemd
+      else
+        [ -x "$b" ] || continue
+        cmd="$b"
+      fi
+      "$cmd" --version 2>/dev/null | sed -n "s/^systemd \([0-9][0-9]*\).*/\1/p" | head -n1
+      exit 0
+    done
+    exit 127
+  ' 2>/dev/null || true
+)"
+
+[ -n "${ver:-}" ] || { echo "error: could not determine systemd version in $root" >&2; exit 1; }
+printf '%s\n' "$ver"

--- a/config/bookworm-minbase-ab.yaml
+++ b/config/bookworm-minbase-ab.yaml
@@ -3,8 +3,9 @@ device:
 
 image:
   layer: image-rota
-  boot_part_size: 200%
-  system_part_size: 300%
+  boot_part_size: 128M
+  system_part_size: 512M
+  data_part_size: 1G
   name: deb12-arm64-min-ab
 
 layer:

--- a/config/trixie-minbase-ab.yaml
+++ b/config/trixie-minbase-ab.yaml
@@ -3,8 +3,9 @@ device:
 
 image:
   layer: image-rota
-  boot_part_size: 200%
-  system_part_size: 300%
+  boot_part_size: 128M
+  system_part_size: 512M
+  data_part_size: 1G
   name: deb13-arm64-min-ab
 
 layer:

--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -123,10 +123,9 @@
     <div class="header">
         <h1>image-rota</h1>
         <span class="badge">image</span>
-        <span class="badge">v3.1.0</span>
-        <p>Rotational OTA and AB support with GPT.
- This layout supports redundancy of boot and system slot components and
- provides a seperate user data partition.</p>
+        <span class="badge">v4.0.0</span>
+        <p>Immutable GPT A/B layout for rotational OTA updates,
+ boot/system redundancy, and a shared persistent data partition.</p>
     </div>
 
     
@@ -134,6 +133,165 @@
         <h2>Additional Documentation</h2>
         <div class="companion-content">
             <div class="sect1">
+<h2 id="_immutable_root_and_mount_points">Immutable root and mount points</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This system uses an A/B, read‑only root with all writable state on a single persistent partition.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-even stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 33.3333%;">
+<col style="width: 11.1111%;">
+<col style="width: 44.4445%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Mount point</th>
+<th class="tableblock halign-left valign-top">Backing</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/dev/disk/by-slot/active/system</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ext4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Read‑only system root (active slot A or B)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/boot/firmware</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/dev/disk/by-slot/active/boot</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">vfat</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boot files (active slot A or B)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/bootfs</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOTFS</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">vfat</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boot metadata</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PERSISTENT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ext4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Shared persistent storage</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/var</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/slots/&lt;slot&gt;/var</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Per‑slot runtime state (systemd, caches, etc.)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/home</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/home</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">User data shared across slots</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/var/log/journal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/log/journal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Single log directory used by both slots</p></td>
+</tr>
+</tbody>
+</table>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>Rationale (immutable root + A/B)</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>Supports delta/incremental OTA updates by treating root as a static image.</p>
+</li>
+<li>
+<p>Reliable rollbacks: slot can be flipped if a new root fails health checks.</p>
+</li>
+<li>
+<p>Reduced write amplification and storage wear, clearer separation of state.</p>
+</li>
+<li>
+<p>Predictable per‑slot state in <code>/var</code>.</p>
+</li>
+<li>
+<p>Shared <code>/home</code> for slot agnostic user storage.</p>
+</li>
+<li>
+<p>Shared journalling: centralised point for device logging.</p>
+</li>
+<li>
+<p>Preserves SBOM accuracy: executing software matches the manifest exactly.</p>
+</li>
+<li>
+<p>Blocks on-device package installs, preventing SBOM drift.</p>
+</li>
+<li>
+<p>Enables auditable, reproducible releases and stronger supply-chain assurances.</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><strong>Logging</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>A single persistent journal directory at <code>/persistent/log/journal</code> stores logs from either slot.</p>
+</li>
+<li>
+<p>Journaling is configured for endurance and reliability.</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><strong>Machine Identity (systemd)</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p><code>/etc/machine-id</code> is synchronised early with <code>/persistent/common/etc/machine-id</code> using a oneshot unit.</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Warning</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Slot partition GPT labels are mandatory to associate the immutable root with its matching persistent storage.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Root slots must have stable PARTLABELs: e.g. <code>system_a</code> and <code>system_b</code>.</p>
+</li>
+<li>
+<p>At boot, a generator reads the root slot’s <code>PARTLABEL</code> to select <code>/persistent/slots/&lt;slot&gt;/var</code>.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>If slot GPT labels are missing/duplicated, <code>/var</code> binding will fail.</p>
+</div>
+<div class="paragraph">
+<p>If slot GPT labels can’t be guaranteed, this layout is not suitable for your device.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_slot_selection_run_time">Slot Selection (run-time)</h2>
 <div class="sectionbody">
 <div class="paragraph">
@@ -227,6 +385,7 @@
             <a href="image-base.html" class="dep-badge">image-base</a>
             <a href="device-base.html" class="dep-badge">device-base</a>
             <a href="rpi-ab-slot-mapper.html" class="dep-badge">rpi-ab-slot-mapper</a>
+            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
         </div>
         
         
@@ -263,11 +422,11 @@
                 
                 <tr>
                     <td><code>IGconf_image_boot_part_size</code></td>
-                    <td>Boot partition size per slot.</td>
+                    <td>Boot partition size per-slot.</td>
                     <td>
                        
                            
-                           <code>100%</code>
+                           <code>96M</code>
                            
                        
                     </td>
@@ -279,11 +438,11 @@
                 
                 <tr>
                     <td><code>IGconf_image_system_part_size</code></td>
-                    <td>System partition size per slot.</td>
+                    <td>System partition size per-slot.</td>
                     <td>
                        
                            
-                           <code>100%</code>
+                           <code>512M</code>
                            
                        
                     </td>
@@ -295,11 +454,12 @@
                 
                 <tr>
                     <td><code>IGconf_image_data_part_size</code></td>
-                    <td>Data partition retained across rotations.</td>
+                    <td>Writable storage partition retained across
+ slot rotations.</td>
                     <td>
                        
                            
-                           <code>256M</code>
+                           <code>1G</code>
                            
                        
                     </td>
@@ -329,7 +489,8 @@
                     <td><code>IGconf_image_pmap</code></td>
                     <td>Provisioning Map type for this image layout.
  All partitions will be provisioned unencrypted (clear).
- System partitions will be provisioned encrypted (crypt).</td>
+ System partitions will be provisioned encrypted (crypt).
+ System B will be provisioned encrypted (hybrid). Development only.</td>
                     <td>
                        
                            

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -844,6 +844,10 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
+            <a href="rpi-splash-screen.html">rpi-splash-screen</a><span class="layer-desc">- Raspberry Pi fullscreen splash screen support with custom image configuration.</span>
+        </div>
+        
+        <div class="layer-item">
             <a href="rpi-user-credentials.html">rpi-user-credentials</a><span class="layer-desc">- Raspberry Pi base layer for local user admin.
  Creates a local account for user IGconf_device_user1, a home directory...</span>
         </div>
@@ -867,9 +871,8 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
-            <a href="image-rota.html">image-rota</a><span class="layer-desc">- Rotational OTA and AB support with GPT.
- This layout supports redundancy of boot and system slot components and
- prov...</span>
+            <a href="image-rota.html">image-rota</a><span class="layer-desc">- Immutable GPT A/B layout for rotational OTA updates,
+ boot/system redundancy, and a shared persistent data partition.</span>
         </div>
         
         <div class="layer-item">

--- a/docs/layer/systemd-min.html
+++ b/docs/layer/systemd-min.html
@@ -138,6 +138,8 @@
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
+            <a href="image-rota.html" class="dep-badge">image-rota</a>
+            
             <a href="rpi-connect.html" class="dep-badge">rpi-connect</a>
             
             <a href="rpi-connect-lite.html" class="dep-badge">rpi-connect-lite</a>

--- a/image/gpt/ab_userdata/device/provisionmap-clear.json
+++ b/image/gpt/ab_userdata/device/provisionmap-clear.json
@@ -75,7 +75,7 @@
    {
       "partitions": [
          {
-            "image": "data"
+            "image": "persistent"
          }
       ]
    }

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -76,14 +76,12 @@
                   }
                ]
             }
-         }
+         },
+         "partitions": [
+            {
+               "image": "persistent"
+            }
+         ]
       }
-   },
-   {
-      "partitions": [
-         {
-            "image": "data"
-         }
-      ]
    }
 ]

--- a/image/gpt/ab_userdata/device/provisionmap-hybrid.json
+++ b/image/gpt/ab_userdata/device/provisionmap-hybrid.json
@@ -86,7 +86,7 @@
    {
       "partitions": [
          {
-            "image": "data"
+            "image": "persistent"
          }
       ]
    }

--- a/image/gpt/ab_userdata/device/rootfs-overlay/etc/systemd/system/machine-id-sync.service
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/etc/systemd/system/machine-id-sync.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sync machine-id to/from persistent storage
+DefaultDependencies=no
+Requires=persistent.mount
+After=persistent.mount
+Before=systemd-journald.service sysinit.target
+ConditionPathExists=/persistent/common/etc
+RequiresMountsFor=/persistent/common/etc/machine-id
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -eu -c 'P=/persistent/common/etc/machine-id; R=/run/machine-id; if [ -s "$P" ]; then cat "$P" > "$R"; else /usr/bin/install -m0644 "$R" "$P"; fi'
+
+[Install]
+WantedBy=sysinit.target

--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
@@ -1,0 +1,69 @@
+#!/bin/sh
+# systemd generator to bind per-slot /var based on GPT PARTLABEL
+
+set -eu
+
+OUT_DIR="/run/systemd/generator"
+PERSIST_LABEL="${PERSIST_LABEL:-PERSISTENT}"     # label of the shared persistent partition
+
+mkdir -p "$OUT_DIR"
+
+
+# 1) Determine current slot
+SLOT=""
+ROOT_DEV="$(findmnt -no SOURCE / || true)"
+if [ -n "$ROOT_DEV" ]; then
+  PARTLABEL="$(blkid -s PARTLABEL -o value -- "$ROOT_DEV" 2>/dev/null || true)"
+  case "$(printf '%s' "$PARTLABEL" | tr '[:upper:]' '[:lower:]')" in
+    system_a) SLOT="system_a" ;;
+    system_b) SLOT="system_b" ;;
+  esac
+fi
+
+# Optional fallback if label is missing/unexpected
+: "${SLOT:=${SLOT_FALLBACK:-system_a}}"
+
+VAR_SRC="/persistent/slots/${SLOT}/var"
+
+
+# 2) Emit persistent.mount (mount the shared persistent partition by label)
+#
+# Mount with:
+# noatime: avoids atime writes entirely (better than relatime)
+# lazytime: defer inode timestamps to memory, flushed with fsync/mtime changes / 24h.
+# commit=60: batches journal commits (fewer writes, risk up to 60s metadata loss on power loss).
+# errors=remount-ro: safer failure mode
+cat >"$OUT_DIR/persistent.mount" <<EOF
+[Unit]
+Description=Persistent data partition
+Before=local-fs.target
+Conflicts=umount.target
+
+[Mount]
+What=/dev/disk/by-label/${PERSIST_LABEL}
+Where=/persistent
+Type=ext4
+Options=rw,noatime,lazytime,commit=60,errors=remount-ro
+
+[Install]
+WantedBy=local-fs.target
+EOF
+
+# 3) Emit var.mount (bind per-slot /var)
+cat >"$OUT_DIR/var.mount" <<EOF
+[Unit]
+Description=Per-slot /var for ${SLOT}
+Requires=persistent.mount
+After=persistent.mount
+Before=local-fs.target
+ConditionPathExists=${VAR_SRC}
+
+[Mount]
+What=${VAR_SRC}
+Where=/var
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target
+EOF

--- a/image/gpt/ab_userdata/genimage.cfg.in
+++ b/image/gpt/ab_userdata/genimage.cfg.in
@@ -24,7 +24,7 @@ image system.sparse {
 
 image data.sparse {
    android-sparse {
-      image = data.ext4
+      image = persistent.ext4
    }
 }
 
@@ -68,9 +68,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       partition-type-uuid = L
    }
 
-   partition data {
+   partition persistent {
       in-partition-table = true
-      image = data.ext4
+      image = persistent.ext4
       partition-type-uuid = L
    }
 }
@@ -106,13 +106,12 @@ image system.ext4 {
    exec-pre = "<SLOTP> SYSTEM"
 }
 
-image data.ext4 {
-   empty = true
+image persistent.ext4 {
    ext4 {
       use-mke2fs = true
-      label = "USERDATA"
+      label = "PERSISTENT"
       extraargs = "<MKE2FS_DATA>"
    }
-   size = <DATA_SIZE>
-   mountpoint = "/data"
+   mountpoint = "/persistent"
+   size = <PERSISTENT_SIZE>
 }

--- a/image/gpt/ab_userdata/image.adoc
+++ b/image/gpt/ab_userdata/image.adoc
@@ -1,5 +1,55 @@
 = image-rota
 
+== Immutable root and mount points
+
+This system uses an A/B, read‑only root with all writable state on a single persistent partition.
+
+[cols="1,3,1,4", options="header"]
+|===
+| Mount point | Backing | Type | Notes
+
+| / | /dev/disk/by-slot/active/system | ext4 | Read‑only system root (active slot A or B)
+| /boot/firmware | /dev/disk/by-slot/active/boot | vfat | Boot files (active slot A or B)
+| /bootfs | BOOTFS | vfat | Boot metadata
+| /persistent | PERSISTENT | ext4 | Shared persistent storage
+
+| /var | /persistent/slots/<slot>/var | bind | Per‑slot runtime state (systemd, caches, etc.)
+| /home | /persistent/home | bind | User data shared across slots
+| /var/log/journal | /persistent/log/journal | bind | Single log directory used by both slots
+|===
+
+* **Rationale (immutable root + A/B)**
+   ** Supports delta/incremental OTA updates by treating root as a static image.
+   ** Reliable rollbacks: slot can be flipped if a new root fails health checks.
+   ** Reduced write amplification and storage wear, clearer separation of state.
+   ** Predictable per‑slot state in `/var`.
+   ** Shared `/home` for slot agnostic user storage.
+   ** Shared journalling: centralised point for device logging.
+   ** Preserves SBOM accuracy: executing software matches the manifest exactly.
+   ** Blocks on-device package installs, preventing SBOM drift.
+   ** Enables auditable, reproducible releases and stronger supply-chain assurances.
+
+* **Logging**
+   ** A single persistent journal directory at `/persistent/log/journal` stores logs from either slot.
+   ** Journaling is configured for endurance and reliability.
+
+* **Machine Identity (systemd)**
+   ** `/etc/machine-id` is synchronised early with `/persistent/common/etc/machine-id` using a oneshot unit.
+
+
+[WARNING]
+====
+Slot partition GPT labels are mandatory to associate the immutable root with its matching persistent storage.
+
+- Root slots must have stable PARTLABELs: e.g. `system_a` and `system_b`.
+- At boot, a generator reads the root slot’s `PARTLABEL` to select `/persistent/slots/<slot>/var`.
+
+If slot GPT labels are missing/duplicated, `/var` binding will fail.
+
+If slot GPT labels can’t be guaranteed, this layout is not suitable for your device.
+====
+
+
 == Slot Selection (run-time)
 
 Handled entirely by layer `rpi-ab-slot-mapper`.

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -1,31 +1,31 @@
 # METABEGIN
 # X-Env-Layer-Name: image-rota
 # X-Env-Layer-Category: image
-# X-Env-Layer-Desc: Rotational OTA and AB support with GPT.
-#  This layout supports redundancy of boot and system slot components and
-#  provides a seperate user data partition.
-# X-Env-Layer-Version: 3.1.0
-# X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper
+# X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
+#  boot/system redundancy, and a shared persistent data partition.
+# X-Env-Layer-Version: 4.0.0
+# X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
 # X-Env-VarRequires: IGconf_device_storage_type
 #
 # X-Env-VarPrefix: image
 #
-# X-Env-Var-boot_part_size: 100%
-# X-Env-Var-boot_part_size-Desc: Boot partition size per slot.
+# X-Env-Var-boot_part_size: 96M
+# X-Env-Var-boot_part_size-Desc: Boot partition size per-slot.
 # X-Env-Var-boot_part_size-Required: n
 # X-Env-Var-boot_part_size-Valid: size
 # X-Env-Var-boot_part_size-Set: y
 #
-# X-Env-Var-system_part_size: 100%
-# X-Env-Var-system_part_size-Desc: System partition size per slot.
+# X-Env-Var-system_part_size: 512M
+# X-Env-Var-system_part_size-Desc: System partition size per-slot.
 # X-Env-Var-system_part_size-Required: n
 # X-Env-Var-system_part_size-Valid: size
 # X-Env-Var-system_part_size-Set: y
 #
-# X-Env-Var-data_part_size: 256M
-# X-Env-Var-data_part_size-Desc: Data partition retained across rotations.
+# X-Env-Var-data_part_size: 1G
+# X-Env-Var-data_part_size-Desc: Writable storage partition retained across
+#  slot rotations.
 # X-Env-Var-data_part_size-Required: n
 # X-Env-Var-data_part_size-Valid: size
 # X-Env-Var-data_part_size-Set: y
@@ -40,6 +40,7 @@
 # X-Env-Var-pmap-Desc: Provisioning Map type for this image layout.
 #  All partitions will be provisioned unencrypted (clear).
 #  System partitions will be provisioned encrypted (crypt).
+#  System B will be provisioned encrypted (hybrid). Development only.
 # X-Env-Var-pmap-Required: n
 # X-Env-Var-pmap-Valid: clear,hybrid
 # X-Env-Var-pmap-Set: y

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -49,7 +49,7 @@ cat genimage.cfg.in | sed \
    -e "s|<IMAGE_SUFFIX>|$IGconf_image_suffix|g" \
    -e "s|<BOOT_SIZE>|$IGconf_image_boot_part_size|g" \
    -e "s|<SYSTEM_SIZE>|$IGconf_image_system_part_size|g" \
-   -e "s|<DATA_SIZE>|$IGconf_image_data_part_size|g" \
+   -e "s|<PERSISTENT_SIZE>|$IGconf_image_data_part_size|g" \
    -e "s|<SECTOR_SIZE>|$IGconf_device_sector_size|g" \
    -e "s|<SLOTP>|'$(readlink -ef slot-post-process.sh)'|g" \
    -e "s|<BOOT_LABEL>|$BOOT_LABEL|g" \
@@ -58,3 +58,118 @@ cat genimage.cfg.in | sed \
    -e "s|<MKE2FS_SYSTEM>|$MKE2FS_ARGS_SYSTEM|g" \
    -e "s|<MKE2FS_DATA>|$MKE2FS_ARGS_DATA|g" \
    > ${genimg_in}/genimage.cfg
+
+
+# Create persistent skeleton - must match part names in genimage.cfg.in
+mkdir -p ${fs}/persistent/slots/system_a/var
+mkdir -p ${fs}/persistent/slots/system_b/var
+mkdir -p ${fs}/persistent/common/etc
+
+install -d -m 1777 ${fs}/persistent/slots/system_a/var/tmp
+install -d -m 1777 ${fs}/persistent/slots/system_b/var/tmp
+
+
+# machine-id(5)
+wants_dir="${fs}/etc/systemd/system/sysinit.target.wants"
+units=(
+  "machine-id-sync.service"
+)
+install -d -m 0755 "${wants_dir}"
+for unit in "${units[@]}"; do
+  [ -f "${fs}/etc/systemd/system/${unit}" ] || die "missing ${unit}"
+  chmod 0644 "${fs}/etc/systemd/system/${unit}"
+  ln -sf "../${unit}" "${wants_dir}/${unit}"
+done
+
+# Ship an empty file, add entry for legacy dbus
+rm -f "${fs}/etc/machine-id"
+rm -f "${fs}/var/lib/dbus/machine-id"
+install -m0644 -o root -g root /dev/null "${fs}/etc/machine-id"
+ln -s /etc/machine-id "${fs}/var/lib/dbus/machine-id"
+
+
+# /var is per-slot, so synchronise
+rsync -aHAXS --numeric-ids --delete "${fs}/var/" "${fs}/persistent/slots/system_a/var/"
+rsync -aHAXS --numeric-ids --delete "${fs}/var/" "${fs}/persistent/slots/system_b/var/"
+
+
+# Journal is retained across slot rotations
+install -d -m 2755 -o root -g systemd-journal "${fs}/persistent/log/journal"
+# set preferences
+# https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html
+install -d -m 0755 ${fs}/etc/systemd/journald.conf.d
+cat > ${fs}/etc/systemd/journald.conf.d/persistent.conf <<'EOF'
+[Journal]
+Storage=persistent
+
+# Reduce space
+Compress=yes
+
+# Lower disk budget
+SystemMaxUse=512M
+SystemKeepFree=15%
+SystemMaxFileSize=20M
+
+# Retention
+MaxRetentionSec=2w
+
+# Endurance profile
+RuntimeMaxUse=128M
+SyncIntervalSec=2m
+RateLimitInterval=30s
+RateLimitBurst=2000
+
+# Integrity
+Seal=yes
+EOF
+
+
+# /home is bind mounted to /persistent/home and retained across slot rotations
+# Mirror it
+mkdir -p "${fs}/persistent/home/"
+rsync -aHAXS --numeric-ids --delete "${fs}/home/" "${fs}/persistent/home/"
+
+# Reclaim /home
+find "${fs}/home" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+
+# Reclaim /var but ensure skeleton exists for services that need PrivateTmp
+# otherwise namespace setup will fail on the immutable root.
+find "${fs}/var" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+install -d -m 1777 ${fs}/var/tmp
+install -d -m 0755 ${fs}/var/log
+install -d -m 0755 ${fs}/var/cache
+install -d -m 0755 ${fs}/var/spool
+
+
+# Older systemd (eg 252/Bookworm) sets up per‑service mount namespaces by
+# bind mounting a read‑only snapshot of / under /run/systemd/unit-root then
+# mounting APIVFS and PrivateTmp bits (eg, /dev, /proc, /sys) inside that.
+# systemd is not able to create these on an immutable root if they don't
+# exist. Even if we create them, namespace init fails (status=226/NAMESPACE).
+# New systemd (eg 257/Trixie) does not have this problem. Only workaround is
+# to relax the sandboxing for these services. See:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
+ver=$(systemd-major "$fs")
+[[ "$ver" =~ ^[0-9]+$ ]] || { echo "systemd-major error for $fs" >&2; exit 1; }
+if [[ "$ver" -lt 257 ]]; then
+  for svc in systemd-resolved systemd-timesyncd; do
+    d="${fs}/etc/systemd/system/${svc}.service.d"
+    mkdir -p "$d"
+    cat > "${d}/immutable-root.conf" <<'EOF'
+[Service]
+PrivateDevices=no
+EOF
+  done
+fi
+
+
+# Perms for bind mounts on the immutable root
+chmod 755 "${fs}/home"
+chmod 755 "${fs}/var"
+
+
+# Generate the persistent skeleton suitable for on-device overlay
+tar --xattrs --xattrs-include='*' --acls --numeric-owner \
+   -C "${fs}/persistent" \
+   -czf "${genimg_in}/persistent-skel.tar.gz" \
+   --exclude='lost+found' .

--- a/image/gpt/ab_userdata/slot-post-process.sh
+++ b/image/gpt/ab_userdata/slot-post-process.sh
@@ -9,10 +9,18 @@ echo "pre-process $IMAGEMOUNTPATH for $COMP" 1>&2
 case $COMP in
    SYSTEM)
       cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-/dev/disk/by-slot/active/system /              ext4 rw,relatime,errors=remount-ro,commit=30 0 1
+/dev/disk/by-slot/active/system /              ext4 ro,relatime,commit=30 0 1
 /dev/disk/by-slot/active/boot   /boot/firmware vfat defaults,rw,noatime,nofail  0 2
-LABEL=USERDATA                  /data          ext4 rw,relatime,nofail,commit=30 0 2
 LABEL=BOOTFS                    /bootfs        vfat defaults,rw,noatime,errors=panic 0 2
+
+# Bespoke systemd generators mount /persistent, /var and bind mount into it
+# for per-slot storage. See slot-perst-generator.
+
+#tmpfs  /var/tmp  tmpfs  mode=1777,nosuid,nodev,size=256M  0  0
+
+# home and journal persist across slots
+/persistent/home         /home             none  bind,x-systemd.requires-mounts-for=/persistent/home,x-systemd.after=persistent.mount  0  0
+/persistent/log/journal  /var/log/journal  none  bind,x-systemd.requires-mounts-for=/persistent/log/journal,x-systemd.after=persistent.mount  0  0
 EOF
       ;;
    BOOT)


### PR DESCRIPTION
Make each system slot rootfs read-only and move mutable state to a persistent partition, with per-slot isolation for /var and shared identity/data/logs across slots.

Key changes:
- Root immutability:
  - Mount / as ro; no remounting rw during boot.
- Per-slot /var:
  - Add early systemd generator to mount persistent storage at /persistent and bind /var to /persistent/slots/<slot>/var based on the active slot. Requires GPT PARTLABEL support.
- Shared home:
  - Bind /home to /persistent/home so user data is retained across slot rotations.
- Stable machine-id across slots:
  - /etc/machine-id shipped as an empty regular file (no change).
  - Link /var/lib/dbus/machine-id to /etc/machine-id symlink for legacy clients.
  - Add new machine-id-sync.service to:
      - first boot: copy /run/machine-id to /persistent/common/etc/machine-id
      - subsequent boots: write in-place persistent to /run/machine-id
- Persistent journald across slots:
  - Bind /var/log/journal to /persistent/log/journal.
  - Add journalling preferences.
- Image build tweaks:
  - Stage persistent (slots/*/var, common/etc).
  - Enable units under *basic/sysinit*.target.wants
- Hardening:
  - Add ConditionPathExists=/run/machine-id and /persistent/common/etc to units.
  - Use RequiresMountsFor=/persistent/common/etc/machine-id where relevant.

Results:
- Consistent machine-id in /run, /etc, and /persistent across reboots and slot rotations.
- Journald writes to /persistent/log/journal/ preserving machine-id across slots.
- /home persists across A/B.
- /var remains per-slot enabling predictable state.

Note:
Due to differences in systemd startup, there are some per‑service mount namespace failures (error 226/NAMESPACE) when using sandboxing with 252 (Bookworm) that don't exist in 257 (Trixie) because of differences in how systemd boots. Add a workaround to drop PrivateDevices for affected services (timesyncd and resolved). This reduces the sandboxing for these units.

Other:
- Relocate persistent partition inside LUKS for crypt PMAP