### PR TITLE
Add dynamic layer support

### DIFF
--- a/bin/generators/README.adoc
+++ b/bin/generators/README.adoc
@@ -1,0 +1,20 @@
+= Generator Scripts
+
+== Purpose
+
+Helper scripts in this directory are invoked by the layer manager when a layer declares `X-Env-Layer-Type: dynamic`. Each generator reads a template layer file (`$1`) and writes the rendered result to the output file path (`$2`). This is a reference for each script. The layer manager guarantees that the input file and parent directory of the output file are valid.
+
+== Available Generators
+
+[cols="1,4,4", options="header"]
+|===
+| Script | Purpose   | Notes
+| envcp  | `<PLACEHOLDER>` replacement using environment variables | If `DEBIAN_SNAPSHOT_TS` is unset, `<SNAPSHOT>` is derived from the current UTC time.
+|===
+
+
+== Adding New Generators
+
+1. Drop the executable script in this directory.
+2. Document it in the table above.
+

--- a/bin/generators/envcp
+++ b/bin/generators/envcp
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu
+
+if [[ -n ${DEBIAN_SNAPSHOT_TS:-} ]]; then
+   snapshot=$(date -u -d @"$DEBIAN_SNAPSHOT_TS" +%Y%m%dT%H%M%SZ)
+else
+   snapshot=$(date -u +%Y%m%dT%H%M%SZ)
+fi
+
+cat "$1" | sed \
+   -e "s|<SNAPSHOT>|$snapshot|g" \
+   > "$2"

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -66,6 +66,33 @@ mmdebstrap:
     - network-manager
 ```
 
+=== Static vs Dynamic Layers
+
+Layers are static unless explicitly marked dynamic. To render a layer at build time add:
+
+```
+# X-Env-Layer-Type: dynamic
+# X-Env-Layer-Generator: myscript
+```
+
+The loader then:
+
+1. Checks for the existence of a temporary directory specified by tag `TMPROOT_layer=<tmpdir>` on the layer search path (`rpi-image-gen` does this automatically).
+2. Runs the generator with two arguments, `<template-path> <output-path>`, where the output is written to `TMPROOT_layer/path/to/<layer-name>.yaml`. The `path/to` portion matches the layer’s path under its original search root, so dynamic layers mirror the same directory structure as static layers when reported via tagged paths.
+3. Reads all mmdebstrap/env content from the generated file while continuing to use the original `# X-Env-*` metadata for naming, dependencies, documentation, etc.
+
+Generators must write a complete layer to the output path. A trivial generator could copy the template directly to the output (e.g. `cp` works fine). More more complex generators may inject snapshot timestamps, merge user data, or pull content from other sources. If the generator writes nothing, the layer still 'exists' (metadata is intact) but it contains no YAML body information (packages, hooks, etc) and `--describe` output will reflect that. Dynamic layers provide a way to manipulate the layer YAML at build time. Modifications made by the generator only affect the YAML body. The original `# X-Env-*` metadata is always taken from the template.
+
+[IMPORTANT]
+====
+`X-Env-Layer-Generator` must resolve to an executable (on PATH or via a relative/absolute path).
+====
+
+[NOTE]
+====
+`rpi-image-gen` ships its own generators in `bin/generators`. If a source directory was specified at build time, `<SRCROOT>/bin/generators` is automatically included in `PATH` if present.
+====
+
 === Layer Attributes
 `X-Env-Layer-Name`: Layer name
 
@@ -82,6 +109,10 @@ mmdebstrap:
 `X-Env-Layer-RequiresProvider`: Services or capabilities this layer requires
 
 `X-Env-Layer-Conflicts`: Layers that cannot be used together with this one
+
+`X-Env-Layer-Type`: Static (default) or dynamic
+
+`X-Env-Layer-Generator`: If dynamic, the generator invoked by the loader
 
 === Dependencies and Providers
 

