### PR TITLE
image-rota: Generate dm-verity hash assets for root

### DIFF
--- a/depends
+++ b/depends
@@ -25,6 +25,7 @@ build:uuidgen:uuid-runtime
 build:fdisk
 build::python3-jsonschema
 build::dpkg-dev
+build:veritysetup:cryptsetup
 
 # pkg buildsys
 build::python3-pip

--- a/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
+++ b/image/gpt/ab_userdata/bdebstrap/customize05-rootfs
@@ -16,9 +16,10 @@ BOOT_LABEL=$(uuidgen | sed 's/-.*//' | tr 'a-f' 'A-F')
 BOOT_UUID=$(echo "$BOOT_LABEL" | sed 's/^\(....\)\(....\)$/\1-\2/')
 SYSTEM_UUID=$(uuidgen)
 CRYPT_UUID=$(uuidgen)
+VERITY_UUID=$(uuidgen)
 
 rm -f ${IGconf_image_outputdir}/img_uuids
-for v in BOOT_LABEL BOOT_UUID SYSTEM_UUID CRYPT_UUID; do
+for v in BOOT_LABEL BOOT_UUID SYSTEM_UUID CRYPT_UUID VERITY_UUID; do
     eval "val=\$$v"
     echo "$v=$val" >> "${IGconf_image_outputdir}/img_uuids"
 done
@@ -36,7 +37,3 @@ sed -i \
 pmap --schema "$IGconf_image_pmap_schema" \
      --file "${IGconf_image_outputdir}/provisionmap.json" \
      --slotvars > "$1/boot/slot.map"
-
-
-# Hint to initramfs-tools we have an ext4 rootfs
-sed -i "s|FSTYPE=\([^ ]*\)|FSTYPE=ext4|" $1/etc/initramfs-tools/initramfs.conf

--- a/image/gpt/ab_userdata/genimage.cfg.in.erofs
+++ b/image/gpt/ab_userdata/genimage.cfg.in.erofs
@@ -103,6 +103,13 @@ image system.erofs {
    exec-pre = "<SLOTP> SYSTEM"
 }
 
