### PR TITLE
Write artefact version on cleanup

### DIFF
--- a/scripts/bdebstrap/cleanup01
+++ b/scripts/bdebstrap/cleanup01
@@ -17,3 +17,4 @@ GH=$(git describe --dirty 2> /dev/null || \
 
 mkdir -p $1/etc
 echo "Generated using rpi-image-gen ${GH} on $(date +%Y-%m-%d)" > $1/etc/rpi-issue
+echo "Artefact version: $IGconf_artefact_version" >> $1/etc/rpi-issue


### PR DESCRIPTION
/etc/rpi-issue now contains the version identified by config variable IGconf_artefact_version