### PR TITLE
Improved startup robustness for the persistent partition

### DIFF
--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -156,31 +156,25 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock">/</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/dev/disk/by-slot/active/system</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ext4</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Read‑only system root (active slot A or B)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ro System root (active slot A or B)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/boot/firmware</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/dev/disk/by-slot/active/boot</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">vfat</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boot files (active slot A or B)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ro Boot files (active slot A or B)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/bootfs</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">BOOTFS</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">vfat</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boot metadata</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rw Boot metadata</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/persistent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">PERSISTENT</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ext4</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Shared persistent storage</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">/var</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/slots/&lt;slot&gt;/var</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Per‑slot runtime state (systemd, caches, etc.)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rw Shared persistent storage</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/home</p></td>
@@ -189,10 +183,22 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock">User data shared across slots</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/var</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/slots/&lt;slot&gt;/var</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Per‑slot runtime state (systemd, caches, etc.)</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/var/log/journal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/log/journal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Single log directory used by both slots</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/var/tmp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">tmpfs</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">tmpfs</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Volatile scratch</p></td>
 </tr>
 </tbody>
 </table>

--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -194,12 +194,6 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Single log directory used by both slots</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">/var/tmp</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">tmpfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">tmpfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Volatile scratch</p></td>
-</tr>
 </tbody>
 </table>
 <div class="ulist">

--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
@@ -4,10 +4,14 @@
 set -eu
 
 OUT_DIR="/run/systemd/generator"
-PERSIST_LABEL="${PERSIST_LABEL:-PERSISTENT}"     # label of the shared persistent partition
-
 mkdir -p "$OUT_DIR"
 
+# Label of the shared persistent partition
+PERSIST_LABEL="${PERSIST_LABEL:-PERSISTENT}"
+
+# Corresponding fsck unit
+path=$(systemd-escape --path "/dev/disk/by-label/${PERSIST_LABEL}")
+FSCK_UNIT="systemd-fsck@${path}.service"
 
 # 1) Determine current slot
 SLOT=""
@@ -25,9 +29,7 @@ fi
 
 VAR_SRC="/persistent/slots/${SLOT}/var"
 
-
 # 2) Emit persistent.mount (mount the shared persistent partition by label)
-#
 # Mount with:
 # noatime: avoids atime writes entirely (better than relatime)
 # lazytime: defer inode timestamps to memory, flushed with fsync/mtime changes / 24h.
@@ -38,6 +40,8 @@ cat >"$OUT_DIR/persistent.mount" <<EOF
 Description=Persistent data partition
 Before=local-fs.target
 Conflicts=umount.target
+Requires=${FSCK_UNIT}
+After=${FSCK_UNIT}
 
 [Mount]
 What=/dev/disk/by-label/${PERSIST_LABEL}
@@ -49,7 +53,17 @@ Options=rw,noatime,lazytime,commit=60,errors=remount-ro
 WantedBy=local-fs.target
 EOF
 
-# 3) Emit var.mount (bind per-slot /var)
+# 3) Emit fsck settings
+fsck_dir="/run/systemd/system/${FSCK_UNIT}.d"
+mkdir -p "$fsck_dir"
+cat >"$fsck_dir/repair.conf" <<EOF
+[Service]
+# Automatic non-interactive repair always
+Environment=SYSTEMD_FSCK_FORCE=yes
+Environment=SYSTEMD_FSCK_REPAIR=yes
+EOF
+
+# 4) Emit var.mount (bind per-slot /var)
 cat >"$OUT_DIR/var.mount" <<EOF
 [Unit]
 Description=Per-slot /var for ${SLOT}

--- a/image/gpt/ab_userdata/image.adoc
+++ b/image/gpt/ab_userdata/image.adoc
@@ -8,14 +8,14 @@ This system uses an A/B, read‑only root with all writable state on a single pe
 |===
 | Mount point | Backing | Type | Notes
 