+image system.verity {
+   verity {
+      image = "system.erofs"
+      extraargs = "<VERITY_SYSTEM>"
+   }
+}
+
 image persistent.ext4 {
    ext4 {
       use-mke2fs = true

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -12,10 +12,19 @@ genimg_in=$2
 . ${genimg_in}/img_uuids
 
 
-# mkfs args: UUIDs are image-structural, fs-specific args from IGconf_fs_*
+# mkfs args: UUIDs are image-structural
 MKE2FS_ARGS_SYSTEM="-U $SYSTEM_UUID ${IGconf_fs_ext4_mkfs_args:-}"
 MKE2FS_ARGS_DATA="${IGconf_fs_ext4_mkfs_args:-}"
 EROFS_ARGS_SYSTEM="-U $SYSTEM_UUID ${IGconf_fs_erofs_mkfs_args:-}"
+
+# verity
+VERITY_ARGS_SYSTEM="\
+ --data-block-size ${IGconf_linux_page_size:-4096} \
+ --hash-block-size ${IGconf_linux_page_size:-4096} \
+ --hash sha256 \
+ --uuid ${VERITY_UUID} \
+ --salt $(uuidgen | tr -d '-') \
+ --root-hash-file ${IGconf_image_outputdir}/system.roothash"
 
 
 # Set up the partition layout for tryboot support. Partition numbering
@@ -46,6 +55,7 @@ cat "genimage.cfg.in.$IGconf_image_rootfs_type" | sed \
    -e "s|<MKE2FS_SYSTEM>|$MKE2FS_ARGS_SYSTEM|g" \
    -e "s|<MKE2FS_DATA>|$MKE2FS_ARGS_DATA|g" \
    -e "s|<EROFS_SYSTEM>|$EROFS_ARGS_SYSTEM|g" \
+   -e "s|<VERITY_SYSTEM>|$VERITY_ARGS_SYSTEM|g" \
    > ${genimg_in}/genimage.cfg
 
 

--- a/package/genimage/patches/19/0001-verity-add-handler-to-create-dm-verity-hash-trees.patch
+++ b/package/genimage/patches/19/0001-verity-add-handler-to-create-dm-verity-hash-trees.patch
@@ -1,0 +1,192 @@
+From 055ab67ad25b1b63d1694fc815f9a863dc375b9d Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Thu, 18 Sep 2025 21:39:10 +0200
+Subject: [PATCH 1/3] verity: add handler to create dm-verity hash trees
+
+Use 'veritysetup format' to generate a hash tree from an input
+image. For integration with the upcoming support for verity signature
+images compatible with UAPI DPS, we make sure to record the root hash
+value in tmppath().
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ Makefile.am    |   1 +
+ config.c       |   6 +++
+ genimage.c     |   1 +
+ genimage.h     |   1 +
+ image-verity.c | 110 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 5 files changed, 119 insertions(+)
+ create mode 100644 image-verity.c
+
+diff --git a/Makefile.am b/Makefile.am
+index d030836..93d67e4 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -40,6 +40,7 @@ genimage_SOURCES = \
+ 	image-tar.c \
+ 	image-ubi.c \
+ 	image-ubifs.c \
++	image-verity.c \
+ 	image-vfat.c
+ 
+ genimage_CFLAGS = \
+diff --git a/config.c b/config.c
+index 9aae8d8..40f44c3 100644
+--- a/config.c
++++ b/config.c
+@@ -519,6 +519,12 @@ static struct config opts[] = {
+ 		.env = "GENIMAGE_FIPTOOL",
+ 		.def = "fiptool",
+ 	},
++	{
++		.name = "veritysetup",
++		.opt = CFG_STR("veritysetup", NULL, CFGF_NONE),
++		.env = "GENIMAGE_VERITYSETUP",
++		.def = "veritysetup",
++	},
+ 	{
+ 		.name = "config",
+ 		.env = "GENIMAGE_CONFIG",
+diff --git a/genimage.c b/genimage.c
+index e0c53e7..c4b1817 100644
+--- a/genimage.c
++++ b/genimage.c
+@@ -62,6 +62,7 @@ static struct image_handler *handlers[] = {
+ 	&tar_handler,
+ 	&ubi_handler,
+ 	&ubifs_handler,
++	&verity_handler,
+ 	&vfat_handler,
+ };
+ 
+diff --git a/genimage.h b/genimage.h
+index 71234dc..f4bbe9c 100644
+--- a/genimage.h
++++ b/genimage.h
+@@ -138,6 +138,7 @@ extern struct image_handler squashfs_handler;
+ extern struct image_handler tar_handler;
+ extern struct image_handler ubi_handler;
+ extern struct image_handler ubifs_handler;
++extern struct image_handler verity_handler;
+ extern struct image_handler vfat_handler;
+ extern struct image_handler fit_handler;
+ extern struct image_handler fip_handler;
+diff --git a/image-verity.c b/image-verity.c
+new file mode 100644
+index 0000000..78ee284
+--- /dev/null
++++ b/image-verity.c
+@@ -0,0 +1,110 @@
++/*
++ * Copyright (c) 2025 Tobias Waldekranz <tobias@waldekranz.com>, Wires
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2
++ * as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <confuse.h>
++#include <errno.h>
++#include <stdio.h>
++#include <string.h>
++#include <stdlib.h>
++#include <sys/stat.h>
++
++#include "genimage.h"
++
++static char *verity_tmp_path(const char *verity, const char *suffix)
++{
++	char *path, *slug;
++
++	slug = sanitize_path(verity);
++	xasprintf(&path, "%s/%s.%s", tmppath(), slug, suffix);
++	free(slug);
++
++	return path;
++}
++
++static int verity_generate(struct image *image)
++{
++	const char *data, *extraargs;
++	struct partition *part;
++	struct stat sb;
++	int ret;
++
++	ret = prepare_image(image, image->size);
++	if (ret < 0)
++		return ret;
++
++	part = list_first_entry(&image->partitions, struct partition, list);
++	data = imageoutfile(image_get(part->image));
++
++	extraargs = cfg_getstr(image->imagesec, "extraargs");
++
++	/* As a side-effect of creating the hash tree, request that
++	 * veritysetup emits the resulting root-hash into a file in
++	 * tmppath(), where 'verity-sig' images that reference this
++	 * 'verity' can find it.
++	 */
++	ret = systemp(image, "%s format --root-hash-file '%s' %s '%s' '%s'",
++		      get_opt("veritysetup"),
++		      verity_tmp_path(image->file, "root-hash"),
++		      extraargs ? extraargs : "", data, imageoutfile(image));
++	if (ret)
++		return ret;
++
++	if (stat(imageoutfile(image), &sb))
++		return -errno;
++
++	if (image->size && image->size < (unsigned long)sb.st_size) {
++		image_error(image,
++			    "Specified image size (%llu) is too small, generated %ld bytes\n",
++			    image->size, sb.st_size);
++		return -E2BIG;
++	}
++
++	image_debug(image, "generated %ld bytes\n", sb.st_size);
++	image->size = sb.st_size;
++	return 0;
++}
++
++static int verity_parse(struct image *image, cfg_t *cfg)
++{
++	struct partition *part;
++	const char *data;
++
++	data = cfg_getstr(image->imagesec, "image");
++	if (!data) {
++		image_error(image, "Mandatory 'image' option is missing!\n");
++		return -EINVAL;
++	}
++
++	part = xzalloc(sizeof(*part));
++	part->image = data;
++	list_add_tail(&part->list, &image->partitions);
++
++	return 0;
++}
++
++static cfg_opt_t verity_opts[] = {
++	CFG_STR("image", NULL, CFGF_NONE),
++	CFG_STR("extraargs", NULL, CFGF_NONE),
++	CFG_END()
++};
++
++struct image_handler verity_handler = {
++	.type = "verity",
++	.no_rootpath = cfg_true,
++	.generate = verity_generate,
++	.parse = verity_parse,
++	.opts = verity_opts,
++};
+-- 
+2.39.5
+

--- a/package/genimage/patches/19/0002-verity-sig-add-handler-to-UAPI-DPS-compatible-verity.patch
+++ b/package/genimage/patches/19/0002-verity-sig-add-handler-to-UAPI-DPS-compatible-verity.patch
@@ -1,0 +1,360 @@
+From 0b4632980cb198f9e08711221ad9a10568dadb38 Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Fri, 19 Sep 2025 12:31:52 +0200
+Subject: [PATCH 2/3] verity-sig: add handler to UAPI DPS compatible verity
+ signatures
+
+The UAPI Group's Discoverable Partitions Specifications[1] defines the
+format of <part>-<arch>-verity-sig partitions. Add a handler that can
+create these.
+
+[1]: https://uapi-group.org/specifications/specs/discoverable_partitions_specification/#verity
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ config.c       |   6 ++
+ genimage.c     |   1 +
+ genimage.h     |   1 +
+ image-verity.c | 271 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 279 insertions(+)
+
+diff --git a/config.c b/config.c
+index 40f44c3..8c0d381 100644
+--- a/config.c
++++ b/config.c
+@@ -459,6 +459,12 @@ static struct config opts[] = {
+ 		.env = "GENIMAGE_MKFSBTRFS",
+ 		.def = "mkfs.btrfs",
+ 	},
++	{
++		.name = "openssl",
++		.opt = CFG_STR("openssl", NULL, CFGF_NONE),
++		.env = "GENIMAGE_OPENSSL",
++		.def = "openssl",
++	},
+ 	{
+ 		.name = "sloadf2fs",
+ 		.opt = CFG_STR("sloadf2fs", NULL, CFGF_NONE),
+diff --git a/genimage.c b/genimage.c
+index c4b1817..cf92ae4 100644
+--- a/genimage.c
++++ b/genimage.c
+@@ -63,6 +63,7 @@ static struct image_handler *handlers[] = {
+ 	&ubi_handler,
+ 	&ubifs_handler,
+ 	&verity_handler,
++	&verity_sig_handler,
+ 	&vfat_handler,
+ };
+ 
+diff --git a/genimage.h b/genimage.h
+index f4bbe9c..4e26f12 100644
+--- a/genimage.h
++++ b/genimage.h
+@@ -139,6 +139,7 @@ extern struct image_handler tar_handler;
+ extern struct image_handler ubi_handler;
+ extern struct image_handler ubifs_handler;
+ extern struct image_handler verity_handler;
++extern struct image_handler verity_sig_handler;
+ extern struct image_handler vfat_handler;
+ extern struct image_handler fit_handler;
+ extern struct image_handler fip_handler;
+diff --git a/image-verity.c b/image-verity.c
+index 78ee284..c28be9e 100644
+--- a/image-verity.c
++++ b/image-verity.c
+@@ -16,13 +16,22 @@
+ 
+ #include <confuse.h>
+ #include <errno.h>
++#include <fcntl.h>
++#include <stdbool.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#include <unistd.h>
++#include <sys/sendfile.h>
+ #include <sys/stat.h>
+ 
+ #include "genimage.h"
+ 
++#define VERITY_SIG_CERT 0
++#define VERITY_SIG_KEY	1
++
++static const char *pkcs11_prefix = "pkcs11:";
++
+ static char *verity_tmp_path(const char *verity, const char *suffix)
+ {
+ 	char *path, *slug;
+@@ -34,6 +43,268 @@ static char *verity_tmp_path(const char *verity, const char *suffix)
+ 	return path;
+ }
+ 
++static int verity_sig_write_json_rh(FILE *json, const char *rh)
++{
++	char line[0x80], *ret;
++	FILE *fp;
++
++	fp = fopen(rh, "r");
++	if (!fp)
++		return -EIO;
++
++	ret = fgets(line, sizeof(line), fp);
++	fclose(fp);
++	if (!ret)
++		return -EIO;
++
++	if (fprintf(json, "\"rootHash\":\"%s\"", line) < 0)
++		return -EIO;
++
++	return 0;
++}
++
++static int verity_sig_write_json_certfp(FILE *json, const char *certfp)
++{
++	unsigned char b[32];
++	int scanned;
++	FILE *fp;
++
++	fp = fopen(certfp, "r");
++	if (!fp)
++		return -EIO;
++
++	/* clang-format off */
++	scanned = fscanf(fp, "sha256 Fingerprint="
++			 "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:"
++			 "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:"
++			 "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:"
++			 "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX",
++			 &b[ 0], &b[ 1], &b[ 2], &b[ 3], &b[ 4], &b[ 5], &b[ 6], &b[ 7],
++			 &b[ 8], &b[ 9], &b[10], &b[11], &b[12], &b[13], &b[14], &b[15],
++			 &b[16], &b[17], &b[18], &b[19], &b[20], &b[21], &b[22], &b[23],
++			 &b[24], &b[25], &b[26], &b[27], &b[28], &b[29], &b[30], &b[31]);
++	/* clang-format on */
++	fclose(fp);
++	if (scanned != 32)
++		return -EIO;
++
++	/* clang-format off */
++	if (fprintf(json, "\"certificateFingerprint\":\""
++		    "%02x%02x%02x%02x%02x%02x%02x%02x"
++		    "%02x%02x%02x%02x%02x%02x%02x%02x"
++		    "%02x%02x%02x%02x%02x%02x%02x%02x"
++		    "%02x%02x%02x%02x%02x%02x%02x%02x" "\"",
++		    b[ 0], b[ 1], b[ 2], b[ 3], b[ 4], b[ 5], b[ 6], b[ 7],
++		    b[ 8], b[ 9], b[10], b[11], b[12], b[13], b[14], b[15],
++		    b[16], b[17], b[18], b[19], b[20], b[21], b[22], b[23],
++		    b[24], b[25], b[26], b[27], b[28], b[29], b[30], b[31]) < 0)
++		return -EIO;
++	/* clang-format on */
++
++	return 0;
++}
++
++static int verity_sig_write_json_p7s(FILE *json, const char *p7s)
++{
++	static const char *begin = "-----BEGIN CMS-----";
++	static const char *end = "-----END CMS-----";
++	char line[0x80], *ret;
++	FILE *fp;
++
++	fp = fopen(p7s, "r");
++	if (!fp)
++		return -EIO;
++
++	ret = fgets(line, sizeof(line), fp);
++	if (!ret || strncmp(line, begin, strlen(begin)))
++		goto err;
++
++	fputs("\"signature\":\"", json);
++
++	while (fgets(line, sizeof(line), fp)) {
++		if (!strncmp(line, end, strlen(end))) {
++			fputs("\"", json);
++			fclose(fp);
++			return 0;
++		}
++
++		fwrite(line, 1, strlen(line) - 1, json);
++	}
++
++err:
++	fclose(fp);
++	return -EIO;
++}
++
++static ssize_t verity_sig_write_json(struct image *image,
++				     const char *rh, const char *certfp, const char *p7s)
++{
++	ssize_t size;
++	FILE *json;
++	int ret;
++
++	json = fopen(imageoutfile(image), "w+");
++	if (!json) {
++		image_error(image, "Unable to open output: %m\n");
++		return -errno;
++	}
++
++	fputs("{", json);
++	ret = verity_sig_write_json_rh(json, rh);
++	fputs(",", json);
++	ret = ret ? ret : verity_sig_write_json_certfp(json, certfp);
++	fputs(",", json);
++	ret = ret ? ret : verity_sig_write_json_p7s(json, p7s);
++	fputs("}", json);
++
++	if (ret) {
++		size = ret;
++		goto out;
++	}
++
++	size = ftell(json);
++	size += 4095;
++	size &= ~4095;
++
++	/* UAPI DPS dictates NUL padding up to the next 4k boundary */
++	if (ftruncate(fileno(json), size))
++		size = ret = -errno;
++
++out:
++	fclose(json);
++
++	if (ret)
++		image_error(image, "Error while writing output: %m\n");
++
++	return size;
++}
++
++static int verity_sig_generate(struct image *image)
++{
++	char *certfp, *p7s, *rh;
++	const char *cert, *key;
++	struct partition *part;
++	ssize_t size;
++	int ret;
++
++	ret = prepare_image(image, image->size);
++	if (ret < 0)
++		return ret;
++
++	cert = cfg_getstr(image->imagesec, "cert");
++	key = cfg_getstr(image->imagesec, "key");
++
++	list_for_each_entry(part, &image->partitions, list) {
++		if (part->partition_type == VERITY_SIG_CERT)
++			cert = imageoutfile(image_get(part->image));
++
++		if (part->partition_type == VERITY_SIG_KEY)
++			key = imageoutfile(image_get(part->image));
++	}
++
++	/* The 'image' option points to the 'verity' image for which
++	 * we are to generate a signature. During the generation of
++	 * that image, the root-hash will have been stored in tmppath
++	 * for us to find.
++	 */
++	rh = verity_tmp_path(cfg_getstr(image->imagesec, "image"), "root-hash");
++
++	p7s = verity_tmp_path(image->file, "p7s");
++	certfp = verity_tmp_path(image->file, "certfp");
++
++	ret = systemp(image,
++		      "%s cms -sign -noattr -signer '%s' -inkey '%s' "
++		      "-binary -in '%s' -outform PEM -out '%s'",
++		      get_opt("openssl"), cert, key, rh, p7s);
++	if (ret) {
++		image_error(image, "Unable to create signature of root-hash\n");
++		goto out;
++	}
++
++	ret = systemp(image,
++		      "%s x509 -fingerprint -sha256 -in '%s' -noout >'%s'",
++		      get_opt("openssl"), cert, certfp);
++	if (ret) {
++		image_error(image, "Unable to extract certificate fingerprint\n");
++		goto out;
++	}
++
++	size = verity_sig_write_json(image, rh, certfp, p7s);
++	if (size < 0) {
++		ret = size;
++		goto out;
++	}
++
++	if (image->size && image->size < (unsigned long)size) {
++		image_error(image,
++			    "Specified image size (%llu) is too small, generated %ld bytes\n",
++			    image->size, size);
++		ret = -E2BIG;
++		goto out;
++	}
++
++	image_debug(image, "generated %ld bytes\n", size);
++	image->size = size;
++
++out:
++	free(certfp);
++	free(p7s);
++	free(rh);
++
++	return ret;
++}
++
++static int verity_sig_parse(struct image *image, cfg_t *cfg)
++{
++	struct partition *part;
++	const char *cert, *key;
++
++	if (!cfg_getstr(image->imagesec, "image")) {
++		image_error(image, "Mandatory 'image' option is missing!\n");
++		return -EINVAL;
++	}
++
++	cert = cfg_getstr(image->imagesec, "cert");
++	if (!cert) {
++		image_error(image, "Mandatory 'cert' option is missing!\n");
++		return -EINVAL;
++	}
++	if (strncmp(pkcs11_prefix, cert, strlen(pkcs11_prefix))) {
++		part = xzalloc(sizeof(*part));
++		part->image = cert;
++		part->partition_type = VERITY_SIG_CERT;
++		list_add_tail(&part->list, &image->partitions);
++	}
++
++	key = cfg_getstr(image->imagesec, "key");
++	if (!key) {
++		image_error(image, "Mandatory 'key' option is missing!\n");
++		return -EINVAL;
++	}
++	if (strncmp(pkcs11_prefix, key, strlen(pkcs11_prefix))) {
++		part = xzalloc(sizeof(*part));
++		part->image = key;
++		part->partition_type = VERITY_SIG_KEY;
++		list_add_tail(&part->list, &image->partitions);
++	}
++	return 0;
++}
++
++static cfg_opt_t verity_sig_opts[] = {
++	CFG_STR("image", NULL, CFGF_NONE),
++	CFG_STR("cert", NULL, CFGF_NONE),
++	CFG_STR("key", NULL, CFGF_NONE),
++	CFG_END()
++};
++
++struct image_handler verity_sig_handler = {
++	.type = "verity-sig",
++	.no_rootpath = cfg_true,
++	.generate = verity_sig_generate,
++	.parse = verity_sig_parse,
++	.opts = verity_sig_opts,
++};
++
+ static int verity_generate(struct image *image)
+ {
+ 	const char *data, *extraargs;
+-- 
+2.39.5
+

--- a/package/genimage/patches/19/0003-README-Document-verity-and-verity-sig-images.patch
+++ b/package/genimage/patches/19/0003-README-Document-verity-and-verity-sig-images.patch
@@ -1,0 +1,89 @@
+From 1f80dc30277790d64676aa39ea6cf42fbb092e5b Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Fri, 26 Sep 2025 16:32:34 +0200
+Subject: [PATCH 3/3] README: Document verity and verity-sig images
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ README.rst | 47 ++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/README.rst b/README.rst
+index 167c845..66313c7 100644
+--- a/README.rst
++++ b/README.rst
+@@ -108,7 +108,7 @@ Additionally each image can have one of the following sections describing the
+ type of the image:
+ 
+ cpio, cramfs, custom, erofs, ext2, ext3, ext4, f2fs, file, flash, hdimage, iso,
+-jffs2, mdraid, qemu, squashfs, tar, ubi, ubifs, vfat.
++jffs2, mdraid, qemu, squashfs, tar, ubi, ubifs, verity, verity-sig, vfat.
+ 
+ Partition options:
+ 
+@@ -637,6 +637,49 @@ Options:
+ :max-size:		Maximum size of the UBIFS image
+ :space-fixup:           Instructs the file-system free space to be freed up on first mount.
+ 
++verity
++******
++Generates a dm-verity hash tree from an existing image.
++
++Options:
++
++:extraargs:		Extra arguments passed to ``veritysetup format``
++:image:			Image from which to construct the hash tree
++
++The input image is typically a read-only filesystem image (SquashFS/EROFS)::
++
++  image rootfs.verity {
++	verity {
++		image = "rootfs.squashfs"
++	}
++  }
++
++
++verity-sig
++**********
++Generates a signature of the root hash of a ``verity`` image that is
++compatible with the Discoverable Partition Specification (DPS).
++
++Options:
++
++:image:			``verity`` image whose root hash should be signed
++
++:cert:			Path to the X509 certificate, file or PKCS#11 URI, whose
++			associated public key can be used to verify this signature.
++:key:			Path to the private key, file or PKCS#11 URI, used to create this
++			signature.
++
++Continuing from the previous example, a signature image can be created by referencing the
++verity image::
++
++  image rootfs.verity-sig {
++	verity-sig {
++		image = "rootfs.verity"
++		cert = "mycert.crt"
++		key = "pkcs11:token=mytoken;object=csk"
++	}
++  }
++
+ vfat
+ ****
+ Generates a VFAT image.
+@@ -783,10 +826,12 @@ variable.
+ :mkfsjffs2:	path to the mkfs.jffs2 program (default mkfs.jffs2)
+ :mkfsubifs:	path to the mkfs.ubifs program (default mkfs.ubifs)
+ :mksquashfs:	path to the mksquashfs program (default mksquashfs)
++:openssl:	path to the openssl program (default openssl)
+ :qemu-img:	path to the qemu-img program (default qemu-img)
+ :tar:		path to the tar program (default tar)
+ :tune2fs:	path to the tune2fs program (default tune2fs)
+ :ubinize:	path to the ubinize program (default ubinize)
++:veritysetup:	path to the veritysetup program (default veritysetup)
+ :fiptool:	path to the fiptool utility (default fiptool)
+ 
+ 
+-- 
+2.39.5
+


### PR DESCRIPTION
Utilise veritysetup from the host to generate the hash-tree of the EROFS rootfs, saving the root hash to file. This requires upstream changes to genimage v19, so these are applied as patches via the package build framework.

Remove redundant hinting of initramfs fstype - this is already handled by a common hook.