### PR TITLE
New config features

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -257,6 +257,13 @@ The engine supports deferred variable expansion, meaning that it's possible to f
 
 === Environment Variable Expansion
 
+Variable values may include parameter expansion or command substitution. To be expanded by the engine, they must use one of these forms:
+
+- `${variable}`
+- `$(command)`
+
+Any other `$` (eg, `$VAR` or `$6$...`) is treated as literal and will be escaped.
+
 [source,yaml]
 ----
 device:

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -595,6 +595,22 @@ root_part_size = 300%</code></pre>
 </div>
 <div class="sect2">
 <h3 id="_environment_variable_expansion"><a class="anchor" href="#_environment_variable_expansion"></a><a class="link" href="#_environment_variable_expansion">Environment Variable Expansion</a></h3>
+<div class="paragraph">
+<p>Variable values may include parameter expansion or command substitution. To be expanded by the engine, they must use one of these forms:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>${variable}</code></p>
+</li>
+<li>
+<p><code>$(command)</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Any other <code>$</code> (eg, <code>$VAR</code> or <code>$6$&#8230;&#8203;</code>) is treated as literal and will be escaped.</p>
+</div>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code class="language-yaml" data-lang="yaml">device:

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -171,6 +171,8 @@ Unlike dependencies, environment variables are not supported when evaluating pro
 
 `X-Env-Var-<name>-Set`: Set policy (immediate, lazy, force, skip)
 
+`X-Env-Var-<name>-Triggers`: Derived actions based on the variable value
+
 === Variable Naming Convention
 Variables follow the pattern: `IGconf_<prefix>_<name>`
 
@@ -186,6 +188,93 @@ Variable values support dynamic placeholders:
 `${FILENAME}`: Name of the layer file (without extension)
 
 `${FILEPATH}`: Full path to the layer file
+
+=== Triggers
+
+Triggers (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
+
+* Conditional: `VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Unconditional: `set TARGET=VALUE [policy=force|immediate|lazy]`
+
+Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate`.
+
+Lint will fail on:
+
+* Unknown actions.
+* Actions that do not start with `TARGET=VALUE`.
+* Target names that are not POSIX identifiers.
+
+Usage:
+
+* Target values are preserved as literals with no expansion.
+* Triggers are collected from every definition of a variable across all layers. They are evaluated once against the variable’s final resolved value, so triggers declared in upstream layers still fire even if a downstream layer overrides the variable’s value. Suppression of upstream triggers is not supported.
+
+==== Supported actions
+
+[cols="1,3,2,3",options="header"]
+|===
+|Action |Description |Default policy |Applies to
+
+|`set` |Inject an environment variable with the given value and policy. | immediate |X-Env-*-Var
+|===
+
+==== Examples
+
+* Conditional:
++
+`# X-Env-Var-rootfs_type-Triggers: btrfs set IG_HAS_BTRFS_PROGS=1 policy=force`
+
+* Unconditional:
++
+`# X-Env-Var-rootfs_type-Triggers: set IG_ALWAYS_ON=1 policy=immediate`
+
+* Multiple with different conditions (new line per condition helps readability, but is not mandatory):
++
+```
+# X-Env-Var-rootfs_type-Triggers:
+#  btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
+#  ext4 set IG_HAS_E2FS_PROGS=1 policy=force
+```
+
+* Multiple actions sharing the same condition (omit the condition on following line to inherit the previous one):
++
+```
+# X-Env-Var-rootfs_type-Triggers:
+#  ext4 set IG_HAS_E2FS_PROGS=1
+#  set IG_HAS_SRCBUILD=1
+```
+
+[IMPORTANT]
+====
+Trigger precedence is determined by layer order, not file order.
+
+* Variable declarations in the same layer share that layer's position.
+* If a trigger sets a variable, it adds a definition for the target variable, e.g. at 'position + 0.01'.
+* Any definition of that target variable from a later layer (higher position) wins via the normal force/immediate/lazy policy rules.
+
+Within a single layer:
+
+* If the same variable is declared multiple times, last declaration is retained (before triggers are considered).
+* If a trigger sets a variable, the trigger’s injected definition sits after the layer’s base definition and will override that variable’s declaration in the same layer (force/immediate/lazy still apply). A later layer can still override the trigger.
+====
+
+==== Example (same layer):
+
+```
+# X-Env-VarPrefix: image
+
+# X-Env-Var-deploy_type: develop
+# X-Env-Var-deploy_type-Valid: develop,production
+# X-Env-Var-deploy_type-Set: y
+# X-Env-Var-deploy_type-Triggers: production set IGconf_image_pmap=crypt policy=force
+
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: y
+# X-Env-Var-pmap-Set: force
+```
+
+If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGconf_image_pmap=crypt` after the source variable, overriding `pmap: clear` in the same layer. A later layer defining `IGconf_image_pmap` with `force` would still win over the trigger.
 
 == Configuration Variables
 

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -280,16 +280,25 @@ If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGc
 
 === Variable Conflicts
 
-Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when others are also set. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.
+Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited. Conditional conflicts are supported with `name=value` or `name!=value` syntax. Multiple conflicts can be specified, separated by commas.
 
 Examples:
 
 ```
+# Unconditional:
 # X-Env-Var-user1pass:
 # X-Env-Var-user1pass-Conflicts: user1hashpass
 #
 # X-Env-Var-user1hashpass:
 # X-Env-Var-user1hashpass-Conflicts: user1pass
+
+
+# Conditional:
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Valid: sd,emmc,nvme
+#
+# X-Env-Var-lockemmc: y
+# X-Env-Var-lockemmc-Conflicts: storage_type!=emmc
 ```
 
 == Configuration Variables

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -173,6 +173,8 @@ Unlike dependencies, environment variables are not supported when evaluating pro
 
 `X-Env-Var-<name>-Triggers`: Derived actions based on the variable value
 
+`X-Env-Var-<name>-Conflicts`: Variables that cannot be set when this variable is also set
+
 === Variable Naming Convention
 Variables follow the pattern: `IGconf_<prefix>_<name>`
 
@@ -275,6 +277,20 @@ Within a single layer:
 ```
 
 If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGconf_image_pmap=crypt` after the source variable, overriding `pmap: clear` in the same layer. A later layer defining `IGconf_image_pmap` with `force` would still win over the trigger.
+
+=== Variable Conflicts
+
+Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when others are also set. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.
+
+Examples:
+
+```
+# X-Env-Var-user1pass:
+# X-Env-Var-user1pass-Conflicts: user1hashpass
+#
+# X-Env-Var-user1hashpass:
+# X-Env-Var-user1hashpass-Conflicts: user1pass
+```
 
 == Configuration Variables
 

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -280,7 +280,9 @@ If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGc
 
 === Variable Conflicts
 
-Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited. Conditional conflicts are supported with `name=value` or `name!=value` syntax. Multiple conflicts can be specified, separated by commas.
+Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.
+
+Conflict expressions adhere to `<precursor> <condition>` syntax. The precursor is optional (`when=<value>`) and a single expression may only include one precursor. The condition can be unconditional (`name`) or conditional (`name=value` / `name!=value`). Multiple expressions can be specified, separated by commas, and may be wrapped across multiple lines. Each expression may include only one precursor.
 
 Examples:
 
@@ -292,13 +294,16 @@ Examples:
 # X-Env-Var-user1hashpass:
 # X-Env-Var-user1hashpass-Conflicts: user1pass
 
-
-# Conditional:
+# Conditional (no precursor):
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Valid: sd,emmc,nvme
 #
 # X-Env-Var-lockemmc: y
+# X-Env-Var-lockemmc-Valid: bool
 # X-Env-Var-lockemmc-Conflicts: storage_type!=emmc
+
+# Conditional (with precursor):
+# X-Env-Var-lockemmc-Conflicts: when=y storage_type!=emmc
 ```
 
 == Configuration Variables

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -22,11 +22,11 @@
         h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { color: #333; text-decoration: none; }
 
         /* AsciiDoc table styling */
-        .tableblock { width: 100%; border-collapse: collapse; margin: 1.25em 0; }
+        .tableblock { width: 100%; border-collapse: collapse; margin: 1.25em 0; table-layout: fixed; }
         .tableblock.frame-all { border: 1px solid #dedede; }
         .tableblock.grid-all th, .tableblock.grid-all td { border: 1px solid #dedede; }
         .tableblock.stretch { width: 100%; }
-        .tableblock th, .tableblock td { padding: 0.5625em 0.625em; text-align: left; vertical-align: top; }
+        .tableblock th, .tableblock td { padding: 0.5625em 0.625em; text-align: left; vertical-align: top; overflow-wrap: anywhere; word-break: break-word; }
         .tableblock th { background: #f8f9fa; font-weight: 600; color: rgba(0,0,0,.8); }
         .tableblock tbody tr:nth-child(even) { background: #f8f8f7; }
         .tableblock p { margin: 0; line-height: 1.6; }
@@ -156,6 +156,14 @@
 <li><a href="#_environment_variables">Environment Variables</a></li>
 <li><a href="#_variable_naming_convention">Variable Naming Convention</a></li>
 <li><a href="#_placeholder_support">Placeholder Support</a></li>
+<li><a href="#_triggers">Triggers</a>
+<ul class="sectlevel3">
+<li><a href="#_supported_actions">Supported actions</a></li>
+<li><a href="#_examples">Examples</a></li>
+<li><a href="#_example_same_layer">Example (same layer):</a></li>
+</ul>
+</li>
+<li><a href="#_variable_conflicts">Variable Conflicts</a></li>
 </ul>
 </li>
 <li><a href="#_configuration_variables">Configuration Variables</a></li>
@@ -518,6 +526,12 @@ mmdebstrap:
 <div class="paragraph">
 <p><code>X-Env-Var-&lt;name&gt;-Set</code>: Set policy (immediate, lazy, force, skip)</p>
 </div>
+<div class="paragraph">
+<p><code>X-Env-Var-&lt;name&gt;-Triggers</code>: Derived actions based on the variable value</p>
+</div>
+<div class="paragraph">
+<p><code>X-Env-Var-&lt;name&gt;-Conflicts</code>: Variables that cannot be set when this variable is also set</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_variable_naming_convention"><a class="anchor" href="#_variable_naming_convention"></a><a class="link" href="#_variable_naming_convention">Variable Naming Convention</a></h3>
@@ -551,6 +565,214 @@ mmdebstrap:
 </div>
 <div class="paragraph">
 <p><code>${FILEPATH}</code>: Full path to the layer file</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_triggers"><a class="anchor" href="#_triggers"></a><a class="link" href="#_triggers">Triggers</a></h3>
+<div class="paragraph">
+<p>Triggers (<code>X-Env-Var-*-Triggers</code>) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Conditional: <code>VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+<li>
+<p>Unconditional: <code>set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code>.</p>
+</div>
+<div class="paragraph">
+<p>Lint will fail on:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Unknown actions.</p>
+</li>
+<li>
+<p>Actions that do not start with <code>TARGET=VALUE</code>.</p>
+</li>
+<li>
+<p>Target names that are not POSIX identifiers.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Usage:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Target values are preserved as literals with no expansion.</p>
+</li>
+<li>
+<p>Triggers are collected from every definition of a variable across all layers. They are evaluated once against the variable’s final resolved value, so triggers declared in upstream layers still fire even if a downstream layer overrides the variable’s value. Suppression of upstream triggers is not supported.</p>
+</li>
+</ul>
+</div>
+<div class="sect3">
+<h4 id="_supported_actions"><a class="anchor" href="#_supported_actions"></a><a class="link" href="#_supported_actions">Supported actions</a></h4>
+<table class="tableblock frame-all grid-all stripes-even stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 33.3333%;">
+<col style="width: 22.2222%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Action</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default policy</th>
+<th class="tableblock halign-left valign-top">Applies to</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>set</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Inject an environment variable with the given value and policy.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">immediate</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">X-Env-*-Var</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_examples"><a class="anchor" href="#_examples"></a><a class="link" href="#_examples">Examples</a></h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Conditional:</p>
+<div class="paragraph">
+<p><code># X-Env-Var-rootfs_type-Triggers: btrfs set IG_HAS_BTRFS_PROGS=1 policy=force</code></p>
+</div>
+</li>
+<li>
+<p>Unconditional:</p>
+<div class="paragraph">
+<p><code># X-Env-Var-rootfs_type-Triggers: set IG_ALWAYS_ON=1 policy=immediate</code></p>
+</div>
+</li>
+<li>
+<p>Multiple with different conditions (new line per condition helps readability, but is not mandatory):</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># X-Env-Var-rootfs_type-Triggers:
+#  btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
+#  ext4 set IG_HAS_E2FS_PROGS=1 policy=force</code></pre>
+</div>
+</div>
+</li>
+<li>
+<p>Multiple actions sharing the same condition (omit the condition on following line to inherit the previous one):</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># X-Env-Var-rootfs_type-Triggers:
+#  ext4 set IG_HAS_E2FS_PROGS=1
+#  set IG_HAS_SRCBUILD=1</code></pre>
+</div>
+</div>
+</li>
+</ul>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Trigger precedence is determined by layer order, not file order.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Variable declarations in the same layer share that layer&#8217;s position.</p>
+</li>
+<li>
+<p>If a trigger sets a variable, it adds a definition for the target variable, e.g. at 'position + 0.01'.</p>
+</li>
+<li>
+<p>Any definition of that target variable from a later layer (higher position) wins via the normal force/immediate/lazy policy rules.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Within a single layer:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>If the same variable is declared multiple times, last declaration is retained (before triggers are considered).</p>
+</li>
+<li>
+<p>If a trigger sets a variable, the trigger’s injected definition sits after the layer’s base definition and will override that variable’s declaration in the same layer (force/immediate/lazy still apply). A later layer can still override the trigger.</p>
+</li>
+</ul>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_same_layer"><a class="anchor" href="#_example_same_layer"></a><a class="link" href="#_example_same_layer">Example (same layer):</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># X-Env-VarPrefix: image
+
+# X-Env-Var-deploy_type: develop
+# X-Env-Var-deploy_type-Valid: develop,production
+# X-Env-Var-deploy_type-Set: y
+# X-Env-Var-deploy_type-Triggers: production set IGconf_image_pmap=crypt policy=force
+
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: y
+# X-Env-Var-pmap-Set: force</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>If <code>IGconf_image_deploy_type</code> resolves to <code>production</code>, the trigger injects <code>IGconf_image_pmap=crypt</code> after the source variable, overriding <code>pmap: clear</code> in the same layer. A later layer defining <code>IGconf_image_pmap</code> with <code>force</code> would still win over the trigger.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_variable_conflicts"><a class="anchor" href="#_variable_conflicts"></a><a class="link" href="#_variable_conflicts">Variable Conflicts</a></h3>
+<div class="paragraph">
+<p>Variable conflicts (<code>X-Env-Var-*-Conflicts</code>) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved <code>IGconf</code> prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.</p>
+</div>
+<div class="paragraph">
+<p>Conflict expressions adhere to <code>&lt;precursor&gt; &lt;condition&gt;</code> syntax. The precursor is optional (<code>when=&lt;value&gt;</code>) and a single expression may only include one precursor. The condition can be unconditional (<code>name</code>) or conditional (<code>name=value</code> / <code>name!=value</code>). Multiple expressions can be specified, separated by commas, and may be wrapped across multiple lines. Each expression may include only one precursor.</p>
+</div>
+<div class="paragraph">
+<p>Examples:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># Unconditional:
+# X-Env-Var-user1pass:
+# X-Env-Var-user1pass-Conflicts: user1hashpass
+#
+# X-Env-Var-user1hashpass:
+# X-Env-Var-user1hashpass-Conflicts: user1pass
+
+# Conditional (no precursor):
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Valid: sd,emmc,nvme
+#
+# X-Env-Var-lockemmc: y
+# X-Env-Var-lockemmc-Valid: bool
+# X-Env-Var-lockemmc-Conflicts: storage_type!=emmc
+
+# Conditional (with precursor):
+# X-Env-Var-lockemmc-Conflicts: when=y storage_type!=emmc</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -984,6 +1206,10 @@ IGconf_layer_app=my-app</code></pre>
         
         <div class="layer-item">
             <a href="rpi-connect-lite.html">rpi-connect-lite</a><span class="layer-desc">- Raspberry Pi Connect client with remote shell access</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="rpi-connect-ota.html">rpi-connect-ota</a><span class="layer-desc">- Configures Raspberry Pi Connect's experimental remote update capability</span>
         </div>
         
     </div>

--- a/docs/layer/rpi-connect-ota.html
+++ b/docs/layer/rpi-connect-ota.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>rpi-connect-ota - Layer Documentation</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
+        .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
+        .section { margin-bottom: 30px; }
+        .badge { display: inline-block; background: #007acc; color: white; padding: 2px 8px; border-radius: 3px; font-size: 12px; margin-right: 10px; }
+        .policy-immediate { background: #28a745; color: white; text-decoration: none; }
+        .policy-lazy { background: #ffc107; color: #212529; text-decoration: none; }
+        .policy-force { background: #dc3545; color: white; text-decoration: none; }
+        .policy-skip { background: #6c757d; color: white; text-decoration: none; }
+        .policy-immediate:hover { background: #1e7e34; }
+        .policy-lazy:hover { background: #e0a800; }
+        .policy-force:hover { background: #c82333; }
+        .policy-skip:hover { background: #545b62; }
+        table { width: 100%; border-collapse: collapse; margin-top: 10px; table-layout: auto; }
+        th, td { text-align: left; padding: 8px 12px; border-bottom: 1px solid #ddd; }
+        th { background: #f8f9fa; font-weight: 600; }
+        td:nth-child(3) {
+            width: auto;
+        }
+        code { background: #f1f3f4; padding: 2px 4px; border-radius: 3px; font-family: 'Monaco', monospace; font-size: 14px; }
+        code.long-default { word-break: break-all; white-space: pre-wrap; display: block; min-width: 30ch; }
+        .back-link { margin-bottom: 20px; }
+        .back-link a { text-decoration: none; color: #007acc; }
+        .deps { display: flex; flex-wrap: wrap; gap: 5px; }
+        .dep-badge { background: #28a745; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; text-decoration: none; }
+        .dep-badge:hover { background: #1e7e34; }
+        /* Main content headers styling */
+        h1, h2, h3, h4, h5, h6 { color: #333; margin-top: 20px; margin-bottom: 10px; }
+        /* Companion documentation content styling */
+        .companion-content h1, .companion-content h2, .companion-content h3, .companion-content h4, .companion-content h5, .companion-content h6 { color: #333; margin-top: 20px; margin-bottom: 10px; }
+        .companion-content p { margin: 10px 0; }
+        .companion-content ul, .companion-content ol { margin: 10px 0; padding-left: 30px; }
+        .companion-content blockquote { border-left: 4px solid #007acc; padding-left: 15px; margin: 15px 0; color: #666; background: #f8f9fa; padding: 10px 15px; }
+        .companion-content pre { background: #f8f9fa; padding: 15px; border-radius: 5px; overflow-x: auto; border-left: 4px solid #007acc; }
+        .companion-content table { border: 1px solid #ddd; }
+        .companion-content th, .companion-content td { border: 1px solid #ddd; }
+
+        /* AsciiDoc admonition blocks (NOTE, TIP, WARNING, etc.) */
+        .admonitionblock {
+            margin: 1.5em 0;
+            padding: 0.4em 0.6em;
+            border-left: 4px solid;
+            background: #f8f9fa;
+            border-radius: 0 4px 4px 0;
+        }
+
+        .admonitionblock .title {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 0.85em;
+            margin-bottom: 0.25em;
+            letter-spacing: 0.5px;
+        }
+
+        .admonitionblock .content {
+            margin: 0;
+        }
+
+        /* Reduce spacing for paragraphs inside admonitions */
+        .admonitionblock p {
+            margin: 0.25em 0;
+        }
+
+        .admonitionblock p:first-child {
+            margin-top: 0;
+        }
+
+        .admonitionblock p:last-child {
+            margin-bottom: 0;
+        }
+
+        /* Specific admonition types */
+        .admonitionblock.note {
+            border-color: #17a2b8;
+            background: #d1ecf1;
+        }
+
+        .admonitionblock.note .title {
+            color: #0c5460;
+        }
+
+        .admonitionblock.tip {
+            border-color: #28a745;
+            background: #d4edda;
+        }
+
+        .admonitionblock.tip .title {
+            color: #155724;
+        }
+
+        .admonitionblock.important {
+            border-color: #ffc107;
+            background: #fff3cd;
+        }
+
+        .admonitionblock.important .title {
+            color: #856404;
+        }
+
+        .admonitionblock.warning,
+        .admonitionblock.caution {
+            border-color: #dc3545;
+            background: #f8d7da;
+        }
+
+        .admonitionblock.warning .title,
+        .admonitionblock.caution .title {
+            color: #721c24;
+        }
+    </style>
+</head>
+<body>
+    <div class="back-link">
+        <a href="index.html">← Back to Layer Index</a>
+    </div>
+
+    <div class="header">
+        <h1>rpi-connect-ota</h1>
+        <span class="badge">service</span>
+        <span class="badge">v1.0.0</span>
+        <p>Configures Raspberry Pi Connect's experimental remote update capability</p>
+    </div>
+    <div class="section">
+        <h2>Relationships</h2>
+        <p><strong>Requires Provider:</strong> rpi-connect-client</p>
+    </div>
+    <div class="section">
+        <h2>Configuration Variables</h2>
+        <p><strong>References:</strong>
+        <code>IGconf_device_user1</code>
+        </p>
+    </div>
+    <div class="section">
+        <h2>mmdebstrap</h2>
+        
+        <h3>Packages</h3>
+        <p>Installs:</p>
+        <ul>
+            <li><code>rpi-connect-ota</code></li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Attributes</h2>
+        <p><strong>File:</strong> <code>rpi/device/services/rpi-connect-ota.yaml</code></p>
+        <p><strong>Type:</strong> <code>static</code></p>
+    </div>
+</body>
+</html>

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -226,11 +226,12 @@ map_path() {
 export -f map_path
 
 
-# General purpose key=value normaliser that escapes chracters that would
-# break posix expansion
+# General purpose key=value normaliser that escapes characters that would
+# break shell expansion.
 safe_kv() {
   python3 - "$1" <<'PY'
 import sys
+import re
 with open(sys.argv[1], encoding='utf-8') as src:
    for raw in src:
       line = raw.rstrip('\n')
@@ -238,7 +239,9 @@ with open(sys.argv[1], encoding='utf-8') as src:
          print(line)
          continue
       key, value = line.split('=', 1)
-      value = value.replace('\\', '\\\\').replace('"', '\\"')
+      value = value.replace('\\', '\\\\').replace('"', '\\"').replace('`', '\\`')
+      # Permits ${var} or $(cmd) expansion, escapes $6$salt$hash
+      value = re.sub(r'\$(?![({])', r'\\$', value)
       print(f'{key}="{value}"')
 PY
 }

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -566,6 +566,10 @@ class LayerManager:
                 if not silent:
                     log_error(f"[FAIL] {result['required_var']} - REQUIRED but not set (layer: {layer_name})")
                 layer_valid = False
+            elif result["status"] == "conflict":
+                if not silent:
+                    log_error(f"[FAIL] {result['message']} (layer: {layer_name})")
+                layer_valid = False
             elif result["status"] == "invalid_value":
                 if not silent:
                     log_error(f"[FAIL] {var}={result['value']} (invalid value, layer: {layer_name})")

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -566,6 +566,10 @@ class LayerManager:
                 if not silent:
                     log_error(f"[FAIL] {result['required_var']} - REQUIRED but not set (layer: {layer_name})")
                 layer_valid = False
+            elif result["status"] == "invalid_value":
+                if not silent:
+                    log_error(f"[FAIL] {var}={result['value']} (invalid value, layer: {layer_name})")
+                layer_valid = False
             elif result["status"] == "validated" and not result["valid"]:
                 if not silent:
                     log_error(f"[FAIL] {var}={result['value']} (invalid, layer: {layer_name})")

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -2,8 +2,9 @@ import os
 import argparse
 import yaml
 from debian import deb822
+from typing import Dict
 from validators import parse_validator
-from env_types import EnvVariable, EnvLayer, MetadataContainer, XEnv
+from env_types import EnvVariable, EnvLayer, MetadataContainer, XEnv, VariableResolver
 from logger import log_error
 
 
@@ -109,6 +110,7 @@ SUPPORTED_FIELD_PATTERNS = {
     XEnv.var_valid_pattern(): {"type": "pattern", "description": "Variable validation rule"},
     XEnv.var_set_pattern(): {"type": "pattern", "description": "Whether to auto-set variable"},
     XEnv.var_anchor_pattern(): {"type": "pattern", "description": "Anchor mapping for environment variable"},
+    f"{XEnv.VAR_PREFIX}*-Triggers": {"type": "pattern", "description": "Trigger rules to set other variables when this variable matches a value"},
 
     # Variable requirements (any environment variables)
     XEnv.var_requires(): {"type": "single", "description": "Environment variables required by this layer"},
@@ -158,6 +160,7 @@ class Metadata:
 
     def __init__(self, filepath, doc_mode: bool = False):
         self.filepath = filepath
+        self._resolved_vars = None
         raw_metadata = self._load_metadata(filepath)
 
         # Create the container (applies placeholder substitutions internally)
@@ -379,6 +382,10 @@ class Metadata:
 
     def validate_env_vars(self):
         """Validate environment variables - now broken into focused smaller methods"""
+        # Always recompute resolved vars per validation pass to reflect current
+        # environment and any trigger-injected values from prior steps.
+        self._resolved_vars = None
+
         # Schema validation first
         schema_errors = self._validate_schema()
         if schema_errors:
@@ -444,64 +451,107 @@ class Metadata:
         """Validate all defined variables from the metadata."""
         results = {}
 
-        for var_name, env_var in self._container.variables.items():
+        # Use resolved variables so trigger-injected values (and their validation metadata)
+        # are validated, not just the base metadata defaults.
+        if self._resolved_vars is None:
+            resolver = VariableResolver()
+            variable_definitions = {name: [env_var] for name, env_var in self._container.variables.items()}
+            self._resolved_vars = resolver.resolve(variable_definitions)
+        else:
+            resolver = VariableResolver()
+
+        # Validate the resolved set (includes triggers) plus any original definitions
+        # that did not resolve (e.g., Set: n/skip) so required checks still apply.
+        combined_vars: Dict[str, EnvVariable] = dict(self._resolved_vars)
+        for name, env_var in self._container.variables.items():
+            if name not in combined_vars:
+                combined_vars[name] = env_var
+
+        # Also validate injected trigger definitions even if they do not "win" resolution,
+        # to catch invalid trigger values.
+        trigger_defs = resolver._collect_trigger_definitions(self._resolved_vars)
+
+        # Build a list of all definitions to validate, deduped by (name, value, policy, position)
+        seen_defs = set()
+        all_vars: List[EnvVariable] = []
+        for env_var in combined_vars.values():
+            key = (env_var.name, env_var.value, env_var.set_policy, env_var.position)
+            if key not in seen_defs:
+                seen_defs.add(key)
+                all_vars.append(env_var)
+        for defs in trigger_defs.values():
+            for env_var in defs:
+                key = (env_var.name, env_var.value, env_var.set_policy, env_var.position)
+                if key not in seen_defs:
+                    seen_defs.add(key)
+                    all_vars.append(env_var)
+
+        for env_var in all_vars:
+            var_name = env_var.name
             current_value = os.environ.get(var_name)
 
             # First check for unsupported validation rules - this should always be checked
             var_short_name = var_name.split('_')[-1].upper()
             valid_rule_str = self._container.raw_metadata.get(XEnv.var_valid(var_short_name))
             if valid_rule_str and not self._is_supported_rule(valid_rule_str):
-                # Unsupported validation rule trumps everything else
-                results[f"DEFAULT_{var_name}"] = self._result_builder.unsupported_validation_rule(
-                    var_name, valid_rule_str, env_var.value, env_var.required
-                )
+                if results.get(var_name, {}).get("status") != "invalid_value":
+                    results[var_name] = self._result_builder.unsupported_validation_rule(
+                        var_name, valid_rule_str, env_var.value, env_var.required
+                    )
                 continue
 
             # Check if this variable was lazy and did not win
             if env_var.set_policy == "lazy" and current_value is not None and current_value != env_var.value:
-                results[var_name] = self._result_builder.lazy_overridden(current_value, env_var.required)
+                if var_name not in results:
+                    results[var_name] = self._result_builder.lazy_overridden(current_value, env_var.required)
                 continue
 
             # Validate default value if validator exists and can be set
             if env_var.validator and env_var.should_set_in_environment():
                 validation_errors = env_var.validate_value()
                 if validation_errors:
-                    results[f"DEFAULT_{var_name}"] = self._result_builder.build_result(
-                        status="invalid_default",
-                        value=env_var.value,
-                        valid=False,
-                        required=env_var.required,
-                        rule=env_var.get_validation_description(),
-                        message=f"Default value '{env_var.value}' for {var_name} doesn't match validation rule '{env_var.get_validation_description()}'"
-                    )
+                    # Preserve first invalid_value result (e.g., triggered)
+                    if results.get(var_name, {}).get("status") != "invalid_value":
+                        results[var_name] = self._result_builder.build_result(
+                            status="invalid_value",
+                            value=env_var.value,
+                            valid=False,
+                            required=env_var.required,
+                            rule=env_var.get_validation_description(),
+                            message=f"Resolved value '{env_var.value}' for {var_name} doesn't match validation rule '{env_var.get_validation_description()}'"
+                        )
 
             # Check if required variable is missing
             if env_var.required and current_value is None:
-                results[var_name] = self._result_builder.missing_required()
+                if var_name not in results:
+                    results[var_name] = self._result_builder.missing_required()
             elif current_value is not None:
                 # Variable is set - validate it
                 if env_var.validator:
                     validation_errors = env_var.validate_value(current_value)
                     is_valid = len(validation_errors) == 0
-                    results[var_name] = self._result_builder.variable_validated(
-                        current_value, is_valid, env_var.required, env_var.get_validation_description(),
-                        validation_errors if not is_valid else None
-                    )
+                    if var_name not in results:
+                        results[var_name] = self._result_builder.variable_validated(
+                            current_value, is_valid, env_var.required, env_var.get_validation_description(),
+                            validation_errors if not is_valid else None
+                        )
                 else:
-                    results[var_name] = self._result_builder.build_result(
-                        status="no_validation",
-                        value=current_value,
-                        valid=None,
-                        required=env_var.required
-                    )
+                    if var_name not in results:
+                        results[var_name] = self._result_builder.build_result(
+                            status="no_validation",
+                            value=current_value,
+                            valid=None,
+                            required=env_var.required
+                        )
             else:
                 # Variable not set and not required
-                results[var_name] = self._result_builder.build_result(
-                    status="optional_unset",
-                    value=None,
-                    valid=None,
-                    required=False
-                )
+                if var_name not in results:
+                    results[var_name] = self._result_builder.build_result(
+                        status="optional_unset",
+                        value=None,
+                        valid=None,
+                        required=False
+                    )
 
         return results
 
@@ -518,18 +568,22 @@ class Metadata:
                 valid_rule = valid_rules[i] if i < len(valid_rules) else None
 
                 if current_value is None:
-                    results[f"REQUIRED_{req_var}"] = self._result_builder.build_result(
-                        status="missing_required_var",
-                        valid=False,
-                        required=True,
-                        required_var=req_var
-                    )
+                    key = f"REQUIRED_{req_var}"
+                    if key not in results:
+                        results[key] = self._result_builder.build_result(
+                            status="missing_required_var",
+                            valid=False,
+                            required=True,
+                            required_var=req_var
+                        )
                 else:
                     # Required variable is set - validate it if rule provided
                     if valid_rule and not self._is_supported_rule(valid_rule):
-                        results[f"REQUIRED_{req_var}"] = self._result_builder.unsupported_validation_rule(
-                            req_var, valid_rule, current_value, True
-                        )
+                        key = f"REQUIRED_{req_var}"
+                        if key not in results:
+                            results[key] = self._result_builder.unsupported_validation_rule(
+                                req_var, valid_rule, current_value, True
+                            )
                     elif valid_rule:
                         validation_errors = []
                         is_valid = True
@@ -540,25 +594,29 @@ class Metadata:
                         except:
                             is_valid = False
 
-                        result = self._result_builder.build_result(
-                            status="required_validated",
-                            value=current_value,
-                            valid=is_valid,
-                            required=True,
-                            rule=valid_rule,
-                            required_var=req_var
-                        )
-                        if not is_valid and validation_errors:
-                            result['errors'] = validation_errors
-                        results[f"REQUIRED_{req_var}"] = result
+                        key = f"REQUIRED_{req_var}"
+                        if key not in results:
+                            result = self._result_builder.build_result(
+                                status="required_validated",
+                                value=current_value,
+                                valid=is_valid,
+                                required=True,
+                                rule=valid_rule,
+                                required_var=req_var
+                            )
+                            if not is_valid and validation_errors:
+                                result['errors'] = validation_errors
+                            results[key] = result
                     else:
-                        results[f"REQUIRED_{req_var}"] = self._result_builder.build_result(
-                            status="required_no_validation",
-                            value=current_value,
-                            valid=None,
-                            required=True,
-                            required_var=req_var
-                        )
+                        key = f"REQUIRED_{req_var}"
+                        if key not in results:
+                            results[key] = self._result_builder.build_result(
+                                status="required_no_validation",
+                                value=current_value,
+                                valid=None,
+                                required=True,
+                                required_var=req_var
+                            )
 
         return results
 
@@ -575,36 +633,44 @@ class Metadata:
                 valid_rule = valid_rules[i] if i < len(valid_rules) else None
 
                 if current_value is None:
-                    results[f"OPTIONAL_{opt_var}"] = self._result_builder.build_result(
-                        status="optional_var_unset",
-                        valid=None,
-                        required=False,
-                        optional_var=opt_var
-                    )
-                else:
-                    # Optional variable is set - validate it if rule provided
-                    if valid_rule and not self._is_supported_rule(valid_rule):
-                        results[f"OPTIONAL_{opt_var}"] = self._result_builder.unsupported_validation_rule(
-                            opt_var, valid_rule, current_value, False
-                        )
-                    elif valid_rule:
-                        is_valid = self._is_valid(current_value, valid_rule)
-                        results[f"OPTIONAL_{opt_var}"] = self._result_builder.build_result(
-                            status="optional_validated",
-                            value=current_value,
-                            valid=is_valid,
-                            required=False,
-                            rule=valid_rule,
-                            optional_var=opt_var
-                        )
-                    else:
-                        results[f"OPTIONAL_{opt_var}"] = self._result_builder.build_result(
-                            status="optional_no_validation",
-                            value=current_value,
+                    key = f"OPTIONAL_{opt_var}"
+                    if key not in results:
+                        results[key] = self._result_builder.build_result(
+                            status="optional_var_unset",
                             valid=None,
                             required=False,
                             optional_var=opt_var
                         )
+                else:
+                    # Optional variable is set - validate it if rule provided
+                    if valid_rule and not self._is_supported_rule(valid_rule):
+                        key = f"OPTIONAL_{opt_var}"
+                        if key not in results:
+                            results[key] = self._result_builder.unsupported_validation_rule(
+                                opt_var, valid_rule, current_value, False
+                            )
+                    elif valid_rule:
+                        is_valid = self._is_valid(current_value, valid_rule)
+                        key = f"OPTIONAL_{opt_var}"
+                        if key not in results:
+                            results[key] = self._result_builder.build_result(
+                                status="optional_validated",
+                                value=current_value,
+                                valid=is_valid,
+                                required=False,
+                                rule=valid_rule,
+                                optional_var=opt_var
+                            )
+                    else:
+                        key = f"OPTIONAL_{opt_var}"
+                        if key not in results:
+                            results[key] = self._result_builder.build_result(
+                                status="optional_no_validation",
+                                value=current_value,
+                                valid=None,
+                                required=False,
+                                optional_var=opt_var
+                            )
 
         return results
 
@@ -746,17 +812,31 @@ class Metadata:
         if self._container.variables and not self._container.var_prefix:
             raise ValueError("Cannot process variables: X-Env-Var-* fields are defined but X-Env-VarPrefix is missing. Environment variables require a valid prefix.")
 
-        for var_name, env_var in self._container.variables.items():
-            current_value = os.environ.get(var_name)
+        resolver = VariableResolver()
+        variable_definitions = {name: [env_var] for name, env_var in self._container.variables.items()}
+        resolved_vars = resolver.resolve(variable_definitions)
+        self._resolved_vars = resolved_vars
 
-            if env_var.set_policy == "skip":
+        ordered_vars = sorted(resolved_vars.values(), key=lambda env_var: env_var.position)
+
+        for env_var in ordered_vars:
+            var_name = env_var.name
+            current_value = os.environ.get(var_name)
+            policy = env_var.set_policy
+
+            if policy == "already_set":
+                results[var_name] = {
+                    "status": "already_set",
+                    "value": current_value,
+                    "reason": "already in environment"
+                }
+            elif policy == "skip":
                 results[var_name] = {
                     "status": "no_set_policy",
                     "value": None,
                     "reason": "marked as Set: false/skip"
                 }
-            elif env_var.set_policy == "force":
-                # Always overwrite, but skip if empty and rule allows unset
+            elif policy == "force":
                 if env_var.validator and hasattr(env_var.validator, 'allow_unset') and env_var.validator.allow_unset and not env_var.value.strip():
                     results[var_name] = {
                         "status": "no_set_policy",
@@ -770,7 +850,7 @@ class Metadata:
                         "value": env_var.value,
                         "reason": "Set: force override"
                     }
-            elif env_var.set_policy == "immediate":
+            elif policy == "immediate":
                 if current_value is None:
                     os.environ[var_name] = env_var.value
                     results[var_name] = {
@@ -784,8 +864,7 @@ class Metadata:
                         "value": current_value,
                         "reason": "already in environment"
                     }
-            elif env_var.set_policy == "lazy":
-                # For single-layer context, treat like immediate
+            elif policy == "lazy":
                 if current_value is None:
                     if env_var.validator and hasattr(env_var.validator, 'allow_unset') and env_var.validator.allow_unset and not env_var.value.strip():
                         results[var_name] = {
@@ -808,6 +887,12 @@ class Metadata:
                     }
 
         return results
+
+    def get_resolved_env_vars(self) -> Dict[str, EnvVariable]:
+        """Return the most recently resolved env vars (includes trigger injections)."""
+        if self._resolved_vars is not None:
+            return self._resolved_vars
+        return self._container.get_settable_variables()
 
     def get_layer_info(self):
         """Get layer management information from X-Env-Layer metadata fields"""
@@ -1021,7 +1106,7 @@ def _main(args):
                 elif result["status"] == "missing_var_prefix":
                     log_error(result['message'])
                     has_validation_errors = True
-                elif result["status"] == "invalid_default":
+                elif result["status"] == "invalid_value":
                     log_error(result['message'])
                     has_validation_errors = True
                 elif result["status"] == "orphaned_attributes":
@@ -1034,7 +1119,8 @@ def _main(args):
             # Write key=value pairs to file if write_out is specified
             if hasattr(args, 'write_out') and args.write_out:
                 try:
-                    settable_vars = {name: var.value for name, var in meta._container.get_settable_variables().items()}
+                    resolved_vars = meta.get_resolved_env_vars()
+                    settable_vars = {name: var.value for name, var in resolved_vars.items() if var.should_set_in_environment()}
                     with open(args.write_out, 'w') as f:
                         for fullvar, default_value in settable_vars.items():
                             env_value = os.environ.get(fullvar, default_value)
@@ -1102,7 +1188,7 @@ def _main(args):
             elif result["status"] == "missing_var_prefix":
                 print(f"[ERROR] {result['message']}")
                 has_errors = True
-            elif result["status"] == "invalid_default":
+            elif result["status"] == "invalid_value":
                 print(f"[ERROR] {result['message']}")
                 has_errors = True
             elif result["status"] == "orphaned_attributes":

--- a/templates/docs/html/layer-index.html
+++ b/templates/docs/html/layer-index.html
@@ -22,11 +22,11 @@
         h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { color: #333; text-decoration: none; }
 
         /* AsciiDoc table styling */
-        .tableblock { width: 100%; border-collapse: collapse; margin: 1.25em 0; }
+        .tableblock { width: 100%; border-collapse: collapse; margin: 1.25em 0; table-layout: fixed; }
         .tableblock.frame-all { border: 1px solid #dedede; }
         .tableblock.grid-all th, .tableblock.grid-all td { border: 1px solid #dedede; }
         .tableblock.stretch { width: 100%; }
-        .tableblock th, .tableblock td { padding: 0.5625em 0.625em; text-align: left; vertical-align: top; }
+        .tableblock th, .tableblock td { padding: 0.5625em 0.625em; text-align: left; vertical-align: top; overflow-wrap: anywhere; word-break: break-word; }
         .tableblock th { background: #f8f9fa; font-weight: 600; color: rgba(0,0,0,.8); }
         .tableblock tbody tr:nth-child(even) { background: #f8f8f7; }
         .tableblock p { margin: 0; line-height: 1.6; }

--- a/test/layer/trigger-env-override.yaml
+++ b/test/layer/trigger-env-override.yaml
@@ -1,0 +1,20 @@
+# METABEGIN
+# X-Env-Layer-Name: trigger-env-override
+# X-Env-Layer-Category: test
+# X-Env-Layer-Desc: Trigger should fire on env/CLI override and fail validation
+# X-Env-Layer-Version: 1.0.0
+# X-Env-VarPrefix: trig
+#
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Desc: Provisioning map selector
+# X-Env-Var-pmap-Required: n
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: force
+#
+# X-Env-Var-rootfs_type: ext4
+# X-Env-Var-rootfs_type-Desc: Root filesystem type
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: ext4,btrfs
+# X-Env-Var-rootfs_type-Set: y
+# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_trig_pmap=shouldfail policy=force
+# METAEND

--- a/test/layer/trigger-same-layer-force.yaml
+++ b/test/layer/trigger-same-layer-force.yaml
@@ -1,0 +1,20 @@
+# METABEGIN
+# X-Env-Layer-Name: trigger-same-layer-force
+# X-Env-Layer-Category: test
+# X-Env-Layer-Desc: Trigger injects target defined later with force; later definition must win
+# X-Env-Layer-Version: 1.0.0
+# X-Env-VarPrefix: trig2
+#
+# X-Env-Var-rootfs_type: ext4
+# X-Env-Var-rootfs_type-Desc: Root filesystem type
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: ext4,btrfs
+# X-Env-Var-rootfs_type-Set: y
+# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_trig2_pmap=crypt policy=force
+#
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Desc: Provisioning map
+# X-Env-Var-pmap-Required: n
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: force
+# METAEND

--- a/test/meta/invalid-conflicts-conditional-not-eq.yaml
+++ b/test/meta/invalid-conflicts-conditional-not-eq.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-conditional-not-eq-invalid
+# X-Env-Layer-Desc: Not-equals conflicts should fail when values differ
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm5
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class!=cm4
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/invalid-conflicts-conditional.yaml
+++ b/test/meta/invalid-conflicts-conditional.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-conditional-invalid
+# X-Env-Layer-Desc: Conditional conflicts should fail when condition matches
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm4
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class=cm4
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/invalid-conflicts-malformed.yaml
+++ b/test/meta/invalid-conflicts-malformed.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-malformed
+# X-Env-Layer-Desc: Malformed conflict specs should fail to parse
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm4
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class!=
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/invalid-conflicts-operator.yaml
+++ b/test/meta/invalid-conflicts-operator.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-operator
+# X-Env-Layer-Desc: Unsupported operator should fail to parse
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm4
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class==cm4
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/invalid-conflicts-skip.yaml
+++ b/test/meta/invalid-conflicts-skip.yaml
@@ -1,0 +1,17 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-skip
+# X-Env-Layer-Desc: Conflicts ignored when no resolved value exists
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-a: 1
+# X-Env-Var-a-Set: n
+# X-Env-Var-a-Conflicts: b
+#
+# X-Env-Var-b: 2
+# X-Env-Var-b-Set: n
+# X-Env-Var-b-Conflicts: a
+# METAEND
+
+conflict_skip:
+  a: ${IGconf_cft_a}
+  b: ${IGconf_cft_b}

--- a/test/meta/invalid-conflicts-when-missing-conflict.yaml
+++ b/test/meta/invalid-conflicts-when-missing-conflict.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-missing-conflict
+# X-Env-Layer-Desc: when= missing conflict should fail parsing
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: zstd
+# X-Env-Var-compression-Conflicts: when=zstd
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when_missing_conflict:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/invalid-conflicts-when-missing-value.yaml
+++ b/test/meta/invalid-conflicts-when-missing-value.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-missing-value
+# X-Env-Layer-Desc: when= missing value should fail parsing
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: zstd
+# X-Env-Var-compression-Conflicts: when= rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when_missing_value:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/invalid-conflicts-when-multiline-missing-conflict.yaml
+++ b/test/meta/invalid-conflicts-when-multiline-missing-conflict.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-multiline-missing-conflict
+# X-Env-Layer-Desc: when= on its own line should fail parsing
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: zstd
+# X-Env-Var-compression-Conflicts: when=zstd
+#  rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when_multiline_missing_conflict:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/invalid-conflicts-when.yaml
+++ b/test/meta/invalid-conflicts-when.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-invalid
+# X-Env-Layer-Desc: when= conflict should fail if value matches
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: zstd
+# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/invalid-conflicts.yaml
+++ b/test/meta/invalid-conflicts.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-invalid
+# X-Env-Layer-Desc: Conflicting variables should fail validation
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-a: 1
+# X-Env-Var-a-Conflicts: b
+#
+# X-Env-Var-b: 2
+# X-Env-Var-b-Conflicts: a
+# METAEND
+
+conflict:
+  a: ${IGconf_cft_a}
+  b: ${IGconf_cft_b}

--- a/test/meta/invalid-trigger-env-override.yaml
+++ b/test/meta/invalid-trigger-env-override.yaml
@@ -1,0 +1,24 @@
+# METABEGIN
+# X-Env-Layer-Name: trigger-invalid-env-override
+# X-Env-Layer-Desc: Trigger should fire when source var is overridden via env/config
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: image
+#
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Desc: Provisioning Map identifier for this image layout.
+# X-Env-Var-pmap-Required: n
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: force
+#
+# X-Env-Var-rootfs_type: ext4
+# X-Env-Var-rootfs_type-Desc: Root filesystem type.
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: ext4,btrfs
+# X-Env-Var-rootfs_type-Set: y
+# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=invalid policy=force
+# METAEND
+
+trigger_invalid_env_override:
+  rootfs_type: ${IGconf_image_rootfs_type}
+  pmap: ${IGconf_image_pmap}

--- a/test/meta/invalid-trigger-validation-force.yaml
+++ b/test/meta/invalid-trigger-validation-force.yaml
@@ -1,0 +1,44 @@
+# METABEGIN
+# X-Env-Layer-Name: trigger-invalid-force
+# X-Env-Layer-Desc: Trigger sets target to invalid value while target is force-set
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: image
+#
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Desc: Provisioning Map identifier for this image layout.
+#  All partitions will be provisioned unencrypted (clear).
+#  Root partition will be provisioned encrypted (crypt).
+# X-Env-Var-pmap-Required: n
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: force
+# 
+# X-Env-Var-rootfs_type: btrfs
+# X-Env-Var-rootfs_type-Desc: Root filesystem type.
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: ext4,btrfs
+# X-Env-Var-rootfs_type-Set: y
+# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=invalid policy=force
+#
+# X-Env-Var-boot_part_size: 100%
+# X-Env-Var-boot_part_size-Desc: Boot partition size
+# X-Env-Var-boot_part_size-Required: n
+# X-Env-Var-boot_part_size-Valid: size
+# X-Env-Var-boot_part_size-Set: y
+#
+# X-Env-Var-root_part_size: 100%
+# X-Env-Var-root_part_size-Desc: Root partition size
+# X-Env-Var-root_part_size-Required: n
+# X-Env-Var-root_part_size-Valid: size
+# X-Env-Var-root_part_size-Set: y
+#
+# X-Env-Var-assetdir: ${DIRECTORY}
+# X-Env-Var-assetdir-Desc: Image specific asset directory
+# X-Env-Var-assetdir-Required: n
+# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Set: y
+# METAEND
+
+trigger_invalid_force:
+  rootfs_type: ${IGconf_image_rootfs_type}
+  pmap: ${IGconf_image_pmap}

--- a/test/meta/invalid-trigger-validation.yaml
+++ b/test/meta/invalid-trigger-validation.yaml
@@ -1,0 +1,24 @@
+# METABEGIN
+# X-Env-Layer-Name: trigger-invalid
+# X-Env-Layer-Desc: Trigger sets value that violates validation
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: image
+#
+# X-Env-Var-rootfs_type: btrfs
+# X-Env-Var-rootfs_type-Desc: Root filesystem type
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: ext4,btrfs
+# X-Env-Var-rootfs_type-Set: y
+# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=overridden policy=force
+#
+# X-Env-Var-pmap: clear
+# X-Env-Var-pmap-Desc: Provisioning map identifier for this image layout
+# X-Env-Var-pmap-Required: n
+# X-Env-Var-pmap-Valid: clear,crypt
+# X-Env-Var-pmap-Set: force
+# METAEND
+
+trigger_invalid:
+  rootfs_type: ${IGconf_image_rootfs_type}
+  pmap: ${IGconf_image_pmap}

--- a/test/meta/invalid-trigger-verb.yaml
+++ b/test/meta/invalid-trigger-verb.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: invalid-trigger-action
+# X-Env-Layer-Desc: Unknown trigger action should fail parsing
+# X-Env-VarPrefix: trigbad
+#
+# X-Env-Var-mode: fast
+# X-Env-Var-mode-Triggers: fast notify IG_SHOULD_NOT_EXIST=1
+# METAEND
+
+invalid: true
+

--- a/test/meta/lint-invalid-rule-list.yaml
+++ b/test/meta/lint-invalid-rule-list.yaml
@@ -7,4 +7,3 @@
 # X-Env-VarRequires: HOME
 # X-Env-VarRequires-Valid: regex:^(
 # METAEND
-

--- a/test/meta/lint-invalid-var-rule.yaml
+++ b/test/meta/lint-invalid-var-rule.yaml
@@ -7,4 +7,3 @@
 # X-Env-Var-host: localhost
 # X-Env-Var-host-Valid: regex:[
 # METAEND
-

--- a/test/meta/lint-missing-layer-name.yaml
+++ b/test/meta/lint-missing-layer-name.yaml
@@ -5,4 +5,3 @@
 # X-Env-VarPrefix: lint
 # X-Env-Var-foo: bar
 # METAEND
-

--- a/test/meta/lint-no-metadata.yaml
+++ b/test/meta/lint-no-metadata.yaml
@@ -1,2 +1,1 @@
 # This file intentionally has no X-Env-* fields to trigger no_metadata_fields lint.
-

--- a/test/meta/lint-orphan-attr.yaml
+++ b/test/meta/lint-orphan-attr.yaml
@@ -6,4 +6,3 @@
 # X-Env-VarPrefix: lint
 # X-Env-Var-hostname-Desc: Hostname description without base var
 # METAEND
-

--- a/test/meta/lint-unsupported-layer-field.yaml
+++ b/test/meta/lint-unsupported-layer-field.yaml
@@ -7,4 +7,3 @@
 # X-Env-VarPrefix: lint
 # X-Env-Var-foo: bar
 # METAEND
-

--- a/test/meta/lint-unsupported-var-field.yaml
+++ b/test/meta/lint-unsupported-var-field.yaml
@@ -6,4 +6,3 @@
 # X-Env-VarPrefix: lint
 # X-Env-Var-hostname-UnknownAttr: nope
 # METAEND
-

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -161,6 +161,11 @@ run_test "valid-all-types-validate" \
     0 \
     "Valid all-types metadata should validate successfully"
 
+run_test "valid-conflicts" \
+    "ig metadata --validate ${META}/valid-conflicts.yaml" \
+    0 \
+    "Conflicting vars should pass when only one side is set"
+
 run_test "valid-all-types-set" \
     "ig metadata --parse ${META}/valid-all-types.yaml" \
     0 \
@@ -226,6 +231,16 @@ run_test "invalid-unsupported-validate" \
     "ig metadata --validate ${META}/invalid-unsupported-fields.yaml" \
     1 \
     "Metadata with unsupported fields should fail to validate"
+
+run_test "invalid-conflicts" \
+    "ig metadata --validate ${META}/invalid-conflicts.yaml" \
+    1 \
+    "Conflicting vars both set should fail to validate"
+
+run_test "invalid-conflicts-skip" \
+    "ig metadata --validate ${META}/invalid-conflicts-skip.yaml" \
+    0 \
+    "Conflicts ignored when a side has no resolved value"
 
 run_test "invalid-trigger-action-parse" \
     "ig metadata --parse ${META}/invalid-trigger-verb.yaml" \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -166,6 +166,16 @@ run_test "valid-conflicts" \
     0 \
     "Conflicting vars should pass when only one side is set"
 
+run_test "valid-conflicts-conditional" \
+    "ig metadata --validate ${META}/valid-conflicts-conditional.yaml" \
+    0 \
+    "Conditional conflicts should pass when condition does not match"
+
+run_test "valid-conflicts-conditional-not-eq" \
+    "ig metadata --validate ${META}/valid-conflicts-conditional-not-eq.yaml" \
+    0 \
+    "Not-equals conflicts should pass when values are equal"
+
 run_test "valid-all-types-set" \
     "ig metadata --parse ${META}/valid-all-types.yaml" \
     0 \
@@ -236,6 +246,26 @@ run_test "invalid-conflicts" \
     "ig metadata --validate ${META}/invalid-conflicts.yaml" \
     1 \
     "Conflicting vars both set should fail to validate"
+
+run_test "invalid-conflicts-conditional" \
+    "ig metadata --validate ${META}/invalid-conflicts-conditional.yaml" \
+    1 \
+    "Conditional conflicts should fail when condition matches"
+
+run_test "invalid-conflicts-conditional-not-eq" \
+    "ig metadata --validate ${META}/invalid-conflicts-conditional-not-eq.yaml" \
+    1 \
+    "Not-equals conflicts should fail when values differ"
+
+run_test "invalid-conflicts-malformed" \
+    "ig metadata --parse ${META}/invalid-conflicts-malformed.yaml" \
+    1 \
+    "Malformed conflict specifiers should fail to parse"
+
+run_test "invalid-conflicts-operator" \
+    "ig metadata --parse ${META}/invalid-conflicts-operator.yaml" \
+    1 \
+    "Unsupported conflict operators should fail to parse"
 
 run_test "invalid-conflicts-skip" \
     "ig metadata --validate ${META}/invalid-conflicts-skip.yaml" \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -182,6 +182,17 @@ run_test "set-policies-set" \
     0 \
     "Set policies should work correctly"
 
+cleanup_env
+run_test "triggers-parse" \
+    "cleanup_env; ig metadata --parse ${META}/valid-triggers.yaml" \
+    0 \
+    "Triggers metadata should parse successfully"
+
+run_test "triggers-set" \
+    'cleanup_env; TMP_OUT=$(mktemp); ig metadata --parse ${META}/valid-triggers.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_FAST=\"1\"$" "$TMP_OUT" && grep "^IG_TRIG_FAST2=\"1\"$" "$TMP_OUT" && grep "^IG_TRIG_ANY=\"1\"$" "$TMP_OUT" && grep "^IG_TRIG_EXTRA=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
+    0 \
+    "Trigger rules should set target variables (including inherited condition actions)"
+
 # ---------------------------------------------------------------------------
 print_header "INVALID METADATA TESTS"
 
@@ -215,6 +226,29 @@ run_test "invalid-unsupported-validate" \
     "ig metadata --validate ${META}/invalid-unsupported-fields.yaml" \
     1 \
     "Metadata with unsupported fields should fail to validate"
+
+run_test "invalid-trigger-action-parse" \
+    "ig metadata --parse ${META}/invalid-trigger-verb.yaml" \
+    1 \
+    "Unknown trigger action should fail to parse"
+
+cleanup_env
+run_test "invalid-trigger-validation" \
+    "cleanup_env; ig metadata --parse ${META}/invalid-trigger-validation.yaml" \
+    1 \
+    "Trigger-injected value that violates validation should fail to parse"
+
+cleanup_env
+run_test "invalid-trigger-validation-force" \
+    "cleanup_env; ig metadata --parse ${META}/invalid-trigger-validation-force.yaml" \
+    1 \
+    "Trigger-injected invalid value should fail even when target has force policy"
+
+cleanup_env
+run_test "invalid-trigger-env-override" \
+    "cleanup_env; IGconf_image_rootfs_type=btrfs ig metadata --parse ${META}/invalid-trigger-env-override.yaml" \
+    1 \
+    "Trigger should fire when source var is overridden via env/config"
 
 run_test "invalid-yaml-syntax-layer-validate" \
     "ig metadata --validate ${META}/invalid-yaml-syntax.yaml" \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -176,6 +176,31 @@ run_test "valid-conflicts-conditional-not-eq" \
     0 \
     "Not-equals conflicts should pass when values are equal"
 
+run_test "valid-conflicts-when" \
+    "ig metadata --validate ${META}/valid-conflicts-when.yaml" \
+    0 \
+    "when= conflicts should pass when condition does not match"
+
+run_test "valid-conflicts-when-multiple" \
+    "ig metadata --validate ${META}/valid-conflicts-when-multiple.yaml" \
+    0 \
+    "when= conflicts should coexist with other conflicts"
+
+run_test "valid-conflicts-when-whitespace" \
+    "ig metadata --validate ${META}/valid-conflicts-when-whitespace.yaml" \
+    0 \
+    "when= conflicts should tolerate extra whitespace"
+
+run_test "valid-conflicts-when-igconf" \
+    "ig metadata --validate ${META}/valid-conflicts-when-igconf.yaml" \
+    0 \
+    "when= conflicts should accept IGconf_ targets"
+
+run_test "valid-conflicts-when-multiline" \
+    "ig metadata --validate ${META}/valid-conflicts-when-multiline.yaml" \
+    0 \
+    "when= conflicts should support multi-line specs"
+
 run_test "valid-all-types-set" \
     "ig metadata --parse ${META}/valid-all-types.yaml" \
     0 \
@@ -256,6 +281,26 @@ run_test "invalid-conflicts-conditional-not-eq" \
     "ig metadata --validate ${META}/invalid-conflicts-conditional-not-eq.yaml" \
     1 \
     "Not-equals conflicts should fail when values differ"
+
+run_test "invalid-conflicts-when" \
+    "ig metadata --validate ${META}/invalid-conflicts-when.yaml" \
+    1 \
+    "when= conflicts should fail when condition matches"
+
+run_test "invalid-conflicts-when-missing-value" \
+    "ig metadata --parse ${META}/invalid-conflicts-when-missing-value.yaml" \
+    1 \
+    "when= conflicts should fail when value is missing"
+
+run_test "invalid-conflicts-when-missing-conflict" \
+    "ig metadata --parse ${META}/invalid-conflicts-when-missing-conflict.yaml" \
+    1 \
+    "when= conflicts should fail when conflict is missing"
+
+run_test "invalid-conflicts-when-multiline-missing-conflict" \
+    "ig metadata --parse ${META}/invalid-conflicts-when-multiline-missing-conflict.yaml" \
+    1 \
+    "when= conflicts should fail when split across lines"
 
 run_test "invalid-conflicts-malformed" \
     "ig metadata --parse ${META}/invalid-conflicts-malformed.yaml" \

--- a/test/meta/valid-conflicts-conditional-not-eq.yaml
+++ b/test/meta/valid-conflicts-conditional-not-eq.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-conditional-not-eq-valid
+# X-Env-Layer-Desc: Not-equals conflicts should pass when values are equal
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm4
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class!=cm4
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/valid-conflicts-conditional.yaml
+++ b/test/meta/valid-conflicts-conditional.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-conditional-valid
+# X-Env-Layer-Desc: Conditional conflicts only apply when condition matches
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-class: cm5
+# X-Env-Var-test: foo
+# X-Env-Var-test-Conflicts: class=cm4
+# METAEND
+
+conflict_conditional:
+  class: ${IGconf_cft_class}
+  test: ${IGconf_cft_test}

--- a/test/meta/valid-conflicts-when-igconf.yaml
+++ b/test/meta/valid-conflicts-when-igconf.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-igconf
+# X-Env-Layer-Desc: when= works with explicit IGconf_ target
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: none
+# X-Env-Var-compression-Conflicts: when=zstd IGconf_cft_rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: btrfs
+# METAEND
+
+conflict_when_igconf:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/valid-conflicts-when-multiline.yaml
+++ b/test/meta/valid-conflicts-when-multiline.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-multiline
+# X-Env-Layer-Desc: when= conflicts should support multi-line specs
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: none
+# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4,
+#  when=lzma rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: btrfs
+# METAEND
+
+conflict_when_multiline:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/valid-conflicts-when-multiple.yaml
+++ b/test/meta/valid-conflicts-when-multiple.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-multiple
+# X-Env-Layer-Desc: when= can be combined with other conflicts
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: none
+# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4,rootfs_type!=btrfs
+#
+# X-Env-Var-rootfs_type: btrfs
+# METAEND
+
+conflict_when_multiple:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/valid-conflicts-when-whitespace.yaml
+++ b/test/meta/valid-conflicts-when-whitespace.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-whitespace
+# X-Env-Layer-Desc: when= allows extra whitespace before conflict
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: none
+# X-Env-Var-compression-Conflicts: when=zstd    rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when_whitespace:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/valid-conflicts-when.yaml
+++ b/test/meta/valid-conflicts-when.yaml
@@ -1,0 +1,14 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-when-valid
+# X-Env-Layer-Desc: when= conflict should be ignored if value does not match
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-compression: none
+# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4
+#
+# X-Env-Var-rootfs_type: ext4
+# METAEND
+
+conflict_when:
+  compression: ${IGconf_cft_compression}
+  rootfs_type: ${IGconf_cft_rootfs_type}

--- a/test/meta/valid-conflicts.yaml
+++ b/test/meta/valid-conflicts.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: test-conflict-valid
+# X-Env-Layer-Desc: Conflicting variables - only one set
+# X-Env-VarPrefix: cft
+#
+# X-Env-Var-a: 1
+# X-Env-Var-a-Conflicts: b
+#
+# X-Env-Var-b:
+# X-Env-Var-b-Conflicts: a
+# METAEND
+
+conflict:
+  a: ${IGconf_cft_a}
+  b: ${IGconf_cft_b}

--- a/test/meta/valid-triggers.yaml
+++ b/test/meta/valid-triggers.yaml
@@ -1,0 +1,23 @@
+# METABEGIN
+# X-Env-Layer-Name: test-triggers
+# X-Env-Layer-Desc: Trigger-based variable injections
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: trig
+#
+# X-Env-Var-mode: fast
+# X-Env-Var-mode-Desc: Execution mode
+# X-Env-Var-mode-Valid: fast,slow
+# X-Env-Var-mode-Triggers: fast set IG_TRIG_FAST=1 policy=force
+#  set IG_TRIG_FAST2=1
+#  set IG_TRIG_ANY=1 policy=lazy
+#
+# X-Env-Var-extra: on
+# X-Env-Var-extra-Desc: Another variable to prove unconditional triggers
+# X-Env-Var-extra-Triggers: set IG_TRIG_EXTRA=1 policy=immediate
+# METAEND
+
+triggers:
+  mode: ${IGconf_trig_mode}
+  extra: ${IGconf_trig_extra}
+


### PR DESCRIPTION
This change-set brings new config features to rpi-image-gen:

### Triggers
A trigger (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value.

### Conflicts
Variable conflicts (X-Env-Var-*-Conflicts) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value.

These features allow layers to perform dynamic actions at build time and allow authors to dictate / control build-time behaviour from layer metadata, simplifying layer scripts.

The change-set also includes stricter handling of `$` in config variable assignments which is called out clearly in the docs.