### PR TITLE
Engine and layer updates

### DIFF
--- a/device/cm4/device.yaml
+++ b/device/cm4/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm4
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM4 specific device layer
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: device
 #
@@ -14,10 +14,18 @@
 # X-Env-Var-class-Valid: keywords:cm4
 # X-Env-Var-class-Set: y
 #
+# X-Env-Var-variant: 8G
+# X-Env-Var-variant-Desc: Device variant
+# X-Env-Var-variant-Required: n
+# X-Env-Var-variant-Valid: 8G,16G,32G,lite
+# X-Env-Var-variant-Set: lazy
+# X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
+#
 # X-Env-Var-storage_type: emmc
-# X-Env-Var-storage_type-Desc: Storage media type.
+# X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
+#  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: sd,emmc
+# X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
 # X-Env-Var-storage_type-Set: y
 #
 # X-Env-Var-assetdir: ${DIRECTORY}

--- a/device/cm5/device.yaml
+++ b/device/cm5/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM5 specific device layer
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-linux-2712
 # X-Env-Layer-Provides: device
 #
@@ -14,10 +14,18 @@
 # X-Env-Var-class-Valid: keywords:cm5
 # X-Env-Var-class-Set: y
 #
+# X-Env-Var-variant: 16G
+# X-Env-Var-variant-Desc: Device variant
+# X-Env-Var-variant-Required: n
+# X-Env-Var-variant-Valid: 16G,32G,64G,lite
+# X-Env-Var-variant-Set: lazy
+# X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
+#
 # X-Env-Var-storage_type: emmc
-# X-Env-Var-storage_type-Desc: Storage media type.
+# X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
+#  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: sd,nvme,emmc
+# X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
 # X-Env-Var-storage_type-Set: y
 #
 # X-Env-Var-assetdir: ${DIRECTORY}

--- a/device/pi4/device.yaml
+++ b/device/pi4/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi4
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 4 specific device layer
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: device
 #
@@ -15,9 +15,10 @@
 # X-Env-Var-class-Set: y
 #
 # X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Desc: Storage media type.
+# X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
+#  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: keywords:sd
+# X-Env-Var-storage_type-Valid: sd,usb
 # X-Env-Var-storage_type-Set: y
 #
 # X-Env-Var-assetdir: ${DIRECTORY}

--- a/device/pi5/device.yaml
+++ b/device/pi5/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 5 specific device layer
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-linux-2712
 # X-Env-Layer-Provides: device
 #
@@ -15,9 +15,10 @@
 # X-Env-Var-class-Set: y
 #
 # X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Desc: Pi5 storage type.
+# X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
+#  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: sd,nvme
+# X-Env-Var-storage_type-Valid: sd,nvme,usb
 # X-Env-Var-storage_type-Set: y
 #
 # X-Env-Var-assetdir: ${DIRECTORY}

--- a/device/zero2w/device.yaml
+++ b/device/zero2w/device.yaml
@@ -15,7 +15,8 @@
 # X-Env-Var-class-Set: y
 #
 # X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Desc: Storage media type.
+# X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
+#  by the OS.
 # X-Env-Var-storage_type-Required: n
 # X-Env-Var-storage_type-Valid: keywords:sd
 # X-Env-Var-storage_type-Set: y

--- a/docs/layer/device-base.html
+++ b/docs/layer/device-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>device-base</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.3.0</span>
+        <span class="badge">v1.3.1</span>
         <p>Device defaults.</p>
     </div>
     <div class="section">
@@ -220,11 +220,15 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Device storage media type.</td>
+                    <td>Declares the storage media the image is intended
+ for, as seen by the OS. For example, an NVMe backed disk connected via USB
+ would be usb, not nvme. Whether this restricts where the image can be written
+ to or booted from depends on downstream layers. This may seed the configuration
+ and behaviour of run-time boot media detection, device provisioning, etc.</td>
                     <td>
                            <code>sd</code>
                     </td>
-                    <td>Must be one of: sd, emmc, nvme</td>
+                    <td>Must be one of: sd, emmc, nvme, usb</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>

--- a/docs/layer/image-base.html
+++ b/docs/layer/image-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-base</h1>
         <span class="badge">image</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v2.0.2</span>
         <p>Default image settings and build attributes.</p>
     </div>
     <div class="section">
@@ -236,14 +236,16 @@ Unless otherwise stated, the following apply to all image layers:</p>
                 </tr>
                 <tr>
                     <td><code>IGconf_image_compression</code></td>
-                    <td>Identifier for the compression scheme used when
- deploying image assets.</td>
+                    <td>Compression scheme for generating image assets.
+ Downstream layer implementation-dependent. For example, a downstream layer
+ may define available schemes when creating filesystem images (e.g. erofs,
+ squashfs).</td>
                     <td>
                            <code>none</code>
                     </td>
-                    <td>Must be one of: none, zstd</td>
+                    <td>Non-empty string value</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>
@@ -328,6 +330,17 @@ Unless otherwise stated, the following apply to all image layers:</p>
                     <td>Non-empty string value</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_image_rootfs_type</code></td>
+                    <td>Root filesystem type. Implementation-dependent.</td>
+                    <td>
+                           <code>none</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
                     </td>
                 </tr>
             </tbody>

--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -386,7 +386,8 @@
     <div class="section">
         <h2>Configuration Variables</h2>
         <p><strong>References:</strong>
-        <code>IGconf_device_storage_type</code>
+        <code>IGconf_device_storage_type</code>, 
+        <code>IGconf_device_class</code>
         </p>
         <p><strong>Declares</strong> (prefix: <code>image</code>):</p>
         <table>

--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-rota</h1>
         <span class="badge">image</span>
-        <span class="badge">v4.1.0</span>
+        <span class="badge">v4.2.0</span>
         <p>Immutable GPT A/B layout for rotational OTA updates,
  boot/system redundancy, and a shared persistent data partition.</p>
     </div>
@@ -468,11 +468,11 @@
  table. If enabled, the first 8MB of the boot storage device will be
  protected. Applies to eMMC only.</td>
                     <td>
-                           <code>y</code>
+                           <code>n</code>
                     </td>
