### PR TITLE
config: add packages hook and document well-known section names

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -261,6 +261,68 @@ Therefore, included files are resolved using:
 1. **Parent directory**
 2. **Search path**
 
+== Section Names
+
+Any section name used in a configuration file maps directly to the `IGconf_<section>_*` variable namespace. A layer can declare a section via `X-Env-VarPrefix` in its metadata. This means that the set of meaningful section names in a build is determined by the layers included. Declaring a section allows a layer to expose a group of configuration variables. Some section names carry specific functional meaning because the build system actively responds to them.
+
+=== device
+
+The `device` section (`X-Env-VarPrefix: device`) holds variables describing the target hardware. Variables in this section are declared by `device-base` and downstream device layers.
+
+The `device.layer` key has functional meaning: it's one way to specify the device layer to include in the build.
+
+=== image
+
+The `image` section (`X-Env-VarPrefix: image`) holds variables that control image construction. Variables in this section are declared by `image-base` and downstream image layers.
+
+The `image.layer` key has functional meaning: it's one way to specify the image layer to include in the build.
+
+=== layer
+
+The `layer` section is used to specify layers to include in the build. Each key names an extra layer:
+
+[source,yaml]
+----
+layer:
+  app: my-app-layer
+  extra: rpi-splash-screen
+----
+
+The key names are arbitrary - only the values matter. Lists are also supported. This is the primary mechanism for composing a build from multiple optional layers. Device and image layers can be specified here, too:
+
+[source,yaml]
+----
+layer:
+  - rpi-cm5
+  - image-rota
+----
+
+=== packages
+
+The `packages` section triggers automatic package installation into the target rootfs during the build. Each entry is either an apt package name or a path to a local `.deb` file on the build host.
+
+[source,yaml]
+----
+packages:
+  - curl
+  - vim
+  - git
+----
+
+Local `.deb` files are specified by path and are detected by the presence of the file on the build host at the time the hook runs:
+
+[source,yaml]
+----
+packages:
+  apt: curl
+  local1: /path/to/mypkg_1.0_arm64.deb
+  local2: myotherpkg_2.0_arm64.deb
+----
+
+Both list and mapping forms are supported. Local `.deb` files are installed before apt packages so that apt can satisfy any dependencies they introduce.
+
+Absolute paths are fully supported. Relative paths are resolved from the source directory and require `-S` to be specified, falling back to the rpi-image-gen root directory.
+
 == Variable Sources and Precedence
 
 The configuration system supports multiple variable sources with a clear precedence hierarchy:

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -158,6 +158,14 @@
 </li>
 </ul>
 </li>
+<li><a href="#_section_names">Section Names</a>
+<ul class="sectlevel2">
+<li><a href="#_device">device</a></li>
+<li><a href="#_image">image</a></li>
+<li><a href="#_layer">layer</a></li>
+<li><a href="#_packages">packages</a></li>
+</ul>
+</li>
 <li><a href="#_variable_sources_and_precedence">Variable Sources and Precedence</a>
 <ul class="sectlevel2">
 <li><a href="#_command_line_overrides">Command Line Overrides</a></li>
@@ -590,6 +598,86 @@ root_part_size = 300%</code></pre>
 </li>
 </ol>
 </div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_names"><a class="anchor" href="#_section_names"></a><a class="link" href="#_section_names">Section Names</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Any section name used in a configuration file maps directly to the <code>IGconf_&lt;section&gt;_*</code> variable namespace. A layer can declare a section via <code>X-Env-VarPrefix</code> in its metadata. This means that the set of meaningful section names in a build is determined by the layers included. Declaring a section allows a layer to expose a group of configuration variables. Some section names carry specific functional meaning because the build system actively responds to them.</p>
+</div>
+<div class="sect2">
+<h3 id="_device"><a class="anchor" href="#_device"></a><a class="link" href="#_device">device</a></h3>
+<div class="paragraph">
+<p>The <code>device</code> section (<code>X-Env-VarPrefix: device</code>) holds variables describing the target hardware. Variables in this section are declared by <code>device-base</code> and downstream device layers.</p>
+</div>
+<div class="paragraph">
+<p>The <code>device.layer</code> key has functional meaning: it&#8217;s one way to specify the device layer to include in the build.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_image"><a class="anchor" href="#_image"></a><a class="link" href="#_image">image</a></h3>
+<div class="paragraph">
+<p>The <code>image</code> section (<code>X-Env-VarPrefix: image</code>) holds variables that control image construction. Variables in this section are declared by <code>image-base</code> and downstream image layers.</p>
+</div>
+<div class="paragraph">
+<p>The <code>image.layer</code> key has functional meaning: it&#8217;s one way to specify the image layer to include in the build.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_layer"><a class="anchor" href="#_layer"></a><a class="link" href="#_layer">layer</a></h3>
+<div class="paragraph">
+<p>The <code>layer</code> section is used to specify layers to include in the build. Each key names an extra layer:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">layer:
+  app: my-app-layer
+  extra: rpi-splash-screen</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The key names are arbitrary - only the values matter. Lists are also supported. This is the primary mechanism for composing a build from multiple optional layers. Device and image layers can be specified here, too:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">layer:
+  - rpi-cm5
+  - image-rota</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_packages"><a class="anchor" href="#_packages"></a><a class="link" href="#_packages">packages</a></h3>
+<div class="paragraph">
+<p>The <code>packages</code> section triggers automatic package installation into the target rootfs during the build. Each entry is either an apt package name or a path to a local <code>.deb</code> file on the build host.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">packages:
+  - curl
+  - vim
+  - git</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Local <code>.deb</code> files are specified by path and are detected by the presence of the file on the build host at the time the hook runs:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">packages:
+  apt: curl
+  local1: /path/to/mypkg_1.0_arm64.deb
+  local2: myotherpkg_2.0_arm64.deb</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Both list and mapping forms are supported. Local <code>.deb</code> files are installed before apt packages so that apt can satisfy any dependencies they introduce.</p>
+</div>
+<div class="paragraph">
+<p>Absolute paths are fully supported. Relative paths are resolved from the source directory and require <code>-S</code> to be specified, falling back to the rpi-image-gen root directory.</p>
 </div>
 </div>
 </div>

