### PR TITLE
IDP: JSON cleanup

### DIFF
--- a/bin/image2json
+++ b/bin/image2json
@@ -318,6 +318,11 @@ def parse_genimage_config(config_path):
                     if piname == simg.get("image"):
                         partitions[pname]["simage"] = sname
 
+    # Remove filesystem attributes from all partitions
+    for part in partitions.values():
+        fs_key = str(part.get("type", "")).lower()
+        part.pop(fs_key, None)
+
     # Read the partition table from the image
     img_path = get_artefact_path(img_name, "IGconf_image_outputdir")
     try:
@@ -330,10 +335,7 @@ def parse_genimage_config(config_path):
     except Exception as e:
         raise RuntimeError(f"{e} Failed to read partition table from {img_path}")
 
-    # Nodes are don't care
     ptable = json.loads(res.stdout)
-    for p in ptable["partitiontable"]["partitions"]:
-        p.pop("node", None)
 
     # Populate genimage partition entries with GPT attributes
     def insert_gptattr(genimage_partitions, table_json):
@@ -365,89 +367,16 @@ def parse_genimage_config(config_path):
 
         return genimage_partitions
 
+    # Assign GPT attributes from the partition table probe to each genimage partition
     partitions = insert_gptattr(partitions, ptable)
 
+    # Prune non-essential partition table info
+    pt = ptable.get("partitiontable")
+    if isinstance(pt, dict):
+        for key in ("partitions", "device", "unit", "firstlba", "lastlba", "sectorsize"):
+            pt.pop(key, None)
+
     return (disk_attr, partitions, ptable)
-
-
-# Read all fstabs and store in a dict using UUID or label if we can,
-# or a unique key if we can't.
-def parse_fstab(fstab_paths):
-    fstab_data = {}
-    fcount = 1
-    for fstab_path in fstab_paths:
-        try:
-            with open(fstab_path, "r") as f:
-                lcount = 1
-                for line in f:
-                    line = line.strip()
-                    if line.startswith("#") or line == "":
-                        continue  # skip comments or empty
-
-                    parts = line.split()
-                    if len(parts) == 4:
-                        device, mountpoint, fstype, options = parts[:4]
-                        freq = "0"
-                        passn = "0"
-                    elif len(parts) == 5:
-                        device, mountpoint, fstype, options, freq = parts[:5]
-                        passn = "0"
-                    elif len(parts) == 6:
-                        device, mountpoint, fstype, options, freq, passn = parts[:6]
-                    else:
-                        continue  # skip unusable
-
-                    mount_options = options.split(",")
-
-                    # Supported fs_spec:
-                    if device.startswith(("UUID=", "LABEL=", "PARTUUID=", "PARTLABEL=")):
-                        deviceid = device.split("=", 1)[1]
-                    elif device.startswith(("/dev/disk/by-label/", "/dev/disk/by-uuid/")):
-                        deviceid = device.rsplit("/", 1)[-1]
-                    else:
-                        deviceid = f"fstab{fcount}_{lcount}"
-
-                    # This will overwrite previous settings if the device exists in multiple fstabs
-                    # under the same uuid/label.
-                    fstab_data[deviceid] = {"fs_spec": device,
-                                            "fs_file": mountpoint,
-                                            "fs_vfstype": fstype,
-                                            "fs_mntops": mount_options,
-                                            "fs_freq": freq,
-                                            "fs_passno": passn}
-                    lcount += 1
-
-        except FileNotFoundError:
-            sys.exit('invalid fstab: %s' % fstab_path)
-
-        fcount += 1
-
-    return fstab_data
-
-
-# Try to match a genimage partition with an fstab device entry to establish mount options.
-# Try static uuid and label first, falling back to genimage mountpoint.
-# This lookup can only give guaranteed matching results if there is no duplication of
-# uuid, label or mountpoint in each fstab file provided.
-# If a match is found, the fstab section of the partition is populated.
-def merge_configs(genimage_partitions, fstab_data):
-    for pname, pdata in genimage_partitions.items():
-        label = pdata.get("fs_label")
-        uuid = pdata.get("fs_uuid")
-
-        if uuid and uuid in fstab_data:
-            pdata["fstab"] = fstab_data[uuid]
-        elif label and label in fstab_data:
-            pdata["fstab"] = fstab_data[label]
-        else:
-            pmnt = pdata.get("mountpoint")
-            if pmnt:
-                for name, contents in fstab_data.items():
-                    if pmnt == contents.get("fs_file"):
-                        pdata["fstab"] = fstab_data[name]
-
-    return genimage_partitions
-
 
 
 def get_env_vars(prefix=None):
