### PR TITLE
engine: support YAML list sections in config parser

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -135,7 +135,9 @@ The configuration system supports both INI and YAML file formats with automatic 
 
 === YAML Configuration Format
 
-YAML provides the most flexible configuration format with native support for hierarchical data and includes:
+YAML provides the most flexible configuration format with native support for hierarchical data and includes.
+
+==== Mapping Sections
 
 [source,yaml]
 ----
@@ -155,6 +157,46 @@ image:
   boot_part_size: 200%
   root_part_size: 300%
 ----
+
+==== List Sections
+
+In addition to mapping (key-value) sections, YAML configuration files support sequence (list) sections. List items are assigned 0-based numeric keys, producing the same `IGconf_<section>_<key>` variable format as mapping sections.
+
+[source,yaml]
+----
+packages:
+  - vim
+  - git
+  - curl
+----
+
+This produces the following variables:
+
+[source,bash]
+----
+IGconf_packages_0=vim
+IGconf_packages_1=git
+IGconf_packages_2=curl
+----
+
+This is equivalent to the explicit mapping form:
+
+[source,yaml]
+----
+packages:
+  0: vim
+  1: git
+  2: curl
+----
+
+List sections are useful when the key names are not meaningful and only ordering matters. They follow the same include merging and override rules as mapping sections.
+
+
+[WARNING]
+====
+List sections do not merge with includes in the same way as mapping sections. Because list items are internally keyed by their position index, an include merge between two files defining the same list section produces a positional override rather than an append or replacement. For predictable results, avoid defining the same list section in both a base file and a file that includes it.
+====
+
 
 === INI Configuration Format
 

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -143,7 +143,12 @@
 </li>
 <li><a href="#_configuration_file_support">Configuration File Support</a>
 <ul class="sectlevel2">
-<li><a href="#_yaml_configuration_format">YAML Configuration Format</a></li>
+<li><a href="#_yaml_configuration_format">YAML Configuration Format</a>
+<ul class="sectlevel3">
+<li><a href="#_mapping_sections">Mapping Sections</a></li>
+<li><a href="#_list_sections">List Sections</a></li>
+</ul>
+</li>
 <li><a href="#_ini_configuration_format">INI Configuration Format</a></li>
 <li><a href="#_configuration_includes">Configuration Includes</a>
 <ul class="sectlevel3">
@@ -419,8 +424,10 @@ FINAL ENV
 <div class="sect2">
 <h3 id="_yaml_configuration_format"><a class="anchor" href="#_yaml_configuration_format"></a><a class="link" href="#_yaml_configuration_format">YAML Configuration Format</a></h3>
 <div class="paragraph">
-<p>YAML provides the most flexible configuration format with native support for hierarchical data and includes:</p>
+<p>YAML provides the most flexible configuration format with native support for hierarchical data and includes.</p>
 </div>
+<div class="sect3">
+<h4 id="_mapping_sections"><a class="anchor" href="#_mapping_sections"></a><a class="link" href="#_mapping_sections">Mapping Sections</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code class="language-yaml" data-lang="yaml">include:
@@ -438,6 +445,59 @@ image:
   compression: zstd
   boot_part_size: 200%
   root_part_size: 300%</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_list_sections"><a class="anchor" href="#_list_sections"></a><a class="link" href="#_list_sections">List Sections</a></h4>
+<div class="paragraph">
+<p>In addition to mapping (key-value) sections, YAML configuration files support sequence (list) sections. List items are assigned 0-based numeric keys, producing the same <code>IGconf_&lt;section&gt;_&lt;key&gt;</code> variable format as mapping sections.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">packages:
+  - vim
+  - git
+  - curl</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This produces the following variables:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">IGconf_packages_0=vim
+IGconf_packages_1=git
+IGconf_packages_2=curl</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This is equivalent to the explicit mapping form:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">packages:
+  0: vim
+  1: git
+  2: curl</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>List sections are useful when the key names are not meaningful and only ordering matters. They follow the same include merging and override rules as mapping sections.</p>
+</div>
+<div class="admonitionblock warning">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Warning</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>List sections do not merge with includes in the same way as mapping sections. Because list items are internally keyed by their position index, an include merge between two files defining the same list section produces a positional override rather than an append or replacement. For predictable results, avoid defining the same list section in both a base file and a file that includes it.</p>
+</div>
+</td>
+</tr>
+</table>
 </div>
 </div>
 </div>

--- a/site/config_loader.py
+++ b/site/config_loader.py
@@ -103,6 +103,10 @@ class ConfigLoader:
 
             # Handle include directive
             included_sections: Dict[str, Dict[str, str]] = {}
+            if 'include' in yaml_data and isinstance(yaml_data['include'], list):
+                raise ValueError(
+                    f"List includes are not supported in {path}"
+                )
             if 'include' in yaml_data and isinstance(yaml_data['include'], dict):
                 inc_file = yaml_data['include'].get('file')
                 if not inc_file:
@@ -115,9 +119,12 @@ class ConfigLoader:
             # Convert current file sections
             curr_sections: Dict[str, Dict[str, str]] = {}
             for sect, sect_data in yaml_data.items():
-                if not isinstance(sect_data, dict):
-                    raise ValueError(f"Section '{sect}' in {path} must be a mapping")
-                curr_sections[sect] = {k: str(v) for k, v in sect_data.items()}
+                if isinstance(sect_data, list):
+                    curr_sections[sect] = {str(i): str(v) for i, v in enumerate(sect_data)}
+                elif isinstance(sect_data, dict):
+                    curr_sections[sect] = {k: str(v) for k, v in sect_data.items()}
+                else:
+                    raise ValueError(f"Section '{sect}' in {path} must be a mapping or list")
 
             # Merge: current overrides included
             merged = {**included_sections}
@@ -495,19 +502,23 @@ def _main(args):
         _migrate_to_yaml(args.cfg_path, args)
         return
 
-    loader = ConfigLoader(
-        args.cfg_path,
-        expand_vars=not args.no_expand,
-        overrides_path=args.overrides,
-        search_paths=(args.path.split(":") if args.path else ["./config"]),
-    )
-    if args.write_to:
-        loader.write_file(args.write_to, args.section)
-    else:
-        if args.section:
-            loader.load_section(args.section)
+    try:
+        loader = ConfigLoader(
+            args.cfg_path,
+            expand_vars=not args.no_expand,
+            overrides_path=args.overrides,
+            search_paths=(args.path.split(":") if args.path else ["./config"]),
+        )
+        if args.write_to:
+            loader.write_file(args.write_to, args.section)
         else:
-            loader.load_all()
+            if args.section:
+                loader.load_section(args.section)
+            else:
+                loader.load_all()
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise SystemExit(1)
 
 
 def _migrate_to_yaml(ini_path: str, args):


### PR DESCRIPTION
Sections in YAML config files can now be sequences (lists) in addition to mappings (dicts). List items are assigned 0-based numeric keys, producing the equivalent section_key internal representation. For example:
```
packages:
 - foo
 - bar
```
Yields:
```
IGconf_packages_0=foo
IGconf_packages_1=bar
```
Misc:
 - Error on includes specified as list types. Not supported at this time.
 - Handle all parsing errors via try/catch to keep things clean. Docs updated