### PR TITLE
Seed initial timesyncd clock, don't vacuum early AB logs

### DIFF
--- a/docs/layer/systemd-min.html
+++ b/docs/layer/systemd-min.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>systemd-min</h1>
         <span class="badge">general</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Core systemd components for init, SysV compatibility
  and timesyncd, without networkd and resolved services.</p>
     </div>

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -109,8 +109,9 @@ Compress=yes
 SystemMaxUse=512M
 SystemMaxFileSize=20M
 
-# Retention
-MaxRetentionSec=2w
+# No time window retention
+MaxRetentionSec=0
+MaxFileSec=0
 
 # Endurance profile
 RuntimeMaxUse=128M

--- a/layer/sys-apps/systemd-min.yaml
+++ b/layer/sys-apps/systemd-min.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: systemd-min
 # X-Env-Layer-Desc: Core systemd components for init, SysV compatibility
 #  and timesyncd, without networkd and resolved services.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # METAEND
 ---
 mmdebstrap:
@@ -12,5 +12,11 @@ mmdebstrap:
     - systemd-timesyncd
   customize-hooks:
     - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-timesyncd
+    - |-
+      set -eu
+      if [ -n "${SOURCE_DATE_EPOCH:-}" ] ; then
+        install -d -m0755 $1/var/lib/systemd/timesync
+        touch -m -d "@${SOURCE_DATE_EPOCH}" $1/var/lib/systemd/timesync/clock
+      fi
     - mkdir -p $1/etc/systemd/system/getty@tty1.service.d
     - $LAYER_HOOKS/systemd/ttyset noclear > $1/etc/systemd/system/getty@tty1.service.d/noclear.conf


### PR DESCRIPTION
AB: Drop the 2w journald retention policy. This, combined with a big first-boot clock jump, results in journald immediately vacuuming anything older than 2 weeks. On a fresh boot that doesn't have any cached time, early boot log entries are old enough to get dropped. On subsequent boots, the clock is cached (timesyncd state persists on /var), so no vacuuming happens. Removing time-based retention and keeping size-based retention is a better solution and avoids deleting potentially important first boot information from the journal.

layer: Seed systemd's timesyncd clock with SOURCE_DATE_EPOCH if available. This provides a more appropriate initial system time and also avoids a large jump once NTP sync is achieved.

Refs:
journald.conf(5)
systemd-timesyncd(8)
https://reproducible-builds.org/docs/source-date-epoch/