### PR TITLE
Improve user account configuration 

### DIFF
--- a/docs/layer/device-base.html
+++ b/docs/layer/device-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>device-base</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.3.1</span>
+        <span class="badge">v2.0.0</span>
         <p>Device defaults.</p>
     </div>
     <div class="section">
@@ -203,8 +203,9 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_device_user1pass</code></td>
-                    <td>Password required to log into the user1 account. If
- empty, the account will be locked. Password requirements are as follows.
+                    <td>Password required to log into the user1 account.
+ If neither user1pass nor user1passhash is set, the account will be locked.
+ Password requirements are as follows.
  At least 8 characters.
  At least one lowercase letter.
  At least one uppercase letter.
@@ -214,6 +215,58 @@
                            <code>&lt;disabled&gt;</code>
                     </td>
                     <td>Must match regex pattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_device_user1passhash</code></td>
+                    <td>A pre-hashed password for the user1 account.
+ Generate using the provided genpasswd utility, or supply a hash created with
+ the same algorithm used by the chroot.
+ If neither user1pass nor user1passhash is set, the account will be locked.</td>
+                    <td>
+                           <code>&lt;disabled&gt;</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_device_user1sudo</code></td>
+                    <td>Controls sudo access for the user1 account. 'none' disables
+ sudo access entirely. 'passwd' requires a password for sudo. 'nopasswd' grants
+ passwordless sudo. If user1pass or user1passhash is set, defaults to 'passwd'.
+ Note: setting 'nopasswd' without a password is permitted but inadvisable.</td>
+                    <td>
+                           <code>none</code>
+                    </td>
+                    <td>Must be one of: none, passwd, nopasswd</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_device_user1uid</code></td>
+                    <td>The UID assigned to the user1 account. If unset,
+ one will be assigned automatically.</td>
+                    <td>
+                           <code>&lt;disabled&gt;</code>
+                    </td>
+                    <td>Integer value in range 1000 to 65533</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_device_user1gid</code></td>
+                    <td>The GID assigned to the user1 account. If unset,
+ one will be assigned automatically.</td>
+                    <td>
+                           <code>&lt;disabled&gt;</code>
+                    </td>
+                    <td>Integer value in range 1000 to 65533</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
                     </td>

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -207,11 +207,15 @@ Variable values support dynamic placeholders:
 Triggers (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
 
 * Conditional (same variable): `when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional (same variable, wildcard): `when=* set TARGET=VALUE [policy=force|immediate|lazy]`
 * Conditional (cross-variable): `when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
 * Conditional (cross-variable): `when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional (cross-variable, wildcard): `when=VAR=* set TARGET=VALUE [policy=force|immediate|lazy]`
 * Unconditional: `set TARGET=VALUE [policy=force|immediate|lazy]`
 
 For same-variable conditions, matching is an exact string comparison against the source variable's resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable's resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.
+
+The wildcard `*` matches any non-empty value. It will not fire if the variable is unset or set to an empty string.
 
 Lint will fail on:
 

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -603,10 +603,16 @@ mmdebstrap:
 <p>Conditional (same variable): <code>when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
 </li>
 <li>
+<p>Conditional (same variable, wildcard): <code>when=* set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+<li>
 <p>Conditional (cross-variable): <code>when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
 </li>
 <li>
 <p>Conditional (cross-variable): <code>when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+</li>
+<li>
+<p>Conditional (cross-variable, wildcard): <code>when=VAR=* set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
 </li>
 <li>
 <p>Unconditional: <code>set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
@@ -615,6 +621,9 @@ mmdebstrap:
 </div>
 <div class="paragraph">
 <p>For same-variable conditions, matching is an exact string comparison against the source variable&#8217;s resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable&#8217;s resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code> if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.</p>
+</div>
+<div class="paragraph">
+<p>The wildcard <code>*</code> matches any non-empty value. It will not fire if the variable is unset or set to an empty string.</p>
 </div>
 <div class="paragraph">
 <p>Lint will fail on:</p>

--- a/docs/layer/rpi-user-credentials.html
+++ b/docs/layer/rpi-user-credentials.html
@@ -123,11 +123,10 @@
     <div class="header">
         <h1>rpi-user-credentials</h1>
         <span class="badge">general</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Raspberry Pi base layer for local user admin.
  Creates a local account for user IGconf_device_user1, a home directory and
- adds the user to the standard Raspberry Pi groups. The user is also added to
- sudoers.</p>
+ adds the user to the standard Raspberry Pi groups. Sudo access is configurable.</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -59,6 +59,20 @@
 # X-Env-Var-user1passhash-Set: n
 # X-Env-Var-user1passhash-Conflicts: user1pass
 #
+# X-Env-Var-user1uid:
+# X-Env-Var-user1uid-Desc: The UID assigned to the user1 account. If unset,
+#  one will be assigned automatically.
+# X-Env-Var-user1uid-Required: n
+# X-Env-Var-user1uid-Valid: int:1000-65533
+# X-Env-Var-user1uid-Set: n
+#
+# X-Env-Var-user1gid:
+# X-Env-Var-user1gid-Desc: The GID assigned to the user1 account. If unset,
+#  one will be assigned automatically.
+# X-Env-Var-user1gid-Required: n
+# X-Env-Var-user1gid-Valid: int:1000-65533
+# X-Env-Var-user1gid-Set: n
+#
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Desc: Declares the storage media the image is intended
 #  for, as seen by the OS. For example, an NVMe backed disk connected via USB

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -36,8 +36,9 @@
 # X-Env-Var-user1-Set: y
 #
 # X-Env-Var-user1pass:
-# X-Env-Var-user1pass-Desc: Password required to log into the user1 account. If
-#  empty, the account will be locked. Password requirements are as follows.
+# X-Env-Var-user1pass-Desc: Password required to log into the user1 account.
+#  If neither user1pass nor user1passhash is set, the account will be locked.
+#  Password requirements are as follows.
 #  At least 8 characters.
 #  At least one lowercase letter.
 #  At least one uppercase letter.
@@ -46,6 +47,17 @@
 # X-Env-Var-user1pass-Required: n
 # X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
 # X-Env-Var-user1pass-Set: n
+# X-Env-Var-user1pass-Conflicts: user1passhash
+#
+# X-Env-Var-user1passhash:
+# X-Env-Var-user1passhash-Desc: A pre-hashed password for the user1 account.
+#  Generate using the provided genpasswd utility, or supply a hash created with
+#  the same algorithm used by the chroot.
+#  If neither user1pass nor user1passhash is set, the account will be locked.
+# X-Env-Var-user1passhash-Required: n
+# X-Env-Var-user1passhash-Valid: string
+# X-Env-Var-user1passhash-Set: n
+# X-Env-Var-user1passhash-Conflicts: user1pass
 #
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Desc: Declares the storage media the image is intended

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Device defaults.
-# X-Env-Layer-Version: 1.3.1
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Requires:
 # X-Env-Layer-RequiresProvider: device
 #
@@ -48,6 +48,7 @@
 # X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
 # X-Env-Var-user1pass-Set: n
 # X-Env-Var-user1pass-Conflicts: user1passhash
+# X-Env-Var-user1pass-Triggers: when=* set IGconf_device_user1sudo=passwd policy=lazy
 #
 # X-Env-Var-user1passhash:
 # X-Env-Var-user1passhash-Desc: A pre-hashed password for the user1 account.
@@ -58,6 +59,16 @@
 # X-Env-Var-user1passhash-Valid: string
 # X-Env-Var-user1passhash-Set: n
 # X-Env-Var-user1passhash-Conflicts: user1pass
+# X-Env-Var-user1passhash-Triggers: when=* set IGconf_device_user1sudo=passwd policy=lazy
+#
+# X-Env-Var-user1sudo: none
+# X-Env-Var-user1sudo-Desc: Controls sudo access for the user1 account. 'none' disables
+#  sudo access entirely. 'passwd' requires a password for sudo. 'nopasswd' grants
+#  passwordless sudo. If user1pass or user1passhash is set, defaults to 'passwd'.
+#  Note: setting 'nopasswd' without a password is permitted but inadvisable.
+# X-Env-Var-user1sudo-Required: n
+# X-Env-Var-user1sudo-Valid: none,passwd,nopasswd
+# X-Env-Var-user1sudo-Set: lazy
 #
 # X-Env-Var-user1uid:
 # X-Env-Var-user1uid-Desc: The UID assigned to the user1 account. If unset,

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -18,6 +18,7 @@ mmdebstrap:
     - adduser
   customize-hooks:
     - |-
+      # Account creation
       set -eu
       uid_arg=""
       gid_arg=""
@@ -27,6 +28,7 @@ mmdebstrap:
           chroot $1 adduser --disabled-password --gecos "" $uid_arg $gid_arg "$IGconf_device_user1"
       fi
     - |-
+      # Password and group
       set -eu
       if [ -n "${IGconf_device_user1passhash:-}" ] ; then
          printf '%s:%s\n' "$IGconf_device_user1" "$IGconf_device_user1passhash" | chroot $1 chpasswd -e
@@ -41,7 +43,13 @@ mmdebstrap:
          adduser $IGconf_device_user1 \$GRP;
       done"
     - |-
+      # Sudo
       set -eu
+      if [ "$IGconf_device_user1sudo" = "nopasswd" ] &&
+         [ -z "${IGconf_device_user1pass:-}" ] &&
+         [ -z "${IGconf_device_user1passhash:-}" ]; then
+            echo "WARNING: user1sudo=nopasswd but no user1 password is set." >&2
+      fi
       case "$IGconf_device_user1sudo" in
         nopasswd)
           sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
@@ -54,6 +62,7 @@ mmdebstrap:
       esac
     - mkdir -p $1/etc/profile.d
     - |-
+      # Profile
       cat <<- 'EOCHROOT' > $1/etc/profile.d/01local.sh
       #!/bin/sh
       if [ "$(id -u)" -ne 0 ]; then

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -4,12 +4,12 @@
 #  Creates a local account for user IGconf_device_user1, a home directory and
 #  adds the user to the standard Raspberry Pi groups. The user is also added to
 #  sudoers.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 #
 # X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash
+# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid
 # METAEND
 ---
 mmdebstrap:
@@ -18,10 +18,17 @@ mmdebstrap:
     - login
     - adduser
   customize-hooks:
-    - chroot $1 sh -c "if ! id -u $IGconf_device_user1 >/dev/null 2>&1; then
-        adduser --disabled-password --gecos \"\"  $IGconf_device_user1;
-        fi"
     - |-
+      set -eu
+      uid_arg=""
+      gid_arg=""
+      if [ -n "${IGconf_device_user1uid:-}" ]; then uid_arg="--uid ${IGconf_device_user1uid}"; fi
+      if [ -n "${IGconf_device_user1gid:-}" ]; then gid_arg="--gid ${IGconf_device_user1gid}"; fi
+      if ! chroot $1 id -u "$IGconf_device_user1" >/dev/null 2>&1; then
+          chroot $1 adduser --disabled-password --gecos "" $uid_arg $gid_arg "$IGconf_device_user1"
+      fi
+    - |-
+      set -eu
       if [ -n "$IGconf_device_user1passhash" ] ; then
          printf '%s:%s\n' "${IGconf_device_user1}" "${IGconf_device_user1passhash}" | chroot $1 chpasswd -e
       elif [ -n "$IGconf_device_user1pass" ] ; then

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -23,7 +23,12 @@ mmdebstrap:
       uid_arg=""
       gid_arg=""
       if [ -n "${IGconf_device_user1uid:-}" ]; then uid_arg="--uid ${IGconf_device_user1uid}"; fi
-      if [ -n "${IGconf_device_user1gid:-}" ]; then gid_arg="--gid ${IGconf_device_user1gid}"; fi
+      if [ -n "${IGconf_device_user1gid:-}" ]; then
+          gid_arg="--gid ${IGconf_device_user1gid}"
+          if ! chroot $1 getent group "${IGconf_device_user1gid}" >/dev/null 2>&1; then
+              chroot $1 groupadd -g "${IGconf_device_user1gid}" "${IGconf_device_user1}"
+          fi
+      fi
       if ! chroot $1 id -u "$IGconf_device_user1" >/dev/null 2>&1; then
           chroot $1 adduser --disabled-password --gecos "" $uid_arg $gid_arg "$IGconf_device_user1"
       fi

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -2,14 +2,13 @@
 # X-Env-Layer-Name: rpi-user-credentials
 # X-Env-Layer-Desc: Raspberry Pi base layer for local user admin.
 #  Creates a local account for user IGconf_device_user1, a home directory and
-#  adds the user to the standard Raspberry Pi groups. The user is also added to
-#  sudoers.
-# X-Env-Layer-Version: 2.1.0
+#  adds the user to the standard Raspberry Pi groups. Sudo access is configurable.
+# X-Env-Layer-Version: 3.0.0
 #
 # X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid
+# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid,IGconf_device_user1sudo
 # METAEND
 ---
 mmdebstrap:
@@ -29,10 +28,10 @@ mmdebstrap:
       fi
     - |-
       set -eu
-      if [ -n "$IGconf_device_user1passhash" ] ; then
-         printf '%s:%s\n' "${IGconf_device_user1}" "${IGconf_device_user1passhash}" | chroot $1 chpasswd -e
-      elif [ -n "$IGconf_device_user1pass" ] ; then
-         printf '%s:%s\n' "${IGconf_device_user1}" "${IGconf_device_user1pass}" | chroot $1 chpasswd
+      if [ -n "${IGconf_device_user1passhash:-}" ] ; then
+         printf '%s:%s\n' "$IGconf_device_user1" "$IGconf_device_user1passhash" | chroot $1 chpasswd -e
+      elif [ -n "${IGconf_device_user1pass:-}" ] ; then
+         printf '%s:%s\n' "$IGconf_device_user1" "$IGconf_device_user1pass" | chroot $1 chpasswd
       fi
     - chroot $1 usermod --pass='*' root
     - chroot $1 sh -c "for GRP in input spi i2c gpio; do
@@ -41,7 +40,18 @@ mmdebstrap:
     - chroot $1 sh -c "for GRP in adm dialout cdrom audio users sudo video games plugdev input spi i2c gpio render ; do
          adduser $IGconf_device_user1 \$GRP;
       done"
-    - sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+    - |-
+      set -eu
+      case "$IGconf_device_user1sudo" in
+        nopasswd)
+          sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+          ;;
+        passwd)
+          echo "$IGconf_device_user1 ALL=(ALL:ALL) ALL" > $1/etc/sudoers.d/010_pi-nopasswd
+          ;;
+        none)
+          ;;
+      esac
     - mkdir -p $1/etc/profile.d
     - |-
       cat <<- 'EOCHROOT' > $1/etc/profile.d/01local.sh

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -4,12 +4,12 @@
 #  Creates a local account for user IGconf_device_user1, a home directory and
 #  adds the user to the standard Raspberry Pi groups. The user is also added to
 #  sudoers.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 2.0.0
 #
 # X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-VarOptional: IGconf_device_user1pass
+# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash
 # METAEND
 ---
 mmdebstrap:
@@ -22,8 +22,10 @@ mmdebstrap:
         adduser --disabled-password --gecos \"\"  $IGconf_device_user1;
         fi"
     - |-
-      if [ -n "$IGconf_device_user1pass" ] ; then
-         chroot $1 sh -c "printf '%s:%s\n' '${IGconf_device_user1}' '${IGconf_device_user1pass}' | chpasswd"
+      if [ -n "$IGconf_device_user1passhash" ] ; then
+         printf '%s:%s\n' "${IGconf_device_user1}" "${IGconf_device_user1passhash}" | chroot $1 chpasswd -e
+      elif [ -n "$IGconf_device_user1pass" ] ; then
+         printf '%s:%s\n' "${IGconf_device_user1}" "${IGconf_device_user1pass}" | chroot $1 chpasswd
       fi
     - chroot $1 usermod --pass='*' root
     - chroot $1 sh -c "for GRP in input spi i2c gpio; do

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -1072,10 +1072,16 @@ class VariableResolver:
 
         Supported forms:
         - same-variable value condition: "btrfs"
+        - same-variable wildcard: "*" (matches any non-empty value)
         - cross-variable equality: "IGconf_device_storage_type=emmc"
         - cross-variable inequality: "IGconf_device_storage_type!=emmc"
+        - cross-variable wildcard: "IGconf_device_storage_type=*" (matches any non-empty value)
         """
         import os
+
+        def _is_set(v: str) -> bool:
+            """Return True if the value is meaningfully set (non-empty, non-None)."""
+            return v not in ("", "None")
 
         if "!=" in condition:
             lhs, rhs = condition.split("!=", 1)
@@ -1084,6 +1090,8 @@ class VariableResolver:
             lhs, rhs = condition.split("=", 1)
             op = "="
         else:
+            if condition == "*":
+                return _is_set(source_effective_value)
             return source_effective_value == condition
 
         lhs = lhs.strip()
@@ -1096,7 +1104,8 @@ class VariableResolver:
         elif lhs in os.environ:
             lhs_value = str(os.environ.get(lhs, ""))
         elif lhs in resolved:
-            lhs_value = str(resolved[lhs].value)
+            raw = resolved[lhs].value
+            lhs_value = "" if raw is None else str(raw)
         else:
             layer_note = f" (layer: {source_layer})" if source_layer else ""
             raise ValueError(
@@ -1104,6 +1113,8 @@ class VariableResolver:
             )
 
         if op == "=":
+            if rhs == "*":
+                return _is_set(lhs_value)
             return lhs_value == rhs
         return lhs_value != rhs
 

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -269,6 +269,16 @@ run_test "triggers-quoted-ext4-not-set" \
     0 \
     "Trigger for non-matching condition should not set variable"
 
+run_test "triggers-wildcard-fires-when-set" \
+    'cleanup_env; TMP_OUT=$(mktemp); IGconf_trigw_source=hello ig metadata --parse ${META}/valid-triggers-wildcard.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_WILDCARD_SAME=\"1\"$" "$TMP_OUT" && grep "^IG_TRIG_WILDCARD_CROSS=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
+    0 \
+    "Wildcard trigger (when=*) should fire when variable is set to a non-empty value"
+
+run_test "triggers-wildcard-silent-when-unset" \
+    'cleanup_env; TMP_OUT=$(mktemp); ig metadata --parse ${META}/valid-triggers-wildcard.yaml --write-out "$TMP_OUT" && ! grep "^IG_TRIG_WILDCARD_SAME=" "$TMP_OUT" && ! grep "^IG_TRIG_WILDCARD_CROSS=" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
+    0 \
+    "Wildcard trigger (when=*) should not fire when variable is unset"
+
 # ---------------------------------------------------------------------------
 print_header "INVALID METADATA TESTS"
 

--- a/test/meta/valid-triggers-wildcard.yaml
+++ b/test/meta/valid-triggers-wildcard.yaml
@@ -1,0 +1,16 @@
+# METABEGIN
+# X-Env-Layer-Name: test-triggers-wildcard
+# X-Env-Layer-Desc: Trigger wildcard condition - fires when variable is set to any non-empty value
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: trigw
+#
+# X-Env-Var-source:
+# X-Env-Var-source-Desc: Source variable for wildcard trigger tests
+# X-Env-Var-source-Valid: string
+# X-Env-Var-source-Required: n
+# X-Env-Var-source-Set: n
+# X-Env-Var-source-Triggers:
+#  when=* set IG_TRIG_WILDCARD_SAME=1 policy=force
+#  when=IGconf_trigw_source=* set IG_TRIG_WILDCARD_CROSS=1 policy=force
+# METAEND


### PR DESCRIPTION
Extends and improve user account creation and configuration in the rpi-user-credentials layer:

1. Pre-hashed passwords (user1passhash) as an alternative to plaintext (user1pass). The two are mutually exclusive.
2. Configurable UID/GID for the user1 account.
3. Configurable sudo access (user1sudo: none, passwd, nopasswd). Defaults to none. Auto-sets to passwd via a lazy trigger when a password is provided.

3 is a **breaking change**: previously, passwordless sudo was always granted. Existing configs requiring this must now set user1sudo=nopasswd explicitly. 

The above provides a lot more configuration options. For example, set a pre-hashed password for user1 with sudo requiring a password, and specify UID & GID:

```
device:
  layer: rpi5
  user1passhash: $y$j9T$7bTBswPngKo6Y6JSDsCzp1$OaLqfy.yPZKeiep7lgm6ovPKJpjN8VIl4WYfgIa4m9.
  user1sudo: passwd
  user1uid: 1234
  user1gid: 5678
```


