### PR TITLE
Build variable registry and Layer-Sets support

### DIFF
--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -114,6 +114,8 @@ Generators must write a complete layer to the output path. A trivial generator c
 
 `X-Env-Layer-Generator`: If dynamic, the generator invoked by the loader
 
+`X-Env-Layer-Sets`: Space-separated KEY=VALUE pairs injected into the build environment when this layer is present
+
 === Dependencies and Providers
 
 ==== X-Env-Layer-Requires
@@ -156,6 +158,15 @@ Only variables present in the environment can be used in dependencies.
 [IMPORTANT]
 ====
 Unlike dependencies, environment variables are not supported when evaluating providers.
+====
+
+==== X-Env-Layer-Sets
+
+Used to inject KEY=VALUE pairs into the build environment when this layer is present. Later layers override earlier ones.
+
+[IMPORTANT]
+====
+Typically used for internal build/feature flags that do not belong in the `IGconf_` namespace. Specifying `IGconf_` variables here will result in an error.
 ====
 
 === Environment Variables

--- a/layer/base/image-base.yaml
+++ b/layer/base/image-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: image-base
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Default image settings and build attributes.
-# X-Env-Layer-Version: 2.0.2
+# X-Env-Layer-Version: 2.0.3
 # X-Env-Layer-Requires: sys-build-base,sbom-base,target-config,artefact-base,deploy-base
 # X-Env-Layer-RequiresProvider: device
 #
@@ -66,7 +66,7 @@
 # X-Env-Var-provider-Required: n
 # X-Env-Var-provider-Valid: keywords:genimage
 # X-Env-Var-provider-Set: lazy
-# X-Env-Var-provider-Triggers: when=genimage set IG_ENABLE_HOST_GENIMAGE=y
+# X-Env-Var-provider-Triggers: when=genimage set IG_ENABLE_HOST_GENIMAGE=y policy=force
 #
 # X-Env-Var-assetdir: /dev/null
 # X-Env-Var-assetdir-Desc: Image specific asset location. Use this directory

--- a/layer/rpi/device/arm64/linux-image-2712.yaml
+++ b/layer/rpi/device/arm64/linux-image-2712.yaml
@@ -2,7 +2,8 @@
 # X-Env-Layer-Name: rpi-linux-2712
 # X-Env-Layer-Category: kernel
 # X-Env-Layer-Desc: Raspberry Pi 2712 kernel
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Sets: IG_DEVICE_KERNEL_PAGE_SIZE=16K
 # METAEND
 ---
 env:

--- a/lib/tools.sh
+++ b/lib/tools.sh
@@ -5,13 +5,16 @@
 # built and installed as prerequisites in a reusable mini-sysroot.
 # Can scale as needed, eg move away from bash array to file. Main thing
 # is to retain functionality: vars -> registry -> selection -> action
