### PR TITLE
doc: Add cli cmd to serve docs locally, link schema docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,6 +82,8 @@ rpi-image-gen is developed on Raspberry Pi OS, with Debian Bookworm and Trix
 
 * **link:docs/index.adoc[Index]** - Comprehensive reference for the configuration system, layer management, metadata, variable validation, provisioning, execution flow, etc.
 
+Documentation can be served locally using `rpi-image-gen docs`, which starts a web server on port 3142. Point your browser to the URL printed on startup.
+
 === Examples
 
 See the `examples/` directory for tips and help

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -9,12 +9,10 @@ For general information, see the https://github.com/raspberrypi/rpi-image-gen[pr
 
 == Viewing Documentation
 
-=== Online
 - **Technical Documentation**: https://raspberrypi.github.io/rpi-image-gen/
 - **Project Information**: https://github.com/raspberrypi/rpi-image-gen
 
-=== Offline
-The technical documentation HTML pages are browsable offline via `file:///path/to/page.html`.
+Documentation can be served locally using `rpi-image-gen docs`, which starts a web server on port 3142. Point your browser to the URL printed on startup.
 
 == Documentation Structure
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,12 +128,7 @@
         <div id="toc" class="toc">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-<li><a href="#_viewing_documentation">Viewing Documentation</a>
-<ul class="sectlevel2">
-<li><a href="#_online">Online</a></li>
-<li><a href="#_offline">Offline</a></li>
-</ul>
-</li>
+<li><a href="#_viewing_documentation">Viewing Documentation</a></li>
 <li><a href="#_documentation_structure">Documentation Structure</a></li>
 <li><a href="#_terminology">Terminology</a></li>
 </ul>
@@ -151,8 +146,6 @@
 <div class="sect1">
 <h2 id="_viewing_documentation"><a class="link" href="#_viewing_documentation">Viewing Documentation</a></h2>
 <div class="sectionbody">
-<div class="sect2">
-<h3 id="_online"><a class="link" href="#_online">Online</a></h3>
 <div class="ulist">
 <ul>
 <li>
@@ -163,12 +156,8 @@
 </li>
 </ul>
 </div>
-</div>
-<div class="sect2">
-<h3 id="_offline"><a class="link" href="#_offline">Offline</a></h3>
 <div class="paragraph">
-<p>The technical documentation HTML pages are browsable offline via <code><a href="file:///path/to/page.html" class="bare">file:///path/to/page.html</a></code>.</p>
-</div>
+<p>Documentation can be served locally using <code>rpi-image-gen docs</code>, which starts a web server on port 3142. Point your browser to the URL printed on startup.</p>
 </div>
 </div>
 </div>

--- a/docs/provisioning/index.adoc
+++ b/docs/provisioning/index.adoc
@@ -37,6 +37,9 @@ If an image layer is to support IDP, it must declare support of a provisioning m
 
 The IDP and PMAP document formats are formally defined by JSON schemas (draft-07), located in `layer/base/schemas/`. These decouple document validation from the rpi-image-gen build flow - any toolchain capable of producing a conforming IDP document can participate in the Raspberry Pi provisioning flow without depending on rpi-image-gen.
 
+* link:../schemas/idp/v2/schema.html[IDP Schema Reference]
+* link:../schemas/provisionmap/v1/schema.html[PMAP Schema Reference]
+
 Schema validation is performed automatically at build time. The schemas can also be used independently to validate hand-authored or third-party generated IDP and PMAP documents.
 
 === Benefits:

--- a/docs/provisioning/index.html
+++ b/docs/provisioning/index.html
@@ -209,6 +209,16 @@
 <div class="paragraph">
 <p>The IDP and PMAP document formats are formally defined by JSON schemas (draft-07), located in <code>layer/base/schemas/</code>. These decouple document validation from the rpi-image-gen build flow - any toolchain capable of producing a conforming IDP document can participate in the Raspberry Pi provisioning flow without depending on rpi-image-gen.</p>
 </div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="../schemas/idp/v2/schema.html">IDP Schema Reference</a></p>
+</li>
+<li>
+<p><a href="../schemas/provisionmap/v1/schema.html">PMAP Schema Reference</a></p>
+</li>
+</ul>
+</div>
 <div class="paragraph">
 <p>Schema validation is performed automatically at build time. The schemas can also be used independently to validate hand-authored or third-party generated IDP and PMAP documents.</p>
 </div>

--- a/docs/schemas
+++ b/docs/schemas
@@ -1,0 +1,1 @@
+../layer/base/schemas

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -18,6 +18,7 @@ Supported commands:
   layer    [options]    Layer operations (delegated)
   metadata [options]    Layer metadata operations (delegated)
   config   [options]    Config file operations (delegated)
+  docs                  Serve project documentation on http://<host>:3142
 
 Delegated commands are processed by the core engine helper (bin/ig).
 

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -32,6 +32,12 @@ shift
 case $cmd in
    build|clean|layer|metadata|config) ;;
    help) cli_help ; exit 0 ;;
+   doc*)
+      bind=$(hostname -I | cut -d' ' -f1)
+      echo "Point your browser at http://${bind}:3142"
+      python -m http.server 3142 --directory "${IGTOP}/docs/" --bind "$bind"
+      exit 0
+      ;;
    *) cli_help; die "Unknown command" ;;
 esac
 argv=("$@")


### PR DESCRIPTION
rpi-image-gen doc* starts a web server using python to serve the auto-generated HTML documentation on port 3142.
Link the IDP and PMAP schema dir from docs/provisioning to allow nav to the schema html docs.