### PR TITLE
runner: Fix overlay apply with non-dir target

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -184,7 +184,7 @@ case "$phase" in
       ;;
    customize)
       run_phase_scripts "$phase" "$@"
-      apply_overlays "$phase" "$IGconf_target_path"
+      apply_overlays "$phase" "$@"
       run_hook_phase "$phase" "$@"
       ;;
    extract|essential|cleanup)


### PR DESCRIPTION
When applying overlays, use the positional args from bdebstrap rather than target path. If target path is a file (eg tarball) scripts will get the path to a tmpdir containing the chroot.