### PR TITLE
package: use Make-driven variable extraction for deps

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -27,12 +27,10 @@ all: $(ALL_PACKAGE_STAMPS)
 
 $(DEP_DIR)/%.deps.mk: $(PKG_ROOT)/%/Makefile $(PKG_ENV) $(DEPGEN)
 	@mkdir -p "$(DEP_DIR)"
-	@python3 "$(DEPGEN)" \
-		--package "$*" \
-		--makefile "$<" \
-		--pkg-dir "$(PKG_ROOT)/$*" \
-		--pkg-env "$(PKG_ENV)" \
-		--out "$@"
+	@$(MAKE) -C "$(PKG_ROOT)/$*" --no-print-directory deps-mk \
+		IGconf_sys_buildroot="$(IGconf_sys_buildroot)" \
+		DEP_OUT="$@" \
+		DEPGEN="$(DEPGEN)"
 
 clean-%:
 	@rm -f "$(DEP_DIR)/$*.deps.mk"

--- a/package/shared/depgen.py
+++ b/package/shared/depgen.py
@@ -2,6 +2,9 @@
 
 # Generate a Make fragment to describe package's dependencies.
 # This alows Make to build the dependency graph for a package.
+#
+# Variables (PKG_NAME, PKG_VER, PKG_DEPS) are passed as arguments already
+# already expanded by Make.
 
 from __future__ import annotations
 
@@ -10,7 +13,6 @@ import pathlib
 import re
 
 
