### PR TITLE
Deployable .tar.zst to integrate with rpi-sb-provisioner

### DIFF
--- a/layer/base/deploy-base.yaml
+++ b/layer/base/deploy-base.yaml
@@ -10,7 +10,7 @@
 # X-Env-VarRequires: IGconf_sys_workroot,IGconf_artefact_version
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-Var-compression: none
+# X-Env-Var-compression: zstd
 # X-Env-Var-compression-Desc: Compression scheme used when deploying assets.
 #  Identifier for the compression scheme applied to final deployment artefacts.
 #  This setting affects how final assets (disk images, filesystem tarballs,

--- a/layer/base/deploy.sh
+++ b/layer/base/deploy.sh
@@ -77,3 +77,18 @@ echo "Creating manifest..."
   echo "  ]"
   echo "}"
 } > "$IGconf_deploy_dir/deployed.json"
+
+# Create a .tar.zst IDP archive suitable for upload to rpi-sb-provisioner.
+# Bundles uncompressed image.json + sparse images at the top level of the tar.
+if [[ -f "${IGconf_image_outputdir}/image.json" ]]; then
+    echo "Creating IDP archive..."
+    idp_files=("image.json")
+    for f in "${IGconf_image_outputdir}"/*.sparse; do
+        [[ -f "$f" ]] && idp_files+=("$(basename "$f")")
+    done
+
+    archive_name="${IGconf_image_name:-image}-${IGconf_artefact_version:-unknown}.tar.zst"
+    tar -C "${IGconf_image_outputdir}" -cf - "${idp_files[@]}" \
+        | zstd -f -o "$IGconf_deploy_dir/$archive_name"
+    echo "Created IDP archive: $IGconf_deploy_dir/$archive_name"
+fi

--- a/layer/base/deploy.sh
+++ b/layer/base/deploy.sh
@@ -80,7 +80,8 @@ echo "Creating manifest..."
 
 # Create a .tar.zst IDP archive suitable for upload to rpi-sb-provisioner.
 # Bundles uncompressed image.json + sparse images at the top level of the tar.
-if [[ -f "${IGconf_image_outputdir}/image.json" ]]; then
+# Requires zstd, so only run when the compression scheme guarantees it is available.
+if [[ "$IGconf_deploy_compression" == "zstd" ]] && [[ -f "${IGconf_image_outputdir}/image.json" ]]; then
     echo "Creating IDP archive..."
     idp_files=("image.json")
     for f in "${IGconf_image_outputdir}"/*.sparse; do


### PR DESCRIPTION
To simplify ingesting rpi-image-gen artefacts in rpi-sb-provisioner, generate .tar.zst archives that include the IDP json file and the various simg files.