-                    <td>Non-empty string value</td>
+                    <td>Boolean value - accepts: true/false, 1/0, yes/no, y/n (case insensitive)</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
             </tbody>

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -195,10 +195,10 @@ Variable values support dynamic placeholders:
 
 Triggers (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
 
-* Conditional: `VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional: `when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
 * Unconditional: `set TARGET=VALUE [policy=force|immediate|lazy]`
 
-Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate`.
+Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified. Negative matching in the condition is not supported.
 
 Lint will fail on:
 
@@ -209,7 +209,7 @@ Lint will fail on:
 Usage:
 
 * Target values are preserved as literals with no expansion.
-* Triggers are collected from every definition of a variable across all layers. They are evaluated once against the variable’s final resolved value, so triggers declared in upstream layers still fire even if a downstream layer overrides the variable’s value. Suppression of upstream triggers is not supported.
+* Triggers are collected from every definition of a variable across all layers. Because trigger rules are merged across layers and evaluated against the effective final (resolved) value, upstream layer trigger rules can still fire when a downstream layer declaration determines that final value. Suppression of upstream triggers is not supported.
 
 ==== Supported actions
 
@@ -224,7 +224,7 @@ Usage:
 
 * Conditional:
 +
-`# X-Env-Var-rootfs_type-Triggers: btrfs set IG_HAS_BTRFS_PROGS=1 policy=force`
+`# X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force`
 
 * Unconditional:
 +
@@ -234,15 +234,15 @@ Usage:
 +
 ```
 # X-Env-Var-rootfs_type-Triggers:
-#  btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
-#  ext4 set IG_HAS_E2FS_PROGS=1 policy=force
+#  when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
+#  when=ext4 set IG_HAS_E2FS_PROGS=1 policy=force
 ```
 
 * Multiple actions sharing the same condition (omit the condition on following line to inherit the previous one):
 +
 ```
 # X-Env-Var-rootfs_type-Triggers:
-#  ext4 set IG_HAS_E2FS_PROGS=1
+#  when=ext4 set IG_HAS_E2FS_PROGS=1
 #  set IG_HAS_SRCBUILD=1
 ```
 
@@ -268,7 +268,7 @@ Within a single layer:
 # X-Env-Var-deploy_type: develop
 # X-Env-Var-deploy_type-Valid: develop,production
 # X-Env-Var-deploy_type-Set: y
-# X-Env-Var-deploy_type-Triggers: production set IGconf_image_pmap=crypt policy=force
+# X-Env-Var-deploy_type-Triggers: when=production set IGconf_image_pmap=crypt policy=force
 
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Valid: clear,crypt

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -195,10 +195,12 @@ Variable values support dynamic placeholders:
 
 Triggers (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
 
-* Conditional: `when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional (same variable): `when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional (cross-variable): `when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional (cross-variable): `when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
 * Unconditional: `set TARGET=VALUE [policy=force|immediate|lazy]`
 
-Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified. Negative matching in the condition is not supported.
+For same-variable conditions, matching is an exact string comparison against the source variable's resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable's resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.
 
 Lint will fail on:
 
@@ -238,14 +240,6 @@ Usage:
 #  when=ext4 set IG_HAS_E2FS_PROGS=1 policy=force
 ```
 
-* Multiple actions sharing the same condition (omit the condition on following line to inherit the previous one):
-+
-```
-# X-Env-Var-rootfs_type-Triggers:
-#  when=ext4 set IG_HAS_E2FS_PROGS=1
-#  set IG_HAS_SRCBUILD=1
-```
-
 [IMPORTANT]
 ====
 Trigger precedence is determined by layer order, not file order.
@@ -260,16 +254,16 @@ Within a single layer:
 * If a trigger sets a variable, the trigger’s injected definition sits after the layer’s base definition and will override that variable’s declaration in the same layer (force/immediate/lazy still apply). A later layer can still override the trigger.
 ====
 
-==== Example (same layer):
+==== Example (same layer)
 
 ```
 # X-Env-VarPrefix: image
-
+#
 # X-Env-Var-deploy_type: develop
 # X-Env-Var-deploy_type-Valid: develop,production
 # X-Env-Var-deploy_type-Set: y
 # X-Env-Var-deploy_type-Triggers: when=production set IGconf_image_pmap=crypt policy=force
-
+#
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Valid: clear,crypt
 # X-Env-Var-pmap-Set: y
@@ -277,6 +271,23 @@ Within a single layer:
 ```
 
 If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGconf_image_pmap=crypt` after the source variable, overriding `pmap: clear` in the same layer. A later layer defining `IGconf_image_pmap` with `force` would still win over the trigger.
+
+==== Example (cross-var across layers)
+
+```
+# X-Env-VarPrefix: device
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Valid: sd,emmc
+# X-Env-Var-storage_type-Set: y
+```
+```
+# X-Env-VarPrefix: image
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y
+```
+
+If `IGconf_device_storage_type` resolves to `emmc`, the trigger injects `IGconf_image_ptable_protect=y`.
+
 
 === Variable Conflicts
 

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -160,7 +160,8 @@
 <ul class="sectlevel3">
 <li><a href="#_supported_actions">Supported actions</a></li>
 <li><a href="#_examples">Examples</a></li>
-<li><a href="#_example_same_layer">Example (same layer):</a></li>
+<li><a href="#_example_same_layer">Example (same layer)</a></li>
+<li><a href="#_example_cross_var_across_layers">Example (cross-var across layers)</a></li>
 </ul>
 </li>
 <li><a href="#_variable_conflicts">Variable Conflicts</a></li>
@@ -575,7 +576,13 @@ mmdebstrap:
 <div class="ulist">
 <ul>
 <li>
-<p>Conditional: <code>VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+<p>Conditional (same variable): <code>when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+<li>
+<p>Conditional (cross-variable): <code>when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+<li>
+<p>Conditional (cross-variable): <code>when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
 </li>
 <li>
 <p>Unconditional: <code>set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
@@ -583,7 +590,7 @@ mmdebstrap:
 </ul>
 </div>
 <div class="paragraph">
-<p>Rules are exact string matches on the resolved source variable value. Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code>.</p>
+<p>For same-variable conditions, matching is an exact string comparison against the source variable&#8217;s resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable&#8217;s resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code> if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.</p>
 </div>
 <div class="paragraph">
 <p>Lint will fail on:</p>
@@ -610,7 +617,7 @@ mmdebstrap:
 <p>Target values are preserved as literals with no expansion.</p>
 </li>
 <li>
-<p>Triggers are collected from every definition of a variable across all layers. They are evaluated once against the variable’s final resolved value, so triggers declared in upstream layers still fire even if a downstream layer overrides the variable’s value. Suppression of upstream triggers is not supported.</p>
+<p>Triggers are collected from every definition of a variable across all layers. Because trigger rules are merged across layers and evaluated against the effective final (resolved) value, upstream layer trigger rules can still fire when a downstream layer declaration determines that final value. Suppression of upstream triggers is not supported.</p>
 </li>
 </ul>
 </div>
@@ -648,7 +655,7 @@ mmdebstrap:
 <li>
 <p>Conditional:</p>
 <div class="paragraph">
-<p><code># X-Env-Var-rootfs_type-Triggers: btrfs set IG_HAS_BTRFS_PROGS=1 policy=force</code></p>
+<p><code># X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force</code></p>
 </div>
 </li>
 <li>
@@ -662,18 +669,8 @@ mmdebstrap:
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code># X-Env-Var-rootfs_type-Triggers:
-#  btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
-#  ext4 set IG_HAS_E2FS_PROGS=1 policy=force</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>Multiple actions sharing the same condition (omit the condition on following line to inherit the previous one):</p>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code># X-Env-Var-rootfs_type-Triggers:
-#  ext4 set IG_HAS_E2FS_PROGS=1
-#  set IG_HAS_SRCBUILD=1</code></pre>
+#  when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
+#  when=ext4 set IG_HAS_E2FS_PROGS=1 policy=force</code></pre>
 </div>
 </div>
 </li>
@@ -721,16 +718,16 @@ mmdebstrap:
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_same_layer"><a class="anchor" href="#_example_same_layer"></a><a class="link" href="#_example_same_layer">Example (same layer):</a></h4>
+<h4 id="_example_same_layer"><a class="anchor" href="#_example_same_layer"></a><a class="link" href="#_example_same_layer">Example (same layer)</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code># X-Env-VarPrefix: image
-
+#
 # X-Env-Var-deploy_type: develop
 # X-Env-Var-deploy_type-Valid: develop,production
 # X-Env-Var-deploy_type-Set: y
-# X-Env-Var-deploy_type-Triggers: production set IGconf_image_pmap=crypt policy=force
-
+# X-Env-Var-deploy_type-Triggers: when=production set IGconf_image_pmap=crypt policy=force
+#
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Valid: clear,crypt
 # X-Env-Var-pmap-Set: y
@@ -739,6 +736,27 @@ mmdebstrap:
 </div>
 <div class="paragraph">
 <p>If <code>IGconf_image_deploy_type</code> resolves to <code>production</code>, the trigger injects <code>IGconf_image_pmap=crypt</code> after the source variable, overriding <code>pmap: clear</code> in the same layer. A later layer defining <code>IGconf_image_pmap</code> with <code>force</code> would still win over the trigger.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_cross_var_across_layers"><a class="anchor" href="#_example_cross_var_across_layers"></a><a class="link" href="#_example_cross_var_across_layers">Example (cross-var across layers)</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># X-Env-VarPrefix: device
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Valid: sd,emmc
+# X-Env-Var-storage_type-Set: y</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code># X-Env-VarPrefix: image
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>If <code>IGconf_device_storage_type</code> resolves to <code>emmc</code>, the trigger injects <code>IGconf_image_ptable_protect=y</code>.</p>
 </div>
 </div>
 </div>

--- a/docs/layer/rpi-cm4.html
+++ b/docs/layer/rpi-cm4.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-cm4</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi CM4 specific device layer</p>
     </div>
     <div class="section">
@@ -160,12 +160,24 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><code>IGconf_device_variant</code></td>
+                    <td>Device variant</td>
+                    <td>
+                           <code>8G</code>
+                    </td>
+                    <td>Must be one of: 8G, 16G, 32G, lite</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                    </td>
+                </tr>
+                <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Storage media type.</td>
+                    <td>Storage media the image is intended for, as seen
+ by the OS.</td>
                     <td>
                            <code>emmc</code>
                     </td>
-                    <td>Must be one of: sd, emmc</td>
+                    <td>Must be one of: emmc, sd, nvme, usb</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/rpi-cm5.html
+++ b/docs/layer/rpi-cm5.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-cm5</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi CM5 specific device layer</p>
     </div>
     <div class="section">
@@ -184,12 +184,24 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><code>IGconf_device_variant</code></td>
+                    <td>Device variant</td>
+                    <td>
+                           <code>16G</code>
+                    </td>
+                    <td>Must be one of: 16G, 32G, 64G, lite</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                    </td>
+                </tr>
+                <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Storage media type.</td>
+                    <td>Storage media the image is intended for, as seen
+ by the OS.</td>
                     <td>
                            <code>emmc</code>
                     </td>
-                    <td>Must be one of: sd, nvme, emmc</td>
+                    <td>Must be one of: emmc, sd, nvme, usb</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/rpi4.html
+++ b/docs/layer/rpi4.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi4</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi 4 specific device layer</p>
     </div>
     <div class="section">
@@ -161,11 +161,12 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Storage media type.</td>
+                    <td>Storage media the image is intended for, as seen
+ by the OS.</td>
                     <td>
                            <code>sd</code>
                     </td>
-                    <td>Must be one of: sd</td>
+                    <td>Must be one of: sd, usb</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/rpi5.html
+++ b/docs/layer/rpi5.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi5</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi 5 specific device layer</p>
     </div>
     <div class="section">
@@ -185,11 +185,12 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Pi5 storage type.</td>
+                    <td>Storage media the image is intended for, as seen
+ by the OS.</td>
                     <td>
                            <code>sd</code>
                     </td>
-                    <td>Must be one of: sd, nvme</td>
+                    <td>Must be one of: sd, nvme, usb</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>

--- a/docs/layer/rpizero2w.html
+++ b/docs/layer/rpizero2w.html
@@ -161,7 +161,8 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_device_storage_type</code></td>
-                    <td>Storage media type.</td>
+                    <td>Storage media the image is intended for, as seen
+ by the OS.</td>
                     <td>
                            <code>sd</code>
                     </td>

--- a/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
+++ b/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-[[ ${IGconf_device_storage_type:?} != emmc ]] && exit 0
+set -eu
+
+[[ ${IGconf_device_storage_type} == emmc ]] || exit 0
 igconf isy image_ptable_protect || exit 0
 
-chroot $1 apt install mmc-utils
+chroot $1 apt install -y mmc-utils
 
 # layer/ab-initramfs has already installed initramfs-tools
 cat <<- 'EOF' > $1/etc/initramfs-tools/hooks/ab-install-files

--- a/image/gpt/ab_userdata/device/emmc-wp.sh
+++ b/image/gpt/ab_userdata/device/emmc-wp.sh
@@ -11,13 +11,6 @@ esac
 
 set -e
 
-# rpi-slot gives us the boot device details by reporting:
-# boot:<device type>:<partition number>
-# blk:<device node>:<UUID>
-# Only issue the protection op if booting from emmc (device type 1).
-set -- $(rpi-slot 2>/dev/null | sed -n '/^boot:/{s/:/ /g; p; q}')
-[ "$2" = 1 ] || exit 0
-
 DEV=/dev/mmcblk0
 
 # GPT entries begin at +8M. Write Protect everything prior.

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -7,7 +7,8 @@
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
-# X-Env-VarRequires: IGconf_device_storage_type
+# X-Env-VarRequires: IGconf_device_storage_type,IGconf_device_class
+# X-Env-VarRequires-Valid: string,regex:^(cm4|pi4|cm5|pi5)$
 #
 # X-Env-VarPrefix: image
 #

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
 #  boot/system redundancy, and a shared persistent data partition.
-# X-Env-Layer-Version: 4.1.0
+# X-Env-Layer-Version: 4.2.0
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
@@ -48,13 +48,16 @@
 # X-Env-Var-pmap-Valid: clear,crypt,cryptslots,cryptdata,crypthybrid
 # X-Env-Var-pmap-Set: y
 #
-# X-Env-Var-ptable_protect: y
+# X-Env-Var-ptable_protect: n
 # X-Env-Var-ptable_protect-Desc: Enable eMMC Power-On Write Protect of the partition
 #  table. If enabled, the first 8MB of the boot storage device will be
 #  protected. Applies to eMMC only.
 # X-Env-Var-ptable_protect-Required: n
-# X-Env-Var-ptable_protect-Valid: string
-# X-Env-Var-ptable_protect-Set: y
+# X-Env-Var-ptable_protect-Valid: bool
+# X-Env-Var-ptable_protect-Set: lazy
+# X-Env-Var-ptable_protect-Conflicts: when=y IGconf_device_storage_type!=emmc
+# X-Env-Var-ptable_protect-Triggers:
+#  when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y policy=lazy
 #
 # METAEND
 ---

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Device defaults.
-# X-Env-Layer-Version: 1.3.0
+# X-Env-Layer-Version: 1.3.1
 # X-Env-Layer-Requires:
 # X-Env-Layer-RequiresProvider: device
 #
@@ -48,9 +48,13 @@
 # X-Env-Var-user1pass-Set: n
 #
 # X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Desc: Device storage media type.
+# X-Env-Var-storage_type-Desc: Declares the storage media the image is intended
+#  for, as seen by the OS. For example, an NVMe backed disk connected via USB
+#  would be usb, not nvme. Whether this restricts where the image can be written
+#  to or booted from depends on downstream layers. This may seed the configuration
+#  and behaviour of run-time boot media detection, device provisioning, etc.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: sd,emmc,nvme
+# X-Env-Var-storage_type-Valid: sd,emmc,nvme,usb
 # X-Env-Var-storage_type-Set: lazy
 #
 # X-Env-Var-sector_size: 512

--- a/layer/base/image-base.yaml
+++ b/layer/base/image-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: image-base
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Default image settings and build attributes.
-# X-Env-Layer-Version: 2.0.1
+# X-Env-Layer-Version: 2.0.2
 # X-Env-Layer-Requires: sys-build-base,sbom-base,target-config,artefact-base,deploy-base
 # X-Env-Layer-RequiresProvider: device
 #
@@ -18,11 +18,13 @@
 # X-Env-Var-suffix-Set: y
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Desc: Identifier for the compression scheme used when
-#  deploying image assets.
+# X-Env-Var-compression-Desc: Compression scheme for generating image assets.
+#  Downstream layer implementation-dependent. For example, a downstream layer
+#  may define available schemes when creating filesystem images (e.g. erofs,
+#  squashfs).
 # X-Env-Var-compression-Required: n
-# X-Env-Var-compression-Valid: none,zstd
-# X-Env-Var-compression-Set: y
+# X-Env-Var-compression-Valid: string
+# X-Env-Var-compression-Set: lazy
 #
 # X-Env-Var-version: ${IGconf_artefact_version}
 # X-Env-Var-version-Desc: Version string of generated images. This always maps
@@ -73,6 +75,12 @@
 # X-Env-Var-assetdir-Required: n
 # X-Env-Var-assetdir-Valid: string
 # X-Env-Var-assetdir-Set: lazy
+#
+# X-Env-Var-rootfs_type: none
+# X-Env-Var-rootfs_type-Desc: Root filesystem type. Implementation-dependent.
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: string
+# X-Env-Var-rootfs_type-Set: n
 #
 # METAEND
 ---

--- a/layer/base/image-base.yaml
+++ b/layer/base/image-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: image-base
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Default image settings and build attributes.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: sys-build-base,sbom-base,target-config,artefact-base,deploy-base
 # X-Env-Layer-RequiresProvider: device
 #
@@ -64,6 +64,7 @@
 # X-Env-Var-provider-Required: n
 # X-Env-Var-provider-Valid: keywords:genimage
 # X-Env-Var-provider-Set: lazy
+# X-Env-Var-provider-Triggers: when=genimage set IG_ENABLE_HOST_GENIMAGE=y
 #
 # X-Env-Var-assetdir: /dev/null
 # X-Env-Var-assetdir-Desc: Image specific asset location. Use this directory

--- a/lib/tools.sh
+++ b/lib/tools.sh
@@ -1,16 +1,35 @@
 #!/bin/bash
 
+# Dynamic package build selection. Typically, X-Env Triggers set defined
+# variables which map to the package registry below. These compoments are
+# built and installed as prerequisites in a reusable mini-sysroot.
+# Can scale as needed, eg move away from bash array to file. Main thing
+# is to retain functionality: vars -> registry -> selection -> action
+readonly -a IG_TOOLS_REGISTRY=(
+   "IG_ENABLE_HOST_GENIMAGE|y|genimage"
+)
+
+collect_build_deps() {
+   local envfile="${1:?missing env file}"
+   local packages=(bdebstrap) # mandatory
+   local var value pkg
+
+   for entry in "${IG_TOOLS_REGISTRY[@]}"; do
+      IFS='|' read -r var value pkg <<< "$entry"
+      if value_read=$(get_var "$var" "$envfile") && [[ "$value_read" == "$value" ]]; then
+         packages+=("$pkg")
+      fi
+   done
+   echo "${packages[*]}"
+}
+
+
 bootstrap_build_tools() {
    : "${ctx[FINALENV]?missing ctx[FINALENV]}"
    : "${IGconf_sys_workroot?missing IGconf_sys_workroot}"
    : "${DEB_BUILD_GNU_TYPE?missing DEB_BUILD_GNU_TYPE}"
 
-   local tools=(bdebstrap)
-   if value=$(get_var IGconf_image_provider "${ctx[FINALENV]}") \
-      && [[ $value == genimage ]]; then
-      tools+=(genimage)
-   fi
-
+   local tools=( $(collect_build_deps "${ctx[FINALENV]}") )
    local destdir="${IGconf_sys_workroot}/${DEB_BUILD_GNU_TYPE}"
    local prefix=/usr
 

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -15,7 +15,7 @@ rpi-image-gen is a metadata-driven build system. Each layer is a YAML file with 
 
 First, `ig config` parses a configuration file (the frontend), handles override variables and produces an env for pipeline to consume.
 
-Second, `ig pipeline` is the entry point for applying a set of layers: it reads an env file produced by the config stage, uses LayerManager to build a dependency order, runs the policy resolver to apply variables and resolve anchors (`@TARGETDIR`, `@IGROOT`, etc) and all variables in the input env, then emits a final env file plus a layer build order.
+Second, `ig pipeline` is the entry point for applying a set of layers: it reads an env file produced by the config stage, uses LayerManager to build a dependency order, runs a schema-only precheck on each layer, runs the policy resolver to apply variables and resolve anchors (`@TARGETDIR`, `@IGROOT`, etc) and all variables in the input env, then validates values against the resolved winning definitions and emits a final env file plus a layer build order.
 
 Additional tooling like `ig metadata` and `ig layer` let you inspect or validate individual layers, while LayerManager discovers every layer under a defined path heirarchy, computes dependency order, checks provider relationships, etc. The top level rpi-image-gen CLI is the main entry point for all tooling and build operations, passing commands directly through to the engine as needed.
 
@@ -41,7 +41,7 @@ Core parser/validator for the `X-Env-*` metadata blocks embedded in layer YAML f
 
 ==  site/env_types.py
 
-Houses shared data structures: EnvVariable, MetadataContainer, XEnv helpers, and the VariableResolver (policy logic for force/immediate/lazy).
+Houses shared data structures: EnvVariable, MetadataContainer, XEnv helpers, and the VariableResolver (policy logic for force/immediate/lazy/skip).
 Also contains the placeholder substitution utilities used during metadata ingestion.
 
 == site/env_resolver.py
@@ -52,11 +52,11 @@ Used by pipeline to perform final variable expansion.
 == site/layer_manager.py
 
 Discovery and introspection of all layers. Walks search roots, parses metadata, maintains the layer registry (self.layers, file paths, tags).
-Provides dependency graph operations (get build order, provider checks, reverse deps), and the user-facing ig CLI (list, describe, etc).
+Provides dependency graph operations (get build order, provider checks, reverse deps), schema checks used by pipeline pre-validation, and the user-facing ig CLI (list, describe, etc).
 
 == site/pipeline.py
 
-Main orchestrator for the application. Loads the base env file produced by config_loader, asks LayerManager for the dependency order, validates layers, runs the policy resolver (VariableResolver) to apply env vars, writes env/order outputs.
+Main orchestrator for the application. Loads the base env file produced by config_loader, asks LayerManager for the dependency order, runs pre-resolution schema validation, runs the policy resolver (VariableResolver) to apply env vars, then validates env values against the resolved winning variable definitions before writing env/order outputs.
 
 == site/validators.py
 

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -966,6 +966,7 @@ class VariableResolver:
         force_defs = [d for d in definitions if d.set_policy == "force"]
         immediate_defs = [d for d in definitions if d.set_policy == "immediate"]
         lazy_defs = [d for d in definitions if d.set_policy == "lazy"]
+        skip_defs = [d for d in definitions if d.set_policy == "skip"]
 
         # Rule a: If any variable is defined as force, use the last force definition
         if force_defs:
@@ -978,6 +979,10 @@ class VariableResolver:
         # Rule c: If lazy, use the last one provided the variable is not set in the env
         elif lazy_defs and var_name not in os.environ:
             return self._get_last_by_position(lazy_defs)
+
+        # Rule d: If only skip, still return one so validation can check required
+        elif skip_defs:
+            return self._get_last_by_position(skip_defs)
 
         # Variable is set in environment or no applicable definitions
         return None

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -394,6 +394,10 @@ class Metadata:
                 unsupported_fields[field_name] = f"'{field_name}' is not supported"
         return unsupported_fields
 
+    def validate_layer_schema(self):
+        """Return layer-schema issues independent of env/value resolution."""
+        return self._check_unsupported_layer_fields()
+
     def validate_env_vars(self):
         """Validate environment variables - now broken into focused smaller methods"""
         # Always recompute resolved vars per validation pass to reflect current

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -545,11 +545,17 @@ class Metadata:
                     continue
 
                 # A unconditional conflict only applies if this variable and the conflicting
-                # variable are both set.
-                this_value = str(env_var.value)
+                # variable are both set. For skip policy, only env counts as "set".
+                if getattr(env_var, "set_policy", None) == "skip":
+                    this_value = str(os.environ.get(var_name, ""))
+                else:
+                    this_value = str(env_var.value)
                 if when_value is not None and this_value != when_value:
                     continue
-                conflict_target_value = str(conflict_var.value)
+                if getattr(conflict_var, "set_policy", None) == "skip":
+                    conflict_target_value = str(os.environ.get(conflict_var_name, ""))
+                else:
+                    conflict_target_value = str(conflict_var.value)
                 if not this_value or not conflict_target_value:
                     continue
 

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -78,7 +78,7 @@ def _pipeline_main(args):
         print(f"Error: {exc}")
         raise SystemExit(1)
 
-    if not _validate_layers(manager, build_order, ignore_missing_required=True):
+    if not _validate_layers(manager, build_order):
         raise SystemExit(1)
 
     applied_values = _apply_layers(manager, build_order)
@@ -224,14 +224,14 @@ def _apply_layers(
     return applied
 
 
-def _validate_layers(manager: LayerManager, layer_names: List[str], *, ignore_missing_required: bool) -> bool:
+def _validate_layers(manager: LayerManager, layer_names: List[str]) -> bool:
     for layer_name in layer_names:
         if layer_name not in manager.layers:
             print(f"Layer '{layer_name}' not found")
             return False
         if not hasattr(manager, "validate_layer"):
             raise AttributeError("LayerManager.validate_layer is required for pipeline validation")
-        if not manager.validate_layer(layer_name, silent=False, ignore_missing_required=ignore_missing_required):
+        if not manager.validate_layer(layer_name, silent=False):
             return False
     return True
 

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -59,7 +59,7 @@ def _pipeline_main(args):
     try:
         manager = LayerManager(search_paths, ['*.yaml'], fail_on_lint=True)
     except ValueError as exc:
-        print(f"Error: {exc}")
+        log_error(f"Error: {exc}")
         raise SystemExit(1)
 
     resolved_layers: List[str] = []
@@ -76,18 +76,22 @@ def _pipeline_main(args):
     try:
         build_order = manager.get_build_order(resolved_layers)
     except ValueError as exc:
-        print(f"Error: {exc}")
+        log_error(f"Error: {exc}")
         raise SystemExit(1)
 
     if not _validate_layers(manager, build_order):
         raise SystemExit(1)
 
-    applied_values = _apply_layers(manager, build_order)
+    try:
+        applied_values = _apply_layers(manager, build_order)
+    except ValueError as exc:
+        log_error(f"Error: {exc}")
+        raise SystemExit(1)
     for var_name, value in applied_values.items():
         assignments[var_name] = value
 
     if not _validate_resolved(manager, build_order):
-        print("Error: Validation failed for target layers")
+        log_error("Error: Validation failed for target layers")
         raise SystemExit(1)
 
     if args.order_out:

--- a/test/configurations/run-tests.sh
+++ b/test/configurations/run-tests.sh
@@ -90,30 +90,65 @@ print_summary() {
 
 print_header "DRY RUN CONFIG TESTS"
 
-run_test "dryconfig1" \
+run_test "dryconfig1 - docker" \
     "printf 'n\n' | $IG build -S ${SRC} -c trixie-rpios-min-docker.yaml -I" \
     0 \
     "Configuration should parse successfully"
 
-run_test "dryconfig2" \
+run_test "dryconfig2 - splash" \
     "printf 'n\n' | $IG build -S ${SRC} -c trixie-ab-min-splash.yaml -I" \
     0 \
     "Configuration should parse successfully"
 
-run_test "dryconfig3" \
+run_test "dryconfig3 - examples/slim" \
     "printf 'n\n' | $IG build -S ${IGTOP}/examples/slim -c pi5-slim.yaml -I" \
     0 \
     "Configuration should parse successfully"
 
-run_test "dryconfig4" \
+run_test "dryconfig4 - examples/webkiosk" \
     "printf 'n\n' | $IG build -S ${IGTOP}/examples/webkiosk -c kiosk.yaml -I" \
     0 \
     "Configuration should parse successfully"
 
-run_test "dryconfig5" \
+run_test "dryconfig5 - examples/ota" \
     "printf 'n\n' | $IG build -S ${IGTOP}/examples/ota -c ota.yaml -I -- IGconf_connect_authkey=rpuak_foobar" \
     0 \
     "Configuration should parse successfully"
+
+run_test "dryconfig5 - cm4" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi-cm4" \
+    0 \
+    "Configuration should parse successfully"
+
+run_test "dryconfig5 - cm4 lite w/emmc" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi-cm4 IGconf_device_variant=lite IGconf_device_storage_type=emmc" \
+    1 \
+    "Configuration should reject cm4 lite w/emmc"
+
+run_test "dryconfig6 - cm5" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi-cm5" \
+    0 \
+    "Configuration should parse successfully"
+
+run_test "dryconfig7 - cm5 lite w/emmc" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi-cm5 IGconf_device_variant=lite IGconf_device_storage_type=emmc" \
+    1 \
+    "Configuration should reject cm5 lite w/emmc"
+
+run_test "dryconfig8 - pi5" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi5" \
+    0 \
+    "Configuration should parse correctly"
+
+run_test "dryconfig9 - pi5 w/emmc" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpi5 IGconf_device_storage_type=emmc" \
+    1 \
+    "Configuration should reject pi5 w/emmc"
+
+run_test "dryconfig10 - zero2w" \
+    "printf 'n\n' | $IG build -c trixie-minbase.yaml -I -- IGconf_device_layer=rpizero2w" \
+    0 \
+    "Configuration should parse correctly"
 
 print_summary
 exit 0

--- a/test/layer/trigger-env-override.yaml
+++ b/test/layer/trigger-env-override.yaml
@@ -16,5 +16,5 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_trig_pmap=shouldfail policy=force
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_trig_pmap=shouldfail policy=force
 # METAEND

--- a/test/layer/trigger-same-layer-force.yaml
+++ b/test/layer/trigger-same-layer-force.yaml
@@ -10,7 +10,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_trig2_pmap=crypt policy=force
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_trig2_pmap=crypt policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Desc: Provisioning map

--- a/test/meta/invalid-trigger-env-override.yaml
+++ b/test/meta/invalid-trigger-env-override.yaml
@@ -16,7 +16,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=invalid policy=force
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=invalid policy=force
 # METAEND
 
 trigger_invalid_env_override:

--- a/test/meta/invalid-trigger-legacy-condition.yaml
+++ b/test/meta/invalid-trigger-legacy-condition.yaml
@@ -1,0 +1,10 @@
+# METABEGIN
+# X-Env-Layer-Name: invalid-trigger-legacy-condition
+# X-Env-Layer-Desc: Legacy conditional trigger syntax should be rejected
+# X-Env-VarPrefix: triglegacy
+#
+# X-Env-Var-mode: fast
+# X-Env-Var-mode-Triggers: fast set IG_SHOULD_NOT_EXIST=1
+# METAEND
+
+invalid: true

--- a/test/meta/invalid-trigger-validation-force.yaml
+++ b/test/meta/invalid-trigger-validation-force.yaml
@@ -18,7 +18,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=invalid policy=force
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=invalid policy=force
 #
 # X-Env-Var-boot_part_size: 100%
 # X-Env-Var-boot_part_size-Desc: Boot partition size

--- a/test/meta/invalid-trigger-validation.yaml
+++ b/test/meta/invalid-trigger-validation.yaml
@@ -10,7 +10,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: btrfs set IGconf_image_pmap=overridden policy=force
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=overridden policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Desc: Provisioning map identifier for this image layout

--- a/test/meta/invalid-trigger-verb.yaml
+++ b/test/meta/invalid-trigger-verb.yaml
@@ -4,7 +4,7 @@
 # X-Env-VarPrefix: trigbad
 #
 # X-Env-Var-mode: fast
-# X-Env-Var-mode-Triggers: fast notify IG_SHOULD_NOT_EXIST=1
+# X-Env-Var-mode-Triggers: when=fast notify IG_SHOULD_NOT_EXIST=1
 # METAEND
 
 invalid: true

--- a/test/meta/invalid-triggers-cross-var-missing-var.yaml
+++ b/test/meta/invalid-triggers-cross-var-missing-var.yaml
@@ -1,0 +1,16 @@
+# METABEGIN
+# X-Env-Layer-Name: invalid-triggers-cross-var-missing-var
+# X-Env-Layer-Desc: Cross-variable trigger should fail if referenced var is missing
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: trigmiss
+#
+# X-Env-Var-switch: off
+# X-Env-Var-switch-Desc: Switch value
+# X-Env-Var-switch-Valid: on,off
+# X-Env-Var-switch-Set: y
+# X-Env-Var-switch-Triggers: when=IGconf_does_not_exist=on set IG_TRIG_SHOULD_NOT_EXIST=1 policy=force
+# METAEND
+
+triggers:
+  switch: ${IGconf_trigmiss_switch}

--- a/test/meta/lint-unknown-xenv-field.yaml
+++ b/test/meta/lint-unknown-xenv-field.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-unknown-xenv-field
+# X-Env-Layer-Desc: Unknown top-level X-Env field should fail lint
+# X-Env-VarPrefix: typo
+# X-Env-Var-foo: bar
+# X-Env-VarRequires: IGconf_typo_foo
+# X-Env-VarRequiresValid: string
+# METAEND
+
+typo:
+  foo: ${IGconf_typo_foo}

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -233,6 +233,11 @@ run_test "triggers-set" \
     0 \
     "Trigger rules should set target variables (including inherited condition actions)"
 
+run_test "triggers-set-skip-env-override" \
+    'cleanup_env; TMP_OUT=$(mktemp); IGconf_trigskip_rootfs_type=btrfs ig metadata --parse ${META}/valid-triggers-skip-env-override.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_SKIP=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
+    0 \
+    "Trigger rules should use effective env values even when Set: n"
+
 # ---------------------------------------------------------------------------
 print_header "INVALID METADATA TESTS"
 
@@ -321,6 +326,11 @@ run_test "invalid-trigger-action-parse" \
     "ig metadata --parse ${META}/invalid-trigger-verb.yaml" \
     1 \
     "Unknown trigger action should fail to parse"
+
+run_test "invalid-trigger-legacy-condition-parse" \
+    "ig metadata --parse ${META}/invalid-trigger-legacy-condition.yaml" \
+    1 \
+    "Legacy trigger condition syntax without when= should fail to parse"
 
 cleanup_env
 run_test "invalid-trigger-validation" \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -458,6 +458,16 @@ run_test "layer-apply-env-valid" \
     0 \
     "Pipeline apply-env should work with valid metadata"
 
+run_test "layer-apply-env-validates-against-resolved-definition" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && \
+     make_pipeline_env "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-resolved-validator-base test-resolved-validator-consumer --path "${PIPELINE_DIR}" --env-out "$TMP_OUT" >/dev/null && \
+     grep -q "^IGconf_device_storage_type=emmc8G$" "$TMP_OUT" && \
+     grep -q "^IGconf_image_size=8G$" "$TMP_OUT"; \
+     status=$?; rm -f "$TMP_ENV" "$TMP_OUT"; exit $status' \
+    0 \
+    "Pipeline should validate storage_type using the resolved consumer definition"
+
 run_test "layer-apply-env-invalid" \
     'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" && \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -238,6 +238,11 @@ run_test "triggers-set-skip-env-override" \
     0 \
     "Trigger rules should use effective env values even when Set: n"
 
+run_test "triggers-set-cross-var-when" \
+    'cleanup_env; TMP_OUT=$(mktemp); IGconf_trigx_mode=fast ig metadata --parse ${META}/valid-triggers-cross-var-when.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_X=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
+    0 \
+    "Trigger rules should support when=VAR=VALUE cross-variable conditions"
+
 # ---------------------------------------------------------------------------
 print_header "INVALID METADATA TESTS"
 
@@ -349,6 +354,11 @@ run_test "invalid-trigger-env-override" \
     "cleanup_env; IGconf_image_rootfs_type=btrfs ig metadata --parse ${META}/invalid-trigger-env-override.yaml" \
     1 \
     "Trigger should fire when source var is overridden via env/config"
+
+run_test "invalid-trigger-cross-var-missing-var" \
+    "cleanup_env; ig metadata --parse ${META}/invalid-triggers-cross-var-missing-var.yaml" \
+    1 \
+    "Cross-variable trigger condition should fail when referenced var is missing"
 
 run_test "invalid-yaml-syntax-layer-validate" \
     "ig metadata --validate ${META}/invalid-yaml-syntax.yaml" \

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -630,5 +630,10 @@ run_test "lint-no-metadata" \
     1 \
     "Lint should fail when no X-Env-* metadata fields exist"
 
+run_test "lint-unknown-xenv-field" \
+    "ig metadata --lint ${META}/lint-unknown-xenv-field.yaml" \
+    1 \
+    "Lint should fail on unknown top-level X-Env-* field names"
+
 cleanup_env
 print_summary

--- a/test/meta/valid-resolved-validator-base.yaml
+++ b/test/meta/valid-resolved-validator-base.yaml
@@ -1,0 +1,16 @@
+# METABEGIN
+# X-Env-Layer-Name: test-resolved-validator-base
+# X-Env-Layer-Desc: Base validator for storage type
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: device
+#
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Desc: Base layer storage media type
+# X-Env-Var-storage_type-Required: n
+# X-Env-Var-storage_type-Valid: sd,emmc,nvme,usb
+# X-Env-Var-storage_type-Set: lazy
+# METAEND
+
+storage:
+  type: ${IGconf_device_storage_type}

--- a/test/meta/valid-resolved-validator-consumer.yaml
+++ b/test/meta/valid-resolved-validator-consumer.yaml
@@ -12,9 +12,9 @@
 # X-Env-Var-storage_type-Valid: sd,nvme,emmc8G,emmc16G,emmc32G
 # X-Env-Var-storage_type-Set: lazy
 # X-Env-Var-storage_type-Triggers:
-#  emmc8G  set IGconf_image_size=8G  policy=force
-#  emmc16G set IGconf_image_size=16G policy=force
-#  emmc32G set IGconf_image_size=32G policy=force
+#  when=emmc8G  set IGconf_image_size=8G  policy=force
+#  when=emmc16G set IGconf_image_size=16G policy=force
+#  when=emmc32G set IGconf_image_size=32G policy=force
 # METAEND
 
 storage:

--- a/test/meta/valid-resolved-validator-consumer.yaml
+++ b/test/meta/valid-resolved-validator-consumer.yaml
@@ -1,0 +1,21 @@
+# METABEGIN
+# X-Env-Layer-Name: test-resolved-validator-consumer
+# X-Env-Layer-Desc: Consumer validator should win at resolution
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Requires: test-resolved-validator-base
+# X-Env-VarPrefix: device
+#
+# X-Env-Var-storage_type: emmc8G
+# X-Env-Var-storage_type-Desc: Consumer layer storage media type
+# X-Env-Var-storage_type-Required: n
+# X-Env-Var-storage_type-Valid: sd,nvme,emmc8G,emmc16G,emmc32G
+# X-Env-Var-storage_type-Set: lazy
+# X-Env-Var-storage_type-Triggers:
+#  emmc8G  set IGconf_image_size=8G  policy=force
+#  emmc16G set IGconf_image_size=16G policy=force
+#  emmc32G set IGconf_image_size=32G policy=force
+# METAEND
+
+storage:
+  type: ${IGconf_device_storage_type}

--- a/test/meta/valid-triggers-cross-var-when.yaml
+++ b/test/meta/valid-triggers-cross-var-when.yaml
@@ -1,0 +1,22 @@
+# METABEGIN
+# X-Env-Layer-Name: test-triggers-cross-var-when
+# X-Env-Layer-Desc: Trigger conditions can reference another variable
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: trigx
+#
+# X-Env-Var-mode: slow
+# X-Env-Var-mode-Desc: Mode selector
+# X-Env-Var-mode-Valid: fast,slow
+# X-Env-Var-mode-Set: y
+#
+# X-Env-Var-switch: off
+# X-Env-Var-switch-Desc: Switch value
+# X-Env-Var-switch-Valid: on,off
+# X-Env-Var-switch-Set: y
+# X-Env-Var-switch-Triggers: when=IGconf_trigx_mode=fast set IG_TRIG_X=1 policy=force
+# METAEND
+
+triggers:
+  mode: ${IGconf_trigx_mode}
+  switch: ${IGconf_trigx_switch}

--- a/test/meta/valid-triggers-skip-env-override.yaml
+++ b/test/meta/valid-triggers-skip-env-override.yaml
@@ -1,0 +1,17 @@
+# METABEGIN
+# X-Env-Layer-Name: test-triggers-skip-env-override
+# X-Env-Layer-Desc: Trigger conditions should use effective env value even with Set: n
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: trigskip
+#
+# X-Env-Var-rootfs_type: none
+# X-Env-Var-rootfs_type-Desc: Root filesystem type
+# X-Env-Var-rootfs_type-Required: n
+# X-Env-Var-rootfs_type-Valid: none,btrfs
+# X-Env-Var-rootfs_type-Set: n
+# X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_TRIG_SKIP=1 policy=force
+# METAEND
+
+triggers:
+  rootfs_type: ${IGconf_trigskip_rootfs_type}

--- a/test/meta/valid-triggers.yaml
+++ b/test/meta/valid-triggers.yaml
@@ -8,9 +8,9 @@
 # X-Env-Var-mode: fast
 # X-Env-Var-mode-Desc: Execution mode
 # X-Env-Var-mode-Valid: fast,slow
-# X-Env-Var-mode-Triggers: fast set IG_TRIG_FAST=1 policy=force
-#  set IG_TRIG_FAST2=1
-#  set IG_TRIG_ANY=1 policy=lazy
+# X-Env-Var-mode-Triggers: when=fast set IG_TRIG_FAST=1 policy=force
+#  when=fast set IG_TRIG_FAST2=1
+#  when=fast set IG_TRIG_ANY=1 policy=lazy
 #
 # X-Env-Var-extra: on
 # X-Env-Var-extra-Desc: Another variable to prove unconditional triggers


### PR DESCRIPTION
Variable validation wasn't actually using the final/resolved Valid spec. Fixing this exposed a couple of edge cases, now plugged. Other improvements naturally fell out of these code-path changes.

Variable Triggers can now fire conditionally, e.g.

same variable: `when=VALUE set TARGET=VALUE [policy=...]`
cross-variable: `when=VAR=VALUE set TARGET=VALUE [policy=...]`

This is quite a powerful feature because it further enables layer metadata to dictate/drive build-time logic.

More linting improvements made to error out on unknown X-Env fields

Typos and and clarification fixes were made in several layers to address valid queries raised via GH tickets.

The introduction of Conflicts and Triggers have meant that various layers have been able to gain tighter controls and smarter default logic.

Device layers are able to better declare their supported storage types.

Test harness has some more dry-run config tests added.

This change-set is large but brings further substantial improvements to the tool.