### PR TITLE
Improve PMAP doc handling and slim example

### DIFF
--- a/bin/pmap
+++ b/bin/pmap
@@ -17,6 +17,9 @@ def pmap_version(data):
     value = get_key(data, "attributes.PMAPversion")
     if value is None:
         # Try parsing as fully assembled image.json
+        pmap_data = get_key(data, "layout.provisionmap")
+        if isinstance(pmap_data, list) and len(pmap_data) == 0:
+            return None
         value = get_key(data, "layout.provisionmap.attributes.PMAPversion")
         if value is None:
             sys.stderr.write("Error: No version\n")
@@ -283,7 +286,17 @@ if __name__ == '__main__':
         sys.stderr.write(f"Error: invalid JSON: {e}\n")
         sys.exit(1)
 
-    major, minor, patch = validate(data, args.schema)
+    version = validate(data, args.schema)
+
+    if version is None:
+        # IDP doc with no PMAP. schema validation passed but PMAP
+        # specific ops are not possible
+        if args.slotvars or args.cryptvars:
+            sys.stderr.write("Error: No PMAP in IDP doc\n")
+            sys.exit(1)
+        sys.exit(0)
+
+    major, minor, patch = version
 
     if args.get_key:
         value = get_key(data, args.get_key)

--- a/examples/slim/image/compact/genimage.cfg.in
+++ b/examples/slim/image/compact/genimage.cfg.in
@@ -1,3 +1,21 @@
+image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
+   android-sparse {
+      image = <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX>
+   }
+}
+
+image boot.vfat.sparse {
+   android-sparse {
+      image = boot.vfat
+   }
+}
+
+image root.ext4.sparse {
+   android-sparse {
+      image = root.ext4
+   }
+}
+
 image <IMAGE_DIR>/<IMAGE_NAME>.<IMAGE_SUFFIX> {
    hdimage {
       partition-table-type = "mbr"

--- a/layer/base/schemas/provisionmap/v1/schema.html
+++ b/layer/base/schemas/provisionmap/v1/schema.html
@@ -58,7 +58,7 @@
         
         
 
-         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+        <p><span class="badge badge-light restriction min-items-restriction" id="oneOf_i0_minItems">Must contain a minimum of <code>1</code> items</span></p> <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
     <div class="card">
         <div class="card-body items-definition" id="oneOf_i0_items">
             
@@ -3910,7 +3910,7 @@
         
         
 
-         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+        <p><span class="badge badge-light restriction min-items-restriction" id="oneOf_i1_layout_provisionmap_minItems">Must contain a minimum of <code>1</code> items</span></p> <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
     <div class="card">
         <div class="card-body items-definition" id="oneOf_i1_layout_provisionmap_items">
             
@@ -4073,6 +4073,6 @@
         
 
     <footer>
-        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-03-05 at 17:39:34 +0000</p>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-03-30 at 14:27:01 +0100</p>
     </footer></body>
 </html>

--- a/layer/base/schemas/provisionmap/v1/schema.json
+++ b/layer/base/schemas/provisionmap/v1/schema.json
@@ -7,6 +7,7 @@
     {
       "description": "A standalone PMAP document as a bare array of entries.",
       "type": "array",
+      "minItems": 1,
       "items": { "$ref": "#/$defs/entry" }
     },
     {
@@ -24,6 +25,7 @@
             "provisionmap": {
               "description": "The provisioning map array embedded in the IDP layout.",
               "type": "array",
+              "minItems": 1,
               "items": { "$ref": "#/$defs/entry" }
             }
           }

--- a/layer/base/schemas/provisionmap/v1/schema.md
+++ b/layer/base/schemas/provisionmap/v1/schema.md
@@ -81,7 +81,7 @@
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
-| **Min items**        | N/A                |
+| **Min items**        | 1                  |
 | **Max items**        | N/A                |
 | **Items unicity**    | False              |
 | **Additional items** | False              |
@@ -784,7 +784,7 @@ Must be one of:
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
-| **Min items**        | N/A                |
+| **Min items**        | 1                  |
 | **Max items**        | N/A                |
 | **Items unicity**    | False              |
 | **Additional items** | False              |
@@ -806,4 +806,4 @@ Must be one of:
 **Description:** A single PMAP entry.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-03-05 at 17:39:33 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-03-30 at 14:27:01 +0100

--- a/layer/debian/bookworm/arm64/base-slim.yaml
+++ b/layer/debian/bookworm/arm64/base-slim.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Bookworm custom layer for arm64 providing
 #  a usable and practical base.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: locale-base
 #
 # X-Env-VarRequires: IGconf_locale_timezone,
@@ -36,6 +36,7 @@ mmdebstrap:
     - gzip
     - udev
     - e2fsprogs
+    - debian-archive-keyring
   setup-hooks:
     - mkdir -p $1/bin
     - ln -s bash $1/bin/sh

--- a/layer/debian/trixie/arm64/base-slim.yaml
+++ b/layer/debian/trixie/arm64/base-slim.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Trixie custom layer for arm64 providing
 #  a usable and practical base.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: locale-base
 #
 # X-Env-VarRequires: IGconf_locale_timezone,
@@ -37,6 +37,7 @@ mmdebstrap:
     - udev
     - e2fsprogs
     - linux-sysctl-defaults
+    - debian-archive-keyring
   setup-hooks:
     - mkdir -p $1/usr/bin
     - ln -s bash $1/usr/bin/sh


### PR DESCRIPTION
If validating against the provisioning map (PMAP) schema, the array must have at least one entry.
As a result, `bin/pmap` no longer silently allows an empty embedded PMAP in the IDP doc when validating against the PMAP schema (bug fix).

Add sparse image generation to `examples/slim` so it passes IDP doc validation (IDP mandates that every partition must have a sparse image reference).

Since Debian slim layers use `variant: custom` they must explicitly list all packages to install. As we now use deb822 mirror specs, our core `signed-by` hook will check to make sure that each repo can be signed by the applicable keyring, and if not found in the chroot will deliberately fail the build. We need `debian-archive-keyring` to be installed in order for the Debian repos to be authenticated, so the package needs to be added to the install list.