### PR TITLE
layer: systemd-resolved: install stub if non-existent

### DIFF
--- a/layer/sys-apps/systemd-net-min.yaml
+++ b/layer/sys-apps/systemd-net-min.yaml
@@ -15,3 +15,4 @@ mmdebstrap:
     - ln -sf /dev/null $1/etc/systemd/network/99-default.link
     - ln -sf /dev/null $1/etc/systemd/network/73-usb-net-by-mac.link
     - $LAYER_HOOKS/systemd/netgen eth0 > $1/etc/systemd/network/01-eth0.network
+    - '[ -e "$1/run/systemd/resolve/stub-resolv.conf" ] || install -Dm644 /etc/resolv.conf "$1/run/systemd/resolve/stub-resolv.conf"'


### PR DESCRIPTION
Bookworm systemd-resolved (v252) postinst moves /etc/resolv.conf to the stub symlink without first ensuring the stub file exists, so in a chroot that isn’t running resolved, the link dangles breaking DNS.

Trixie (v257) has newer systemd with a fix [1] to copy the existing resolv.conf to the stub before doing the move, therefore retaining working DNS after systemd-resolved postinst has run.

Add a trivial safe workaround in this layer to copy the host's /etc/resolv.conf to the stub if the stub doesn't exist.

[1]
https://salsa.debian.org/systemd-team/systemd/-/commit/71c3f1014c811bd9a1e0f2df4f392687935b9f95

Fixes #116 #151