### PR TITLE
Add AB post-image

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -44,8 +44,8 @@ IGROOT:pre-image.sh \
 SRCROOT:pre-image.sh"
 
    [post-image]="\
-DEVICE_ASSET:post-image.sh|IGROOT_device:post-image.sh \
-IMAGE_ASSET:post-image.sh|IGROOT_image:post-image.sh \
+DEVICE_ASSET:post-image.sh IGROOT_device:post-image.sh \
+IMAGE_ASSET:post-image.sh IGROOT_image:post-image.sh \
 IGROOT:post-image.sh \
 SRCROOT:post-image.sh"
 

--- a/image/gpt/ab_userdata/post-image.sh
+++ b/image/gpt/ab_userdata/post-image.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+upd="${1}/update"
+rm -rf $upd
+mkdir -p $upd
+
+[[ -f ${1}/system.sparse ]] || false
+[[ -f ${1}/boot.sparse ]] || false
+
+ln -sf ../system.sparse ${upd}/system
+ln -sf ../boot.sparse ${upd}/boot
+
+msg "Packing..."
+cd $upd && tar -I zstd -h -cf  ${1}/update.tar.zst -- *


### PR DESCRIPTION
Remove mutual exclusion for post-image hooks - it's not needed.
Plug in a simple post-image hook for the AB layout that packs a compressed archive of slot sparse images.

fyi @pelwell @clowder 