--- a/examples/reproducible_debfs/README.md
+++ b/examples/reproducible_debfs/README.md
@@ -1,0 +1,70 @@
+Build a reproducible Debian Trixie minbase filesystem tarball.
+
+This example demonstrates using a custom dynamic layer to construct a filesystem base from a Debian Trixie snapshot. The dynamic layer uses a built-in generator to output apt compatible snapshot urls in the rendered layer YAML.
+
+Normal layer cli commands function as usual, eg
+
+```bash
+$ rpi-image-gen layer -S ./examples/reproducible_debfs/ --describe example-minbase-snaphot
+
+Layer: example-minbase-snaphot
+Version: 1.0.0
+Category: example
+Description: Architecture agnostic Debian Trixie minbase snapshot
+ providing a reproducible base.
+Type: dynamic
+Generator: envcp
+Path: mylayer.yaml
+```
+
+Run the build to generate the base filesystem:
+
+```bash
+$ rpi-image-gen build -S ./examples/reproducible_debfs/ -c build.yaml
+```
+
+The resulting tarball can be exported as an OCI compatible archive suitable for running or publishing, etc.
+
+```bash
+$ podman import ./path/to/trixie-reproducible.tgz trixie:snapshot
+Getting image source signatures
+Copying blob fc50bbf8ecd0 done
+Copying config d4014b11e8 done
+Writing manifest to image destination
+Storing signatures
+sha256:d4014b11e8ab79c6e70123e9feab3ec76e76a78955577f089ed11f8d94214b69
+$
+$ podman image save --format oci-archive -o trixie-snap-oci.tar trixie:snapshot
+Copying blob c6990d7e892d done
+Copying config d4014b11e8 done
+Writing manifest to image destination
+Storing signatures
+$
+$ gzip trixie-snap-oci.tar
+```
+
+Publish or run...
+
+```bash
+$ podman image load -i ./trixie-snap-oci.tar.gz
+Getting image source signatures
+Copying blob 5c4c1ed5ed94 skipped: already exists
+Copying config d4014b11e8 done
+Writing manifest to image destination
+Storing signatures
+Loaded image: localhost/trixie:snapshot
+$
+$ podman run --rm -it localhost/trixie:snapshot /bin/bash
+root@92b3c9432038:/# hostname
+92b3c9432038
+root@92b3c9432038:/# cat /etc/apt/sources.list
+# Origin
+# deb http://snapshot.debian.org/archive/debian/20251120T122224Z trixie main contrib non-free non-free-firmware
+# deb http://snapshot.debian.org/archive/debian-security/20251120T122224Z trixie-security main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian-security trixie-security main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
+root@92b3c9432038:/#
+```
+
+The filesystem base is reproducible. The layer cleanup phase configures APT for normal use so that any subsequent apt operations use the rolling repositories.

--- a/examples/reproducible_debfs/config/build.yaml
+++ b/examples/reproducible_debfs/config/build.yaml
@@ -1,0 +1,8 @@
+env:
+  DEBIAN_SNAPSHOT_TS: 1763641344
+
+artefact:
+  target_name: trixie-reproducible.tgz
+
+layer:
+  base: example-minbase-snaphot