-ASSIGN_RE = re.compile(r"^\s*PKG_(NAME|VER|DEPS)\s*(?::=|\+=|=)\s*(.*)$")
 RESET_VARS = (
     "PKG_NAME",
     "PKG_VER",
@@ -27,63 +29,15 @@ def sanitise(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", name)
 
 
-def parse_makefile(path: pathlib.Path) -> tuple[str | None, str | None, list[str]]:
-    text = path.read_text(encoding="utf-8")
-    buffer = ""
-    name: str | None = None
-    version: str | None = None
-    deps: list[str] = []
-
-    for raw in text.splitlines():
-        stripped = raw.split("#", 1)[0].rstrip()
-        if not stripped and not buffer:
-            continue
-
-        if stripped.endswith("\\"):
-            buffer += stripped[:-1] + " "
-            continue
-
-        if buffer:
-            stripped = buffer + stripped
-            buffer = ""
-
-        match = ASSIGN_RE.match(stripped)
-        if not match:
-            continue
-
-        key, rhs = match.groups()
-        rhs = rhs.strip()
-        if not rhs:
-            continue
-
-        if key == "DEPS":
-            deps.extend(rhs.split())
-        elif key == "NAME" and name is None:
-            name = rhs.split()[0]
-        elif key == "VER" and version is None:
-            version = rhs.split()[0]
-
-    ordered: list[str] = []
-    seen: set[str] = set()
-    for dep in deps:
-        if dep not in seen:
-            seen.add(dep)
-            ordered.append(dep)
-
-    return name, version, ordered
-
-
 def render(
     *,
-    pkg_identifier: str,
-    pkg_name: str | None,
-    pkg_version: str | None,
+    pkg_name: str,
+    pkg_version: str,
     deps: list[str],
     pkg_dir: pathlib.Path,
     pkg_env: pathlib.Path,
 ) -> str:
-    actual_name = pkg_name or pkg_identifier
-    pkg_id = sanitise(actual_name)
+    pkg_id = sanitise(pkg_name)
     dep_ids = [(dep, sanitise(dep)) for dep in deps]
 
     guard = f"_PKG_LOADED_{pkg_id}"
@@ -93,9 +47,8 @@ def render(
     lines.append(f"ifndef {guard}")
     lines.append(f"{guard} := 1")
     lines.append("")
-    lines.append(f"PKG_NAME := {actual_name}")
-    if pkg_version:
-        lines.append(f"PKG_VER := {pkg_version}")
+    lines.append(f"PKG_NAME := {pkg_name}")
+    lines.append(f"PKG_VER := {pkg_version}")
     if deps:
         lines.append(f"PKG_DEPS := {' '.join(deps)}")
     lines.append(f"include {pkg_env}")
@@ -104,8 +57,7 @@ def render(
     lines.append(f"PKG_DIR_{pkg_id} := {pkg_dir}")
     lines.append(f"PKG_STAMP_{pkg_id} := $(PKG_INSTALL_STAMP)")
     lines.append(f"PKG_SRC_STAMP_{pkg_id} := $(PKG_SOURCE_STAMP)")
-    if pkg_version:
-        lines.append(f"PKG_VER_{pkg_id} := $(PKG_VER)")
+    lines.append(f"PKG_VER_{pkg_id} := $(PKG_VER)")
     lines.append(f"PKG_DEPS_{pkg_id} := {' '.join(deps) if deps else ''}")
     lines.append("")
 
@@ -117,8 +69,8 @@ def render(
     lines.append(f"ALL_PACKAGE_STAMPS += $(PKG_STAMP_{pkg_id})")
     lines.append("")
 
-    lines.append(f".PHONY: {actual_name}")
-    lines.append(f"{actual_name}: $(PKG_STAMP_{pkg_id})")
+    lines.append(f".PHONY: {pkg_name}")
+    lines.append(f"{pkg_name}: $(PKG_STAMP_{pkg_id})")
     lines.append("")
 
     # Source preparation (fetch/extract/patch) runs without waiting for deps
@@ -132,11 +84,7 @@ def render(
         lines.append(f"$(PKG_STAMP_{pkg_id}): $(PKG_SRC_STAMP_{pkg_id}) {prereqs}")
     else:
         lines.append(f"$(PKG_STAMP_{pkg_id}): $(PKG_SRC_STAMP_{pkg_id})")
-    if pkg_version:
-        lines.append(f"\t@echo \"==> Build {actual_name} {pkg_version}\"")
-    else:
-        sys.stderr.write("no version\n")
-        sys.exit(1)
+    lines.append(f"\t@echo \"==> Build {pkg_name} {pkg_version}\"")
     lines.append(f"\t@$(MAKE) -C $(PKG_DIR_{pkg_id}) --no-print-directory")
     lines.append("")
 
@@ -151,27 +99,26 @@ def render(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a package depfile")
-    parser.add_argument("--package", required=True)
-    parser.add_argument("--makefile", required=True, type=pathlib.Path)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--ver", required=True)
+    parser.add_argument("--deps", default="")
     parser.add_argument("--pkg-dir", required=True, type=pathlib.Path)
     parser.add_argument("--pkg-env", required=True, type=pathlib.Path)
     parser.add_argument("--out", required=True, type=pathlib.Path)
     args = parser.parse_args()
 
-    name, version, deps = parse_makefile(args.makefile)
+    deps = args.deps.split()
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     content = render(
-        pkg_identifier=args.package,
-        pkg_name=name,
-        pkg_version=version,
+        pkg_name=args.name,
+        pkg_version=args.ver,
         deps=deps,
         pkg_dir=args.pkg_dir.resolve(),
         pkg_env=args.pkg_env.resolve(),
     )
-    args.out.write_text(content + "\n", encoding="utf-8")
+    args.out.write_text(content, encoding="utf-8")
 
 
 if __name__ == "__main__":
     main()
-

--- a/package/shared/pkg.mk
+++ b/package/shared/pkg.mk
@@ -23,8 +23,6 @@ PKG_META_PATH := $(abspath $(THIS_PKG)/$(PKG_META))
 ifeq (,$(wildcard $(PKG_META_PATH)))
 $(error $(PKG_META_PATH) not found)
 endif
-
-PKG_META_PATH := $(abspath $(CURDIR)/$(PKG_META))
 PKG_SOURCE_DIR ?= $(PKG_NAME)-$(PKG_VER)
 PKG_ARCHIVE ?= $(PKG_NAME)-$(PKG_VER).tar.gz
 PKG_SUBDIR ?= .
@@ -95,7 +93,7 @@ $(PKG_BUILD_LOG):
 	@mkdir -p $(@D)
 	@: > $@
 
-$(PKG_ARCHIVE_PATH): | $(PKG_META_PATH) $(PKG_WORK_DIR) $(PKG_BUILD_LOG)
+$(PKG_ARCHIVE_PATH): $(PKG_META_PATH) | $(PKG_WORK_DIR) $(PKG_BUILD_LOG)
 	$(call msg,GET)
 	@$(call run,vfetch $(PKG_META_PATH) $@)
 
@@ -145,10 +143,10 @@ PIP_WHEELS := $(PKG_CACHE_ROOT)/pip-wheels
 PKG_ENVIRONMENT += PIP_CACHE_DIR=$(PIP_CACHE)
 PKG_ENVIRONMENT += PIP_PREFER_BINARY=1
 
-$(PKG_CACHE_ROOT) $(PIP_WHEELS):
+$(PKG_CACHE_ROOT) $(PIP_CACHE) $(PIP_WHEELS):
 	@mkdir -p $@
 
-$(PKG_BUILD_STAMP): $(PKG_SOURCE_STAMP) | $(PKG_CACHE) $(PIP_WHEELS)
+$(PKG_BUILD_STAMP): $(PKG_SOURCE_STAMP) | $(PIP_CACHE) $(PIP_WHEELS)
 	$(call msg,BUILD)
 	@$(call run,env $(PKG_ENVIRONMENT) \
 		python3 -m pip wheel --wheel-dir $(PIP_WHEELS) $(PKG_SOURCE_PATH))
@@ -259,3 +257,13 @@ endif
 
 .PHONY: install
 install: $(PKG_INSTALL_STAMP)
+
+.PHONY: deps-mk
+deps-mk:
+	@python3 "$(DEPGEN)" \
+		--name "$(PKG_NAME)" \
+		--ver "$(PKG_VER)" \
+		--deps "$(PKG_DEPS)" \
+		--pkg-dir "$(THIS_PKG)" \
+		--pkg-env "$(abspath $(PKG_SHARED_DIR)pkg-env.mk)" \
+		--out "$(DEP_OUT)"


### PR DESCRIPTION
Replace static parsing of package Makefiles with a Make-driven approach. A new deps-mk target in pkg.mk invokes depgen.py with PKG_NAME, PKG_VER and PKG_DEPS already epanded, therefore making depgen.py just a renderer.

Fix 3 bugs in pkg.mk:
- PKG_META_PATH was assigned twice
- $(PKG_META_PATH) was an order-only prerequisite of the archive fetch rule, meaning if the meta file was touched it wouldn't invalidate the downloaded archive.
- $(PKG_CACHE) in the pysrc build stamp prerequisites was undefined. Replace it with what it should have been (PIP_CACHE).