-| / | /dev/disk/by-slot/active/system | ext4 | Read‑only system root (active slot A or B)
-| /boot/firmware | /dev/disk/by-slot/active/boot | vfat | Boot files (active slot A or B)
-| /bootfs | BOOTFS | vfat | Boot metadata
-| /persistent | PERSISTENT | ext4 | Shared persistent storage
-
-| /var | /persistent/slots/<slot>/var | bind | Per‑slot runtime state (systemd, caches, etc.)
+| / | /dev/disk/by-slot/active/system | ext4 | ro System root (active slot A or B)
+| /boot/firmware | /dev/disk/by-slot/active/boot | vfat | ro Boot files (active slot A or B)
+| /bootfs | BOOTFS | vfat | rw Boot metadata
+| /persistent | PERSISTENT | ext4 | rw Shared persistent storage
 | /home | /persistent/home | bind | User data shared across slots
+| /var | /persistent/slots/<slot>/var | bind | Per‑slot runtime state (systemd, caches, etc.)
 | /var/log/journal | /persistent/log/journal | bind | Single log directory used by both slots
+| /var/tmp | tmpfs | tmpfs | Volatile scratch
 |===
 
 * **Rationale (immutable root + A/B)**

--- a/image/gpt/ab_userdata/image.adoc
+++ b/image/gpt/ab_userdata/image.adoc
@@ -15,7 +15,6 @@ This system uses an A/B, read‑only root with all writable state on a single pe
 | /home | /persistent/home | bind | User data shared across slots
 | /var | /persistent/slots/<slot>/var | bind | Per‑slot runtime state (systemd, caches, etc.)
 | /var/log/journal | /persistent/log/journal | bind | Single log directory used by both slots
-| /var/tmp | tmpfs | tmpfs | Volatile scratch
 |===
 
 * **Rationale (immutable root + A/B)**

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -107,7 +107,6 @@ Compress=yes
 
 # Lower disk budget
 SystemMaxUse=512M
-SystemKeepFree=15%
 SystemMaxFileSize=20M
 
 # Retention

--- a/image/gpt/ab_userdata/slot-post-process.sh
+++ b/image/gpt/ab_userdata/slot-post-process.sh
@@ -10,13 +10,12 @@ case $COMP in
    SYSTEM)
       cat << EOF > $IMAGEMOUNTPATH/etc/fstab
 /dev/disk/by-slot/active/system /              ext4 ro,relatime,commit=30 0 1
-/dev/disk/by-slot/active/boot   /boot/firmware vfat defaults,rw,noatime,nofail  0 2
+/dev/disk/by-slot/active/boot   /boot/firmware vfat defaults,ro,noatime,nofail  0 2
 LABEL=BOOTFS                    /bootfs        vfat defaults,rw,noatime,errors=panic 0 2
+tmpfs                           /var/tmp       tmpfs mode=1777,nosuid,nodev,size=256M  0  0
 
 # Bespoke systemd generators mount /persistent, /var and bind mount into it
 # for per-slot storage. See slot-perst-generator.
-
-#tmpfs  /var/tmp  tmpfs  mode=1777,nosuid,nodev,size=256M  0  0
 
 # home and journal persist across slots
 /persistent/home         /home             none  bind,x-systemd.requires-mounts-for=/persistent/home,x-systemd.after=persistent.mount  0  0

--- a/image/gpt/ab_userdata/slot-post-process.sh
+++ b/image/gpt/ab_userdata/slot-post-process.sh
@@ -12,7 +12,6 @@ case $COMP in
 /dev/disk/by-slot/active/system /              ext4 ro,relatime,commit=30 0 1
 /dev/disk/by-slot/active/boot   /boot/firmware vfat defaults,ro,noatime,nofail  0 2
 LABEL=BOOTFS                    /bootfs        vfat defaults,rw,noatime,errors=panic 0 2
-tmpfs                           /var/tmp       tmpfs mode=1777,nosuid,nodev,size=256M  0  0
 
 # Bespoke systemd generators mount /persistent, /var and bind mount into it
 # for per-slot storage. See slot-perst-generator.


### PR DESCRIPTION
Always enforcing repair on the persistent partition filesystem is a best-effort at ensuring it's integrity at startup.
Put `/var/tmp` on tmpfs. This is run-time scratch and does not need to persist to disk.
Mount `/boot/firmware` ro. This filesystem does not need to be writable.
Drop unnecessary journald attribute. No drawbacks. Less noise at boot.