### PR TITLE
Do not overwrite an existing fstasb, instead prepend to the existing fstab

### DIFF
--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -8,6 +8,7 @@ ROOTUUID="$3"
 
 case $LABEL in
    ROOT)
+      FSTABCONTENTS=$(<"$IMAGEMOUNTPATH/etc/fstab")
       case $IGconf_image_rootfs_type in
          ext4)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
@@ -26,6 +27,7 @@ EOF
       cat << EOF >> $IMAGEMOUNTPATH/etc/fstab
 UUID=${BOOTUUID} /boot/firmware  vfat defaults,rw,noatime,errors=remount-ro 0 2
 EOF
+      echo $FSTABCONTENTS >> "$IMAGEMOUNTPATH/etc/fstab"
       ;;
    BOOT)
       sed -i "s|root=\([^ ]*\)|root=UUID=${ROOTUUID}|" $IMAGEMOUNTPATH/cmdline.txt


### PR DESCRIPTION
This fix prevents the basic mbr setup from clobbering any fstab modifications in the generated image when it writes the ROOTUUID and BOOTUUID out to the file.

Instead, the script now reads the existing fstab from the image mount path and appends it back afterwards.

The effect is that the contents of the base image fstab persists into the final image, appended after the generated boot and root images.  This allows a generated image to change default parameters of other fstab entries (e.g. changing the size of the tmpfs, etc) without having the image generation process clobber it without warning.