### PR TITLE
layer: Default apt key dir to non-empty

### DIFF
--- a/docs/layer/sys-build-base.html
+++ b/docs/layer/sys-build-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>sys-build-base</h1>
         <span class="badge">build</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Build environment configuration including workspace, apt
  settings, and system foundation defaults.</p>
     </div>
@@ -188,21 +188,21 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_sys_apt_keydir</code></td>
-                    <td>APT key directory
- If a particular collection of keys are required for bdebstrap to download
- packages from the mirror(s) provided, set the directory containing them here.
- This will be passed to bdebstrap via aptopt Dir::Etc::TrustedParts. If not
- specified, rpi-image-gen sets this directory and assembles the keys it
- requires into it.
+                    <td>APT key directory.
+ If a particular collection of keys are required for apt to download packages
+ from the mirror(s) provided, set the directory containing them here. This
+ will be passed to apt via Dir::Etc::TrustedParts. Other keys necessary for
+ bootstrap, in addition to those in standard system locations, will be copied
+ to this directory.
  This particular setting of Dir::Etc::TrustedParts will not be included in the
  image. If using this option, please make sure to install your key(s) into the
  chroot explicitly if a key contained in this directory points to a location
  that is not otherwise populated during chroot creation (for example by
  installing a keyring package).</td>
                     <td>
-                           <code>&lt;empty&gt;</code>
+                           <code>${@WORKROOT}/keys</code>
                     </td>
-                    <td>String value (may be empty)</td>
+                    <td>Non-empty string value</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>
@@ -224,7 +224,7 @@
                     <td><code>IGconf_sys_cachedir</code></td>
                     <td>Global cache root directory for all operations.</td>
                     <td>
-                           <code class="long-default">${IGconf_sys_workroot}/cache</code>
+                           <code>${@WORKROOT}/cache</code>
                     </td>
                     <td>Non-empty string value</td>
                     <td>
@@ -252,7 +252,7 @@
                     <td><code>IGconf_sys_buildroot</code></td>
                     <td>Global build root directory for source builds.</td>
                     <td>
-                           <code class="long-default">${IGconf_sys_workroot}/build</code>
+                           <code>${@WORKROOT}/build</code>
                     </td>
                     <td>Non-empty string value</td>
                     <td>
@@ -265,12 +265,33 @@
  order, metadata) used to resume the build in a containerised (or later)
  invocation.</td>
                     <td>
-                           <code class="long-default">${IGconf_sys_workroot}/bootstrap</code>
+                           <code>${@WORKROOT}/bootstrap</code>
                     </td>
                     <td>Non-empty string value</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="section">
+        <h2>Anchors</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Anchor</th>
+                    <th>Variable</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>@WORKROOT</code></td>
+                    <td><code>IGconf_sys_workroot</code></td>
+                    <td>The root work directory. Depending on the system(s)
+ being built, this directory can amount to a substantial amount of consumed
+ disk space.</td>
                 </tr>
             </tbody>
         </table>

--- a/layer/base/sys-build-base.yaml
+++ b/layer/base/sys-build-base.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: build
 # X-Env-Layer-Desc: Build environment configuration including workspace, apt
 #  settings, and system foundation defaults.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 #
 # X-Env-VarPrefix: sys
 #
@@ -23,23 +23,24 @@
 # X-Env-Var-apt_get_purge-Valid: bool
 # X-Env-Var-apt_get_purge-Set: y
 #
-# X-Env-Var-apt_keydir:
-# X-Env-Var-apt_keydir-Desc: APT key directory
-#  If a particular collection of keys are required for bdebstrap to download
-#  packages from the mirror(s) provided, set the directory containing them here.
-#  This will be passed to bdebstrap via aptopt Dir::Etc::TrustedParts. If not
-#  specified, rpi-image-gen sets this directory and assembles the keys it
-#  requires into it.
+# X-Env-Var-apt_keydir: ${@WORKROOT}/keys
+# X-Env-Var-apt_keydir-Desc: APT key directory.
+#  If a particular collection of keys are required for apt to download packages
+#  from the mirror(s) provided, set the directory containing them here. This
+#  will be passed to apt via Dir::Etc::TrustedParts. Other keys necessary for
+#  bootstrap, in addition to those in standard system locations, will be copied
+#  to this directory.
 #  This particular setting of Dir::Etc::TrustedParts will not be included in the
 #  image. If using this option, please make sure to install your key(s) into the
 #  chroot explicitly if a key contained in this directory points to a location
 #  that is not otherwise populated during chroot creation (for example by
 #  installing a keyring package).
 # X-Env-Var-apt_keydir-Required: n
