### PR TITLE
Better resolution of triggers, better defaults for CM lite builds

### DIFF
--- a/device/cm4/device.yaml
+++ b/device/cm4/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm4
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM4 specific device layer
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 1.2.0
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: device
 #
@@ -20,13 +20,14 @@
 # X-Env-Var-variant-Valid: 8G,16G,32G,lite
 # X-Env-Var-variant-Set: lazy
 # X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
+# X-Env-Var-variant-Triggers: when=lite set IGconf_device_storage_type=sd policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
 #  by the OS.
 # X-Env-Var-storage_type-Required: n
 # X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
-# X-Env-Var-storage_type-Set: y
+# X-Env-Var-storage_type-Set: lazy
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory

--- a/device/cm5/device.yaml
+++ b/device/cm5/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM5 specific device layer
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 1.2.0
 # X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-linux-2712
 # X-Env-Layer-Provides: device
 #
@@ -20,13 +20,14 @@
 # X-Env-Var-variant-Valid: 16G,32G,64G,lite
 # X-Env-Var-variant-Set: lazy
 # X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
+# X-Env-Var-variant-Triggers: when=lite set IGconf_device_storage_type=sd policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
 #  by the OS.
 # X-Env-Var-storage_type-Required: n
 # X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
-# X-Env-Var-storage_type-Set: y
+# X-Env-Var-storage_type-Set: lazy
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -245,7 +245,7 @@ Usage:
 Trigger precedence is determined by layer order, not file order.
 
 * Variable declarations in the same layer share that layer's position.
-* If a trigger sets a variable, it adds a definition for the target variable, e.g. at 'position + 0.01'.
+* If a trigger sets a variable, it adds a new definition for the target variable at the same layer position.
 * Any definition of that target variable from a later layer (higher position) wins via the normal force/immediate/lazy policy rules.
 
 Within a single layer:

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -692,7 +692,7 @@ mmdebstrap:
 <p>Variable declarations in the same layer share that layer&#8217;s position.</p>
 </li>
 <li>
-<p>If a trigger sets a variable, it adds a definition for the target variable, e.g. at 'position + 0.01'.</p>
+<p>If a trigger sets a variable, it adds a new definition for the target variable at the same layer position.</p>
 </li>
 <li>
 <p>Any definition of that target variable from a later layer (higher position) wins via the normal force/immediate/lazy policy rules.</p>

--- a/docs/layer/rpi-cm4.html
+++ b/docs/layer/rpi-cm4.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-cm4</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.1.0</span>
+        <span class="badge">v1.2.0</span>
         <p>Raspberry Pi CM4 specific device layer</p>
     </div>
     <div class="section">
@@ -179,7 +179,7 @@
                     </td>
                     <td>Must be one of: emmc, sd, nvme, usb</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>

--- a/docs/layer/rpi-cm5.html
+++ b/docs/layer/rpi-cm5.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-cm5</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.1.0</span>
+        <span class="badge">v1.2.0</span>
         <p>Raspberry Pi CM5 specific device layer</p>
     </div>
     <div class="section">
@@ -203,7 +203,7 @@
                     </td>
                     <td>Must be one of: emmc, sd, nvme, usb</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -42,6 +42,7 @@ Core parser/validator for the `X-Env-*` metadata blocks embedded in layer YAML f
 ==  site/env_types.py
 
 Houses shared data structures: EnvVariable, MetadataContainer, XEnv helpers, and the VariableResolver (policy logic for force/immediate/lazy/skip).
+VariableResolver also evaluates trigger injections to a fixed point: resolve -> collect trigger definitions -> re-resolve until the injected definition set is stable, with a hard iteration cap to fail safely on non-converging trigger cycles.
 Also contains the placeholder substitution utilities used during metadata ingestion.
 
 == site/env_resolver.py

--- a/test/meta/fixtures/trigger-cascade-cross-layer/device-base.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/device-base.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: cascade-device-base
+# X-Env-Layer-Desc: Device base defaults
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: cascade
+# X-Env-Var-variant: none
+# X-Env-Var-variant-Valid: none,lite,8G
+# X-Env-Var-variant-Set: lazy
+# X-Env-Var-storage_type: sd
+# X-Env-Var-storage_type-Valid: sd,emmc
+# X-Env-Var-storage_type-Set: lazy
+# METAEND

--- a/test/meta/fixtures/trigger-cascade-cross-layer/device-cm4.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/device-cm4.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: cascade-device-cm4
+# X-Env-Layer-Desc: Device layer overrides storage default
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Requires: cascade-device-base
+# X-Env-VarPrefix: cascade
+# X-Env-Var-variant: 8G
+# X-Env-Var-variant-Valid: none,lite,8G
+# X-Env-Var-variant-Set: lazy
+# X-Env-Var-variant-Triggers: when=lite set IGconf_cascade_storage_type=sd policy=lazy
+# X-Env-Var-storage_type: emmc
+# X-Env-Var-storage_type-Valid: sd,emmc
+# X-Env-Var-storage_type-Set: lazy
+# METAEND

--- a/test/meta/fixtures/trigger-cascade-cross-layer/image-base.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/image-base.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: cascade-image-base
+# X-Env-Layer-Desc: Base image defaults
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Requires: cascade-device-base
+# X-Env-VarPrefix: cascade
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Valid: bool
+# X-Env-Var-ptable_protect-Set: lazy
+# METAEND

--- a/test/meta/fixtures/trigger-cascade-cross-layer/image-rota.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/image-rota.yaml
@@ -1,0 +1,12 @@
+# METABEGIN
+# X-Env-Layer-Name: cascade-image-rota
+# X-Env-Layer-Desc: Image trigger keyed on effective storage type
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Requires: cascade-image-base,cascade-device-cm4
+# X-Env-VarPrefix: cascade
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Valid: bool
+# X-Env-Var-ptable_protect-Set: lazy
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type=emmc set IGconf_cascade_ptable_protect=y policy=lazy
+# METAEND

--- a/test/meta/valid-triggers-fixpoint-cascade.yaml
+++ b/test/meta/valid-triggers-fixpoint-cascade.yaml
@@ -1,0 +1,29 @@
+# METABEGIN
+# X-Env-Layer-Name: test-triggers-fixpoint-cascade
+# X-Env-Layer-Desc: Cascading triggers should be re-evaluated to a fixed point
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: cascade
+#
+# X-Env-Var-variant: normal
+# X-Env-Var-variant-Desc: Device variant
+# X-Env-Var-variant-Valid: normal,lite
+# X-Env-Var-variant-Set: lazy
+# X-Env-Var-variant-Triggers: when=lite set IGconf_cascade_storage_type=sd policy=lazy
+#
+# X-Env-Var-storage_type: emmc
+# X-Env-Var-storage_type-Desc: Storage type
+# X-Env-Var-storage_type-Valid: emmc,sd
+# X-Env-Var-storage_type-Set: lazy
+#
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Desc: Partition table protection
+# X-Env-Var-ptable_protect-Valid: bool
+# X-Env-Var-ptable_protect-Set: lazy
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type=emmc set IGconf_cascade_ptable_protect=y policy=lazy
+# METAEND
+---
+trigger_fixpoint:
+  variant: ${IGconf_cascade_variant}
+  storage: ${IGconf_cascade_storage_type}
+  ptable: ${IGconf_cascade_ptable_protect}


### PR DESCRIPTION
Triggers now resolve (`set`) injections properly.
Layer metadata for CM4 and CM5 now declares a sensible default storage type.