+#
+# See registry.defs
 readonly -a IG_TOOLS_REGISTRY=(
+   "IG_ENABLE_HOST_BDEBSTRAP|y|bdebstrap"
    "IG_ENABLE_HOST_GENIMAGE|y|genimage"
 )
 
 collect_build_deps() {
    local envfile="${1:?missing env file}"
-   local packages=(bdebstrap) # mandatory
+   local packages=
    local var value pkg
 
    for entry in "${IG_TOOLS_REGISTRY[@]}"; do

--- a/registry.defs
+++ b/registry.defs
@@ -1,0 +1,36 @@
+# Registry of build variable defaults. These are seeded before config parsing.
+# User config, cmdline or layers can override. Policy rules do not apply here.
+# Format: X-Env-Var DEB822
+# Validate: metadata --lint
+# Validation types:
+# https://raspberrypi.github.io/rpi-image-gen/layer/variable-validation.html
+
+
+#
+# Tooling
+#
+X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP: y
+X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP-Desc: Build and install bdebstrap for the
+ host. Mission critical.
+X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP-Valid: bool
+X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP-Set: y
+
+
+#
+# Device
+#
+X-Env-Var-IG_DEVICE_KERNEL_PAGE_SIZE: 4K
+X-Env-Var-IG_DEVICE_KERNEL_PAGE_SIZE-Desc: Page size of the linux kernel.
+ Influences filesystem image creation parameters including block size. May also
+ be used to tune other image attributes to match the target kernel.
+X-Env-Var-IG_DEVICE_KERNEL_PAGE_SIZE-Required: n
+X-Env-Var-IG_DEVICE_KERNEL_PAGE_SIZE-Valid: 4K,16K
+X-Env-Var-IG_DEVICE_KERNEL_PAGE_SIZE-Set: y
+
+
+X-Env-Var-IG_DEVICE_PARTITION_ALIGNMENT: 8M
+X-Env-Var-IG_DEVICE_PARTITION_ALIGNMENT-Desc: Alignment boundary for disk
+ partitions. Ensures partition start offsets are aligned to this value for
+ optimal I/O performance on the target storage device.
+X-Env-Var-IG_DEVICE_PARTITION_ALIGNMENT-Valid: capacity
+X-Env-Var-IG_DEVICE_PARTITION_ALIGNMENT-Set: y

--- a/registry.defs
+++ b/registry.defs
@@ -16,6 +16,13 @@ X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP-Valid: bool
 X-Env-Var-IG_ENABLE_HOST_BDEBSTRAP-Set: y
 
 
+X-Env-Var-IG_ENABLE_HOST_GENIMAGE: n
+X-Env-Var-IG_ENABLE_HOST_GENIMAGE-Desc: Build and install genimage for the
+ host. Image creation only.
+X-Env-Var-IG_ENABLE_HOST_GENIMAGE-Valid: bool
+X-Env-Var-IG_ENABLE_HOST_GENIMAGE-Set: y
+
+
 #
 # Device
 #

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -108,12 +108,17 @@ ctx[SRCROOT]="${SRCROOT:-$(realpath -e .)}"
 
 ###############################################################################
 # Stage 1: Parameter assembly
+#   Read registry
 #   Parse config
 #   Seed env for subsequent stages
 ###############################################################################
 parameter_assembly()
 {
    msg "\nPARAM"
+
+   # Seed with registry defaults
+   ig metadata --emit "$IGTOP/registry.defs" > "${TMPDIR}/registry.env" \
+      || die "Failed to parse registry"
 
    # Read config, writing all settings to file. Deferred variable resolution in pipeline
    # means that variable expansion does not happen here, so a config file can use any
@@ -123,8 +128,11 @@ parameter_assembly()
       --path "$HOST_CONFIG_PATH" \
       "$HOST_CONFIG_FILE"     \
       --overrides "$OVRF" \
-      --write-to "${TMPDIR}/config.env" \
+      --write-to "${TMPDIR}/userconfig.env" \
       || die "Config parse failed"
+
+   # Prepend registry defaults so config overrides (last wins)
+   cat "${TMPDIR}/registry.env" "${TMPDIR}/userconfig.env" > "${TMPDIR}/config.env"
 
    # Toolchain variables. Native unless ARCH forces cross.
    if [ -z "${ARCH:-}" ]; then

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -1009,6 +1009,12 @@ def _layer_main(args):
             rel_layer_path = manager.layer_relpaths.get(layer_name, layer_path)
             print(f"Path: {rel_layer_path}")
 
+            mmdebstrap = manager._get_mmdebstrap_config(layer_name)
+            if mmdebstrap:
+                for field in ('suite', 'variant', 'mode'):
+                    if field in mmdebstrap:
+                        print(f"{field.capitalize()}: {mmdebstrap[field]}")
+
             if layer_info['depends']:
                 print("Depends:")
 

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -53,7 +53,7 @@ class ValidationResultBuilder:
             status="orphaned_attributes",
             valid=False,
             required=False,
-            message=f"{self.filepath}: Found attribute fields for variable '{varname}' but no base {XEnv.var_base(varname)} definition"
+            message=f"{self.filepath}: Found attribute fields for variable '{varname}' but no base {XEnv.VAR_PREFIX}{varname} definition"
         )
 
     def unsupported_validation_rule(self, var_name: str, rule: str, value=None, required=False):
@@ -483,20 +483,17 @@ class Metadata:
         for key in self._container.raw_metadata.keys():
             if XEnv.is_var_field(key) and is_field_supported(key):
                 if XEnv.is_base_var_field(key):
-                    # Base variable definition
-                    base_vars.add(XEnv.extract_base_var_name(key).lower())
+                    base_vars.add(XEnv.extract_base_var_name(key))
                 elif any(key.endswith(suffix) for suffix in ["-Desc", "-Valid", "-Required", "-Set", "-Anchor", "-Conflicts"]):
-                    # Attribute field - extract variable name
                     var_part = XEnv.extract_var_name(key)
                     for suffix in ["-Desc", "-Valid", "-Required", "-Set", "-Anchor", "-Conflicts"]:
                         if var_part.endswith(suffix):
-                            varname = var_part[:-len(suffix)].lower()
-                            attribute_vars.add(varname)
+                            attribute_vars.add(var_part[:-len(suffix)])
                             break
 
         orphaned_vars = attribute_vars - base_vars
         for varname in orphaned_vars:
-            results[f"ORPHANED_ATTRS_{varname.upper()}"] = self._result_builder.orphaned_attributes(varname)
+            results[f"ORPHANED_ATTRS_{varname}"] = self._result_builder.orphaned_attributes(varname)
 
         return results
 

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -115,6 +115,7 @@ SUPPORTED_FIELD_PATTERNS = {
     XEnv.layer_generator(): {"type": "single", "description": "Generator executable for dynamic layers"},
     XEnv.layer_provides(): {"type": "single", "description": "Capabilities provided by this layer"},
     XEnv.layer_requires_provider(): {"type": "single", "description": "Capabilities required (virtual)"},
+    XEnv.layer_sets(): {"type": "single", "description": "Internal variables set when this layer is present (KEY=VALUE)"},
 
     # Variable definition patterns (these match multiple fields)
     f"{XEnv.VAR_PREFIX}": {"type": "pattern", "description": "Environment variable definition"},
@@ -1090,6 +1091,7 @@ def _generate_boilerplate():
 # X-Env-Layer-Desc: Layer description
 # X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: general
+# X-Env-Layer-Sets: KEY=VALUE
 #
 # X-Env-Layer-Requires:
 # X-Env-Layer-Conflicts:

--- a/test/layer/string-or-empty.yaml
+++ b/test/layer/string-or-empty.yaml
@@ -1,4 +1,8 @@
 # METABEGIN
+# X-Env-Layer-Name: test-string-or-empty
+# X-Env-Layer-Desc: Test layer for string-or-empty validation
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
 # X-Env-VarPrefix: test
 #
 # X-Env-Var-pmap:

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -556,6 +556,17 @@ run_test "layer-apply-env-trigger-cascade-cross-layer-lite" \
     0 \
     "Cross-layer trigger cascade should resolve lite to sd and disable ptable protection"
 
+run_test "layer-apply-env-layer-sets" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && \
+     make_pipeline_env "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-layer-sets --path "${PIPELINE_DIR}" --env-out "$TMP_OUT" >/dev/null && \
+     grep -q "^IG_ENABLE_HOST_BDEBSTRAP=y$" "$TMP_OUT" && \
+     grep -q "^IG_TEST_LAYER_SETS=active$" "$TMP_OUT" && \
+     grep -q "^IGconf_lsets_marker=present$" "$TMP_OUT"; \
+     status=$?; rm -f "$TMP_ENV" "$TMP_OUT"; exit $status' \
+    0 \
+    "Pipeline should inject X-Env-Layer-Sets variables into the environment"
+
 run_test "layer-apply-env-invalid" \
     'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" && \

--- a/test/meta/valid-layer-sets.yaml
+++ b/test/meta/valid-layer-sets.yaml
@@ -1,0 +1,15 @@
+# METABEGIN
+# X-Env-Layer-Name: test-layer-sets
+# X-Env-Layer-Desc: Layer that sets internal build variables via X-Env-Layer-Sets
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Sets: IG_ENABLE_HOST_BDEBSTRAP=y IG_TEST_LAYER_SETS=active
+# X-Env-VarPrefix: lsets
+#
+# X-Env-Var-marker: present
+# X-Env-Var-marker-Desc: Marker variable to confirm layer was applied
+# X-Env-Var-marker-Set: lazy
+# METAEND
+---
+layer_sets_test:
+  marker: ${IGconf_lsets_marker}


### PR DESCRIPTION
Introduce a central build variable registry and extend the layer metadata system with Layer-Sets, enabling layers to declare system-wide build variables. These are essentially 'global defaults' which can propagate to all build and image creation stages.

### Registry

- New file `registry.defs` defines system-wide build variables in deb822 format, validated against the existing X-Env schema
- New `metadata --emit` command lints, validates, and exports registry variables as shell key=value pairs
- Registry defaults are seeded into the configuration before config parsing, so they can be overridden by user config, command line, or layers
- Refactored metadata load path to support both embedded / comment-wrapped (layer) and raw deb822 (registry) files through a unified code path

### Layer-Sets

- Layers can now declare `X-Env-Layer-Sets` to authoritatively set system-wide build variables which can complement/override registry defaults, e.g. `IG_DEVICE_KERNEL_PAGE_SIZE=16K` now exported by the 2712 kernel layer. This is useful for downstream tooling, e.g. mkfs / image creation can now optimise for 2712 kernel page size.

### Host build tool management

- `bdebstrap` and `genimage` selection now flows through the registry, removing hardcoded mandatory packages

### CLI and engine improvements

- `metadata --describe` now prints all recognised fields
- `layer --describe` prints additional mmdebstrap attributes