### PR TITLE
Minor fixups

### DIFF
--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -46,7 +46,7 @@
 #  crypthybrid: B:system OS partition will be provisioned encrypted (dev only).
 # X-Env-Var-pmap-Required: n
 # X-Env-Var-pmap-Valid: clear,crypt,cryptslots,cryptdata,crypthybrid
-# X-Env-Var-pmap-Set: y
+# X-Env-Var-pmap-Set: force
 #
 # X-Env-Var-ptable_protect: n
 # X-Env-Var-ptable_protect-Desc: Enable eMMC Power-On Write Protect of the partition

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -198,7 +198,7 @@ collect_layers()
 
    # Generate the bootstrap information, resolving all variables. Configuration
    # input is only from the input env file, so run it in a clean room.
-   env -i PATH=$PATH \
+   env -i PATH="$PATH" \
      ig pipeline \
       --env-in "${TMPDIR}/config.env" \
       --layers "${layers[@]}" \


### PR DESCRIPTION
Two small fixups:

1. Improves compatibility with WSL
2. cryptroot integration is not yet ready, so communicate `crypt*` pmap configurations are disabled