@@ -480,11 +409,6 @@ if __name__ == '__main__':
                         help="Path to genimage config file",
                         required=True)
 
-    parser.add_argument("-f", "--fstab",
-                        help="Paths to one or more fstab files",
-                        nargs="*",
-                        required=False)
-
     parser.add_argument("-m", "--provisionmap",
                         help="Path to the JSON provisioning map",
                         type=argparse.FileType('r'),
@@ -495,14 +419,7 @@ if __name__ == '__main__':
 
     # Base info
     attributes, genimage_partitions, ptable = parse_genimage_config(genimage_file)
-
-    # fstab is optional
-    if args.fstab:
-        fstab_files = args.fstab
-        fstab_data = parse_fstab(fstab_files)
-        partition_json = merge_configs(genimage_partitions, fstab_data)
-    else:
-        partition_json = genimage_partitions
+    partition_json = genimage_partitions
 
     top_template["IGmeta"] = get_image_meta()
     top_template["attributes"]["image-name"] = os.path.basename(attributes.get("image-name"))

--- a/image/gpt/ab_userdata/device/provisionmap-clear.json
+++ b/image/gpt/ab_userdata/device/provisionmap-clear.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.2.0",
+         "PMAPversion": "1.3.0",
          "system_type": "slotted"
       }
    },
    {
       "partitions": [
          {
+            "comment": "boot configuration",
             "image": "config"
          }
       ]
@@ -17,6 +18,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot A",
                   "image": "boot_a",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -32,6 +34,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot B",
                   "image": "boot_b",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -47,6 +50,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "root filesystem slot A",
                   "image": "system_a",
                   "static": {
                      "uuid": "<SYSTEM_UUID>",
@@ -62,6 +66,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "root filesystem slot B",
                   "image": "system_b",
                   "static": {
                      "uuid": "<SYSTEM_UUID>",
@@ -75,6 +80,7 @@
    {
       "partitions": [
          {
+            "comment": "user data - shared between slots",
             "image": "persistent"
          }
       ]

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.3.1",
+         "PMAPversion": "1.4.1",
          "system_type": "slotted"
       }
    },
    {
       "partitions": [
          {
+            "comment": "boot configuration",
             "image": "config"
          }
       ]
@@ -17,6 +18,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot A",
                   "image": "boot_a",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -32,6 +34,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot B",
                   "image": "boot_b",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -48,15 +51,16 @@
             "key_size": 512,
             "cipher": "aes-xts-plain64",
             "hash": "sha256",
-            "label": "root",
+            "label": "OSDATA",
             "uuid": "<CRYPT_UUID>",
-            "mname": "cryptroot",
+            "mname": "osdata_crypt",
             "etype": "partitioned"
          },
          "slots": {
             "A": {
                "partitions": [
                   {
+                     "comment": "Encrypted root filesystem slot A",
                      "image": "system_a",
                      "static": {
                         "uuid": "<SYSTEM_UUID>",
@@ -68,6 +72,7 @@
             "B": {
                "partitions": [
                   {
+                     "comment": "Encrypted root filesystem slot B",
                      "image": "system_b",
                      "static": {
                         "uuid": "<SYSTEM_UUID>",
@@ -79,6 +84,7 @@
          },
          "partitions": [
             {
+               "comment": "Encrypted user data - shared between slots",
                "image": "persistent"
             }
          ]

--- a/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.0.0",
+         "PMAPversion": "1.1.0",
          "system_type": "slotted"
       }
    },
    {
       "partitions": [
          {
+            "comment": "boot configuration",
             "image": "config"
          }
       ]
@@ -17,6 +18,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot A",
                   "image": "boot_a",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -32,6 +34,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot B",
                   "image": "boot_b",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -47,6 +50,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "root filesystem slot A",
                   "image": "system_a",
                   "static": {
                      "uuid": "<SYSTEM_UUID>",
@@ -62,6 +66,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "root filesystem slot B",
                   "image": "system_b",
                   "static": {
                      "uuid": "<SYSTEM_UUID>",
@@ -78,13 +83,14 @@
             "key_size": 512,
             "cipher": "aes-xts-plain64",
             "hash": "sha256",
-            "label": "root",
+            "label": "USERDATA",
             "uuid": "<CRYPT_UUID>",
-            "mname": "cryptroot",
+            "mname": "userdata_crypt",
             "etype": "partitioned"
          },
          "partitions": [
             {
+               "comment": "Encrypted user data - shared between slots",
                "image": "persistent"
             }
          ]

--- a/image/gpt/ab_userdata/device/provisionmap-crypthybrid.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypthybrid.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.3.1",
+         "PMAPversion": "1.4.1",
          "system_type": "slotted"
       }
    },
    {
       "partitions": [
          {
+            "comment": "boot configuration",
             "image": "config"
          }
       ]
@@ -17,6 +18,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot A",
                   "image": "boot_a",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -32,6 +34,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot B",
                   "image": "boot_b",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -47,6 +50,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "root filesystem slot A",
                   "image": "system_a",
                   "static": {
                      "uuid": "<SYSTEM_UUID>",
@@ -65,13 +69,14 @@
                   "key_size": 512,
                   "cipher": "aes-xts-plain64",
                   "hash": "sha256",
-                  "label": "rootB",
+                  "label": "OSB",
                   "uuid": "<CRYPT_UUID>",
-                  "mname": "cryptroot",
+                  "mname": "osb_crypt",
                   "etype": "partitioned"
                },
                "partitions": [
                   {
+                     "comment": "Encrypted root filesystem slot B",
                      "image": "system_b",
                      "static": {
                         "uuid": "<SYSTEM_UUID>",
@@ -86,6 +91,7 @@
    {
       "partitions": [
          {
+            "comment": "user data - shared between slots",
             "image": "persistent"
          }
       ]

--- a/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.0.0",
+         "PMAPversion": "1.1.0",
          "system_type": "slotted"
       }
    },
    {
       "partitions": [
          {
+            "comment": "boot configuration",
             "image": "config"
          }
       ]
@@ -17,6 +18,7 @@
          "A": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot A",
                   "image": "boot_a",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -32,6 +34,7 @@
          "B": {
             "partitions": [
                {
+                  "comment": "kernel + device tree + initramfs slot B",
                   "image": "boot_b",
                   "static": {
                      "uuid": "<BOOT_UUID>",
@@ -48,15 +51,16 @@
             "key_size": 512,
             "cipher": "aes-xts-plain64",
             "hash": "sha256",
-            "label": "root",
+            "label": "OSAB",
             "uuid": "<CRYPT_UUID>",
-            "mname": "cryptroot",
+            "mname": "osab_crypt",
             "etype": "partitioned"
          },
          "slots": {
             "A": {
                "partitions": [
                   {
+                     "comment": "Encrypted root filesystem slot A",
                      "image": "system_a",
                      "static": {
                         "uuid": "<SYSTEM_UUID>",
@@ -68,6 +72,7 @@
             "B": {
                "partitions": [
                   {
+                     "comment": "Encrypted root filesystem slot B",
                      "image": "system_b",
                      "static": {
                         "uuid": "<SYSTEM_UUID>",
@@ -82,6 +87,7 @@
    {
       "partitions": [
          {
+            "comment": "user data - shared between slots",
             "image": "persistent"
          }
       ]

--- a/image/mbr/simple_dual/device/provisionmap-clear.json
+++ b/image/mbr/simple_dual/device/provisionmap-clear.json
@@ -1,17 +1,19 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.0.0",
+         "PMAPversion": "1.1.0",
          "system_type": "flat"
       }
    },
    {
       "partitions": [
          {
-            "image": "boot"
+            "image": "boot",
+            "comment": "kernel + device tree + initramfs"
          },
          {
-            "image": "root"
+            "image": "root",
+            "comment": "root filesystem"
          }
       ]
    }

--- a/image/mbr/simple_dual/device/provisionmap-crypt.json
+++ b/image/mbr/simple_dual/device/provisionmap-crypt.json
@@ -1,13 +1,14 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.1.0",
+         "PMAPversion": "1.2.0",
          "system_type": "flat"
       }
    },
    {
       "partitions": [
          {
+            "comment": "kernel + device tree + initramfs",
             "image": "boot"
          }
       ]
@@ -17,14 +18,15 @@
          "luks2": {
             "key_size": 512,
             "cipher": "aes-xts-plain64",
-            "label": "root",
+            "label": "OSROOT",
             "uuid": "<CRYPT_UUID>",
             "hash": "sha256",
-            "mname": "cryptroot",
+            "mname": "osroot_crypt",
             "etype": "raw"
          },
          "partitions": [
             {
+               "comment": "Encrypted root filesystem",
                "image": "root"
             }
          ]

--- a/layer/base/schemas/provisionmap/v1/schema.json
+++ b/layer/base/schemas/provisionmap/v1/schema.json
@@ -25,6 +25,7 @@
       "additionalProperties": false,
       "properties": {
         "image": { "type": "string", "minLength": 1 },
+        "comment": { "type": "string" },
         "static": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
Remove JSON attributes that are not required for IDP.
Add support for a per-partition description in the PMAP schema.
Some LUKS label and mapper renaming.