### PR TITLE
core: Use a dedicated namespace wrapper

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,7 +74,7 @@ rpi-image-gen builds its own copies of critical host tools so it always has curr
 
 === Important
 
-rpi-image-gen is developed on Raspberry Pi OS and supports builds on Debian Bookworm and Trixie arm64 systems. It expects a Debian-based host and will run on non-arm64 platforms (such as x86_64) via QEMU emulation or in container environments, although those non-native setups aren’t formally supported.
+rpi-image-gen is developed on Raspberry Pi OS, with Debian Bookworm and Trixie arm64 as the supported native hosts. It expects a Debian-based system and can run in containers or on non-arm64 hosts via QEMU, but those environments are not formally supported. The build invokes `mmdebstrap` to create a chroot and mount pseudo-filesystems (proc, sysfs, devpts) inside a private mount namespace, which requires `CAP_SYS_ADMIN` or equivalent (eg, `--privileged` or `--security-opt=unconfined` depending on rootless/container setup). The build will fail without that capability. Other environments may succeed if granted the necessary privileges, but remain outside the scope of support. For a supported path, run on native Debian Bookworm/Trixie arm64.
 
 == Documentation
 

--- a/bin/ns
+++ b/bin/ns
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Used to run a command inside a linux user namespace, remapping uid/gid
+# so that permissions may be elevated (eg like inside a container).
+# May be needed for execution of certain commands / tools.
+
+set -eu
+uid=$(id -u)
+if [ "$uid" -eq 0 ]; then
+   exec "$@"
+else
+   exec podman unshare "$@"
+fi

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -390,7 +390,7 @@ generate_filesystem()
 
    local -n _benv="${ctx[ENV_BDEBSTRAP]}" # via nameref
 
-   rund "${ctx[SRCROOT]}" podman unshare bdebstrap \
+   rund "${ctx[SRCROOT]}" ns bdebstrap \
       "${_benv[@]}" \
       --setup-hook     'runner setup "$@"' \
       --extract-hook   'runner extract "$@"' \
@@ -398,13 +398,13 @@ generate_filesystem()
       --customize-hook 'runner customize "$@"' \
       --cleanup-hook   'runner cleanup "$@"'
 
-   runenv "${ctx[FINALENV]}" podman unshare runner post-build
+   runenv "${ctx[FINALENV]}" ns runner post-build
 
    [[ ${ctx[INTERACTIVE]} == y ]] && \
       { ask "Filesystem complete. Proceed to SBOM?" y || exit 0 ; }
 
    msg "\nSBOM"
-   runenv "${ctx[FINALENV]}" podman unshare runner sbom
+   runenv "${ctx[FINALENV]}" ns runner sbom
 }
 
 
@@ -426,15 +426,14 @@ generate_images() {
 
    msg "\nIMAGE"
 
-   runenv "${ctx[FINALENV]}" podman unshare runner pre-image
+   runenv "${ctx[FINALENV]}" ns runner pre-image
 
    if [[ "$provider" == genimage && -d "$filesystem" ]] ; then
       mkdir -p "${TMPDIR}/genimage"
       local cfg
       for cfg in "${output_path}"/genimage*.cfg; do
          [[ -f $cfg ]] || continue
-         runenv "${ctx[FINALENV]}" \
-            podman unshare env genimage \
+         runenv "${ctx[FINALENV]}" ns env genimage \
             --rootpath   "$filesystem" \
             --tmppath    "${TMPDIR}/genimage" \
             --inputpath  "$output_path" \
@@ -446,7 +445,7 @@ generate_images() {
       done
    fi
 
-   runenv "${ctx[FINALENV]}" podman unshare runner post-image
+   runenv "${ctx[FINALENV]}" ns runner post-image
 }
 
 
@@ -456,12 +455,12 @@ generate_images() {
 #   Install build assets for distribution
 ###############################################################################
 deploy() {
-   runenv "${ctx[FINALENV]}" podman unshare runner finalize
+   runenv "${ctx[FINALENV]}" ns runner finalize
 
    [[ ${ctx[INTERACTIVE]} == y ]] && { ask "Deploy assets?" y || exit 0 ; }
 
    msg "\nDEPLOY"
-   runenv "${ctx[FINALENV]}" podman unshare runner deploy
+   runenv "${ctx[FINALENV]}" ns runner deploy
 }
 
 
@@ -479,7 +478,7 @@ clean_worktree() {
       [[ -e $val ]] || continue
       ask "Remove $key [$val]?" y || continue
       if [[ $key == IGconf_target_path ]]; then
-         run podman unshare rm -rf -- "$val"
+         run ns rm -rf -- "$val"
       else
          rm -rf -- "$val"
       fi


### PR DESCRIPTION
Wrap podman unshare so it's only invoked when running rootless. This avoids errors when running rpi-image-gen as root rather than a regular user (eg in some container environments). Top level readme updated to elaborate on the capabilities required for mmdebstrap execution and run-time environment.