### PR TITLE
Introduce hashed password option

### DIFF
--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -36,6 +36,7 @@
 # X-Env-Var-user1-Set: y
 #
 # X-Env-Var-user1pass:
+# X-Env-Var-user1pass-Conflicts: user1hashedpass
 # X-Env-Var-user1pass-Desc: Password required to log into the user1 account. If
 #  empty, the account will be locked. Password requirements are as follows.
 #  At least 8 characters.
@@ -46,6 +47,14 @@
 # X-Env-Var-user1pass-Required: n
 # X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
 # X-Env-Var-user1pass-Set: n
+#
+# X-Env-Var-user1hashedpass:
+# X-Env-Var-user1hashedpass-Conflicts: user1pass
+# X-Env-Var-user1hashedpass-Desc: A pre-hashed value of the password required to log into the user1 account.
+#  to pre-hash a password use the provided genpasswd script in the chroot scope.
+# X-Env-Var-user1hashedpass-Required: n
+# X-Env-Var-user1hashedpass-Valid: string
+# X-Env-Var-user1hashedpass-Set: n
 #
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Desc: Device storage media type.

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -9,7 +9,7 @@
 # X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-VarOptional: IGconf_device_user1pass
+# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1hashedpass
 # METAEND
 ---
 mmdebstrap:
@@ -22,8 +22,10 @@ mmdebstrap:
         adduser --disabled-password --gecos \"\"  $IGconf_device_user1;
         fi"
     - |-
-      if [ -n "$IGconf_device_user1pass" ] ; then
-         chroot $1 sh -c "printf '%s:%s\n' '${IGconf_device_user1}' '${IGconf_device_user1pass}' | chpasswd"
+      if [ -n "$IGconf_device_user1hashedpass" ] ; then
+         printf '%s:%s\n' '${IGconf_device_user1}' '${IGconf_device_user1hashedpass}' | chroot $1 chpasswd -e
+      elif [ -n "$IGconf_device_user1pass" ] ; then
+         printf '%s:%s\n' '${IGconf_device_user1}' '${IGconf_device_user1pass}' | chroot $1 chpasswd
       fi
     - chroot $1 usermod --pass='*' root
     - chroot $1 sh -c "for GRP in input spi i2c gpio; do


### PR DESCRIPTION
It may be useful, for security reasons, to allow the password of the initial user to be set with a pre-hashed value. This is a very simple option to add that functionality.

fixes: #82 