-# X-Env-Var-apt_keydir-Valid: string-or-empty
+# X-Env-Var-apt_keydir-Valid: string
 # X-Env-Var-apt_keydir-Set: y
 #
 # X-Env-Var-workroot: $(realpath --canonicalize-missing ./work)
+# X-Env-Var-workroot-Anchor: @WORKROOT
 # X-Env-Var-workroot-Desc: The root work directory. Depending on the system(s)
 #  being built, this directory can amount to a substantial amount of consumed
 #  disk space.
@@ -47,7 +48,7 @@
 # X-Env-Var-workroot-Valid: string
 # X-Env-Var-workroot-Set: y
 #
-# X-Env-Var-cachedir: ${IGconf_sys_workroot}/cache
+# X-Env-Var-cachedir: ${@WORKROOT}/cache
 # X-Env-Var-cachedir-Desc: Global cache root directory for all operations.
 # X-Env-Var-cachedir-Required: n
 # X-Env-Var-cachedir-Valid: string
@@ -65,13 +66,13 @@
 # X-Env-Var-apt_cachedir-Valid: string-or-empty
 # X-Env-Var-apt_cachedir-Set: force
 #
-# X-Env-Var-buildroot: ${IGconf_sys_workroot}/build
+# X-Env-Var-buildroot: ${@WORKROOT}/build
 # X-Env-Var-buildroot-Desc: Global build root directory for source builds.
 # X-Env-Var-buildroot-Required: n
 # X-Env-Var-buildroot-Valid: string
 # X-Env-Var-buildroot-Set: y
 #
-# X-Env-Var-bootstrapdir: ${IGconf_sys_workroot}/bootstrap
+# X-Env-Var-bootstrapdir: ${@WORKROOT}/bootstrap
 # X-Env-Var-bootstrapdir-Desc: Directory for bootstrap artefacts (e.g. env, layer
 #  order, metadata) used to resume the build in a containerised (or later)
 #  invocation.

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -292,18 +292,12 @@ prepare_build_config()
       msg "-> $key : $value"
       case $key in
          IGconf_sys_apt_keydir)
-            if [[ -z "$value" ]]; then
-               keydir=$(realpath -m "${IGconf_sys_workroot}/keys")
-               mkdir -p -- "$keydir" || die
-               [[ -d /usr/share/keyrings ]] && rsync -a /usr/share/keyrings/ "$keydir"
-               if [[ -n ${HOME:-} && -d ${HOME}/.local/share/keyrings ]]; then
-                  rsync -a "${HOME}/.local/share/keyrings/" "$keydir"
-               fi
-               rsync -a "$IGTOP/keydir/" "$keydir"
-               value="$keydir"
-            else
-               [[ -d $value ]] || die "$key $value is invalid"
+            mkdir -p -- "$value" || die
+            [[ -d /usr/share/keyrings ]] && rsync -a /usr/share/keyrings/ "$value"
+            if [[ -n ${HOME:-} && -d ${HOME}/.local/share/keyrings ]]; then
+               rsync -a "${HOME}/.local/share/keyrings/" "$value"
             fi
+            rsync -a "${IGTOP}/keydir/" "$value"
             _bdebstrap+=( --aptopt "Dir::Etc::TrustedParts $value" ) ;;
 
          IGconf_sys_apt_cachedir)


### PR DESCRIPTION
Layers that require IGconf_sys_apt_keydir need it to be a valid directory. This variable was permitted to be empty (default) which resulted in a non-empty value being set internally and used for the apt trusted-parts dir. Pre-pipeline, this value was then re-injected back into the layer configuration environment. When pipeline was added, the legacy layer env/apply scheme was removed making it impossible for config variable values to be manipulated and re-injected back into the layer configuration. This is by-design, but it meant that the keydir variable could never be set to a value where it would be seen by consumer layers, eg docker.

Change the default value so it's a directory path, create it if it doesn't exist, copy all the appropriate keys into it and pass it to apt. This retains the value through pipeline, therefore exposing it to all consumer layers.

Resolves #170