--- a/examples/debstore/README.md
+++ b/examples/debstore/README.md
@@ -1,9 +1,21 @@
 Build a system with a custom YAML layer to install locally stored Debian packages in the chroot.
 
+> **Note:** For most use cases, local `.deb` files and apt packages can be installed directly via a
+> `[packages]` config section without a custom layer. See the configuration documentation for
+> details. This example remains useful if you need finer control over the installation process.
+
+For example, to install a local package and one from a remote repository, use the following config file addition:
+
+```yaml
+packages:
+  - pkgs/mypkg_1.0_arm64.deb
+  - curl
+```
+
 ```text
 examples/debstore/
 |-- config
-|   `-- deb12-store.yaml
+|   `-- deb-store.yaml
 |-- layer
 |   `-- debstore-installer.yaml
 |-- pkgs
@@ -13,5 +25,5 @@ examples/debstore/
 First, copy the .deb files to examples/debstore/pkgs then:
 
 ```bash
-rpi-image-gen build -S ./examples/debstore/ -c deb12-store.yaml
+rpi-image-gen build -S ./examples/debstore/ -c deb-store.yaml
 ```

--- a/examples/debstore/config/deb-store.yaml
+++ b/examples/debstore/config/deb-store.yaml
@@ -1,5 +1,5 @@
 include:
-  file: bookworm-minbase.yaml
+  file: trixie-minbase.yaml
 
 image:
   name: debstore-test

--- a/scripts/bdebstrap/customize05-packages
+++ b/scripts/bdebstrap/customize05-packages
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eu
+
+# Install packages declared via IGconf_packages_* variables.
+#
+# Values that resolve to an existing file are treated as local .deb packages.
+# Others are treated as package names.
+# All are installed by apt.
+
+apt_pkgs=()
+deb_files=()
+
+for var in "${!IGconf_packages_@}"; do
+    val="${!var}"
+    [[ -z "$val" ]] && continue
+
+    orig_val="$val"
+    if [[ "$val" != /* ]]; then
+        val="${SRCROOT:-${IGTOP}}/$val"
+    fi
+
+    if [[ -f "$val" ]]; then
+        deb_files+=("$val")
+    elif [[ "$orig_val" == *.deb || "$orig_val" == */* ]]; then
+        echo "packages: $var: file not found: $orig_val" >&2
+        exit 1
+    else
+        apt_pkgs+=("$orig_val")
+    fi
+done
+
+# No packages = nothing to do
+[[ ${#deb_files[@]} -eq 0 && ${#apt_pkgs[@]} -eq 0 ]] && exit 0
+
+# Install now.
+# debs are installed first so apt can satisfy dependencies the introduce.
+if [[ ${#deb_files[@]} -gt 0 ]]; then
+    tmpdir=$(mktemp -d "$1/tmp/packages.XXXXXX")
+    trap 'rm -rf "$tmpdir"' EXIT
+    chroot_tmp="/tmp/$(basename "$tmpdir")"
+    chroot_debs=()
+    for f in "${deb_files[@]}"; do
+        cp "$f" "$tmpdir/"
+        chroot_debs+=("$chroot_tmp/$(basename "$f")")
+    done
+    chroot "$1" apt install -y "${chroot_debs[@]}"
+fi
+
+if [[ ${#apt_pkgs[@]} -gt 0 ]]; then
+    chroot "$1" apt install -y "${apt_pkgs[@]}"
+fi


### PR DESCRIPTION
Add a bdebstrap customize hook that automatically installs packages declared via a [packages] config section. Values resolving to existing files are installed as local .deb packages. All others are passed to apt. Docs updated.

This largely obsoletes examples/debstore, which required a custom layer to achieve the same result. The example is retained for cases where finer control over the installation process may be needed, and has been updated to use a trixie base config.