--- a/examples/reproducible_debfs/layer/mylayer.yaml
+++ b/examples/reproducible_debfs/layer/mylayer.yaml
@@ -1,0 +1,33 @@
+# METABEGIN
+# X-Env-Layer-Name: example-minbase-snaphot
+# X-Env-Layer-Category: example
+# X-Env-Layer-Desc: Architecture agnostic Debian Trixie minbase snapshot
+#  providing a reproducible base.
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Type: dynamic
+# X-Env-Layer-Generator: envcp
+# METAEND
+mmdebstrap:
+  suite: trixie
+  variant: minbase
+  mirrors:
+    - deb http://snapshot.debian.org/archive/debian/<SNAPSHOT> trixie main contrib non-free non-free-firmware
+    - deb http://snapshot.debian.org/archive/debian-security/<SNAPSHOT> trixie-security main contrib non-free non-free-firmware
+  setup-hooks:
+    - mkdir -p $1/etc/apt/apt.conf.d
+    - |-
+      cat <<- EOF > $1/etc/apt/apt.conf.d/snapshot.conf
+      Acquire::Check-Valid-Until "false" ;
+      EOF
+  cleanup-hooks:
+    - |-
+      set -e
+      rm -f $1/etc/apt/apt.conf.d/snapshot.conf
+      cat <<- EOF > $1/etc/apt/sources.list
+      # Origin
+      # deb http://snapshot.debian.org/archive/debian/<SNAPSHOT> trixie main contrib non-free non-free-firmware
+      # deb http://snapshot.debian.org/archive/debian-security/<SNAPSHOT> trixie-security main contrib non-free non-free-firmware
+      deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
+      deb http://deb.debian.org/debian-security trixie-security main contrib non-free non-free-firmware
+      deb http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
+      EOF

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -236,6 +236,10 @@ map_path() {
          [[ -n ${IGconf_image_assetdir:-} ]] || return 1
          base=${IGconf_image_assetdir}
          ;;
+      TMPROOT_layer)
+         [[ -n ${ctx[DYN_LAYER_DIR]:-} ]] || return 1
+         base=${ctx[DYN_LAYER_DIR]}
+         ;;
       *)
          printf '%s\n' "$raw"
          return 0

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -43,6 +43,8 @@ declare -A ctx=(
 [[ -d "${ctx[TMPDIR]}" ]] || die "Failed to create temp directory"
 trap 'rm -rf "${ctx[TMPDIR]}"' EXIT
 
+ctx[DYN_LAYER_DIR]="${ctx[TMPDIR]}/layers"
+mkdir -p "${ctx[DYN_LAYER_DIR]}"
 
 # Refresh path variables. These may change after CLI parse.
 path_refresh()
@@ -73,6 +75,10 @@ path_refresh()
          ctx[EXEC_PATH]="${src_bin}:${ctx[EXEC_PATH]}"
       fi
 
+      if src_bin=$(map_path 'SRCROOT:bin/generators' 2>/dev/null) && [[ -d $src_bin ]]; then
+         ctx[EXEC_PATH]="${src_bin}:${ctx[EXEC_PATH]}"
+      fi
+
       for d in device image layer; do
          local sub="${ctx[SRC_DIR]}/$d"
          [[ -d $sub ]] || continue
@@ -85,8 +91,11 @@ path_refresh()
       fi
    fi
 
+   ctx[LAYER_PATH]="TMPROOT_layer=${ctx[DYN_LAYER_DIR]}:${ctx[LAYER_PATH]}"
+
    # Built-in executables always take precedence
    ctx[EXEC_PATH]="$(map_path 'IGROOT:bin'):${ctx[EXEC_PATH]}"
+   ctx[EXEC_PATH]="$(map_path 'IGROOT:bin/generators'):${ctx[EXEC_PATH]}"
 
    PATH=${ctx[EXEC_PATH]}
    export PATH

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -96,6 +96,8 @@ SUPPORTED_FIELD_PATTERNS = {
     XEnv.layer_requires(): {"type": "single", "description": "Required layer dependencies"},
     XEnv.layer_conflicts(): {"type": "single", "description": "Conflicting layers"},
     XEnv.layer_category(): {"type": "single", "description": "Layer category"},
+    XEnv.layer_type(): {"type": "single", "description": "Layer type (static or dynamic)"},
+    XEnv.layer_generator(): {"type": "single", "description": "Generator executable for dynamic layers"},
     XEnv.layer_provides(): {"type": "single", "description": "Capabilities provided by this layer"},
     XEnv.layer_requires_provider(): {"type": "single", "description": "Capabilities required (virtual)"},
 

--- a/templates/docs/html/layer.html
+++ b/templates/docs/html/layer.html
@@ -351,6 +351,10 @@
     <div class="section">
         <h2>Attributes</h2>
         <p><strong>File:</strong> <code>{{ layer.file_path }}</code></p>
+        <p><strong>Type:</strong> <code>{{ layer.layer_info.type }}</code></p>
+        {% if layer.layer_info.type == 'dynamic' and layer.layer_info.generator %}
+        <p><strong>Generator:</strong> <code>{{ layer.layer_info.generator }}</code></p>
+        {% endif %}
         {% if layer.layer_info.conflicts %}
         <p><strong>Conflicts:</strong> {{ layer.layer_info.conflicts|join(', ') }}</p>
         {% endif %}

--- a/test/layer/dynamic-valid.yaml
+++ b/test/layer/dynamic-valid.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: dynamic-test
+# X-Env-Layer-Desc: Dynamic layer for generator tests
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Type: dynamic
+# X-Env-Layer-Generator: test-dynamic-generator
+# METAEND
+
+mmdebstrap:
+  suite: trixie
+  variant: minbase
+  mirrors:
+    - deb http://deb.debian.org/debian trixie main

--- a/test/layer/invalid-dynamic-missing-generator.yaml
+++ b/test/layer/invalid-dynamic-missing-generator.yaml
@@ -1,0 +1,9 @@
+# METABEGIN
+# X-Env-Layer-Name: dynamic-missing
+# X-Env-Layer-Desc: Missing generator declaration
+# X-Env-Layer-Type: dynamic
+# METAEND
+
+mmdebstrap:
+  suite: trixie
+  variant: minbase

--- a/test/layer/test_dynamic_layer_manager.py
+++ b/test/layer/test_dynamic_layer_manager.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import tempfile
+from pathlib import Path
+
+import sys
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SITE_DIR = REPO_ROOT / "site"
+if str(SITE_DIR) not in sys.path:
+    sys.path.insert(0, str(SITE_DIR))
+
+from layer_manager import LayerManager
+
+
+def main() -> None:
+    layers_dir = Path(__file__).resolve().parent
+    tools_dir = layers_dir / "tools"
+    with tempfile.TemporaryDirectory(prefix="dynamic-layer-") as tmpdir:
+        os.environ["PATH"] = f"{tools_dir}:{os.environ['PATH']}"
+        manager = LayerManager([f"TMPROOT_layer={tmpdir}", str(layers_dir)])
+        order = manager.get_build_order(["dynamic-test"])
+        if "dynamic-test" not in order:
+            raise SystemExit("dynamic-test not in build order")
+        generated = Path(manager.layer_files["dynamic-test"])
+        if tmpdir not in str(generated):
+            raise SystemExit("generated file not in dynamic layer directory")
+        data = generated.read_text().strip()
+        if "# generated" not in data:
+            raise SystemExit("generated marker not found in output")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/layer/tools/test-dynamic-generator
+++ b/test/layer/tools/test-dynamic-generator
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+input=$1
+output=$2
+cp "$input" "$output"
+echo "# generated" >> "$output"


### PR DESCRIPTION
This change-set adds the ability to generate YAML layers on the fly (i.e. 'dynamic layers'). This feature opens up many possibilities, including being able to generate reproducible Debian base systems using snapshots (https://snapshot.debian.org/). A new example is added to demonstrate this.
Documentation and test harness updates as required.

Next time the docs are auto-generated, all layer html pages will be updated as a result of their type (ie static or dynamic) now being shown.