### PR TITLE
Layer overlay support and hook fixes

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -11,8 +11,9 @@ add_dir() {
    fi
 }
 
-phase="$1"
-shift 1
+PHASE="$1"
+PLAN="$2"
+shift 2
 
 
 # Script bundles in these dirs are executed in this order
@@ -48,6 +49,12 @@ IGROOT:post-image.sh \
 IGdevice:post-image.sh IGimage:post-image.sh \
 DEVICE_ASSET:post-image.sh IMAGE_ASSET:post-image.sh \
 SRCROOT:post-image.sh"
+
+   [finalize]="\
+IGROOT:finalize.sh \
+IGdevice:finalize.sh IGimage:finalize.sh \
+DEVICE_ASSET:finalize.sh IMAGE_ASSET:finalize.sh \
+SRCROOT:finalize.sh"
 
    [sbom]='VAR:IGconf_sbom_hook'
    [deploy]='VAR:IGconf_deploy_hook'
@@ -174,30 +181,56 @@ phase_args() {
 }
 
 
-msg "runner: in $phase"
-case "$phase" in
+# Apply per-layer rootfs overlays using the layer plan.
+# YAML layer customize-hooks can execute before the discrete hooks get executed
+# by runner. This is because bdebstrap's --XXX-hook arg is invoked after the
+# merged YAML. Unfortunately, this means that a YAML layer's customize-hooks
+# cannot rely on the layer's overlay being applied before they run.
+apply_layer_overlays() {
+   local dest=$1
+   local plan=${PLAN:-}
+   [[ -n $plan && -f $plan ]] || return 0
+
+   local layer static resolved overlay
+   while IFS=: read -r layer static resolved; do
+      [[ -n $layer && -n $static ]] || continue
+      [[ $layer == \#* ]] && continue
+      overlay="${static%.yaml}.rootfs-overlay"
+      if [[ -d $overlay ]]; then
+         msg "runner: layer overlay ($layer) [$overlay -> $dest]"
+         rsync -a -- "$overlay"/ "$dest"/
+         local rc=$?
+         [[ $rc -eq 0 ]] || die "runner: error applying layer overlay for $layer ($rc)"
+      fi
+   done < "$plan"
+}
+
+
+msg "runner: in $PHASE"
+case "$PHASE" in
    setup)
-      run_hook_phase "$phase" "$@"
-      run_phase_scripts "$phase" "$@"
+      run_hook_phase "$PHASE" "$@"
+      run_phase_scripts "$PHASE" "$@"
       ;;
    customize)
-      run_phase_scripts "$phase" "$@"
-      apply_overlays "$phase" "$@"
-      run_hook_phase "$phase" "$@"
+      apply_layer_overlays "$@"
+      apply_overlays "$PHASE" "$@"
+      run_phase_scripts "$PHASE" "$@"
+      run_hook_phase "$PHASE" "$@"
       ;;
    extract|essential|cleanup)
-      run_phase_scripts "$phase" "$@"
+      run_phase_scripts "$PHASE" "$@"
       ;;
    post-build)
-      run_hook_phase "$phase" "$@"
+      run_hook_phase "$PHASE" "$@"
       ;;
    pre-image|post-image)
-      run_hook_phase "$phase" "$@"
+      run_hook_phase "$PHASE" "$@"
       ;;
-   sbom|deploy)
-      run_hook_phase "$phase" "$@"
+   finalize|sbom|deploy)
+      run_hook_phase "$PHASE" "$@"
       ;;
    *)
       ;;
 esac
-msg "runner: out $phase"
+msg "runner: out $PHASE"

--- a/bin/runner
+++ b/bin/runner
@@ -113,7 +113,8 @@ run_phase_scripts() {
       if compgen -G "${dir}/${phase}"* >/dev/null; then
          for script in "${dir}/${phase}"*; do
             s=$(basename "$script")
-            if [[ $s =~ ^[a-zA-Z0-9-]+$ ]]; then
+            stem="${s%%.*}"
+            if [[ $stem =~ ^[a-zA-Z0-9-]+$ ]]; then
                runhook "$script" "$@"
             else
                warn "runner: $dir [skipped $s]"

--- a/docs/execution/index.adoc
+++ b/docs/execution/index.adoc
@@ -161,33 +161,40 @@ Hooks are optional but if a hook is to be executed, it must have executable perm
 
 === Hook Classification: bundle
 
-Runner scans for `setup*`, `extract*`, `essential*`, `customize*`, and `cleanup*` hooks inside `bdebstrap/` subdirectories of:
+Runner scans for `setup*`, `extract*`, `essential*`, `customize*`, and `cleanup*` hooks inside `bdebstrap/` subdirectories of the following in order:
 
-* Device asset directory (`DEVICE_ASSET`)
-* Image asset directory (`IMAGE_ASSET`)
-* Source tree (`SRCROOT/bdebstrap`)
-* Built-in (`IGROOT/scripts/bdebstrap`)
+. Device asset directory (`DEVICE_ASSET`)
+. Image asset directory (`IMAGE_ASSET`)
+. Source tree (`SRCROOT/bdebstrap`)
+. Built-in (`IGROOT/scripts/bdebstrap`)
 
 It executes matching hooks (alphanumeric basename) in that order for each phase. Subdirectories aren’t traversed; the file extension is ignored.
 
 === Hook Classification: single
 
-With the exception of sbom and deploy, all `single` hooks are customisable and optional. Runner scans for `<phase>.sh` inside:
+Runner looks for `<phase>.sh` at each of the following locations in order:
 
-* Device asset directory (if set)
-* Image asset directory (if set)
-* Built-in (IGROOT)
-* Source tree (SRCROOT)
+. Built-in root (`IGROOT`)
+. Built-in device subdir (`IGROOT/device`)
+. Built-in image subdir (`IGROOT/image`)
+. Device asset directory - `DEVICE_ASSET`
+. Image asset directory - `IMAGE_ASSET`
+. Source tree - `SRCROOT`
 
-Execution takes place from the parent directory of the hook.
+Each location is independent: all present hooks run. Execution takes place from the parent directory of the hook.
+
+`sbom` and `deploy` are resolved differently - via config variables, which may point to any path.
 
 === Overlays
 
-Filesystem overlays are applied during `customize`. The following overlay directories are supported:
+Filesystem overlays are applied during `customize`, in the following order (later entries take precedence):
 
-* `DEVICE_ASSET:device/rootfs-overlay`
-* `IMAGE_ASSET:device/rootfs-overlay`
-* `SRCROOT:rootfs-overlay`
+. **Per-layer overlays** - For each layer in build-plan order, if a directory named `<layer-stem>.rootfs-overlay` exists alongside the layer YAML file on disk (e.g. `my-layer.yaml` has `my-layer.rootfs-overlay/`), it is applied. This allows a layer to ship files into the target filesystem without hooks.
+. **Device asset overlay** - `DEVICE_ASSET/device/rootfs-overlay`
+. **Image asset overlay** - `IMAGE_ASSET/device/rootfs-overlay`
+. **Source tree overlay** - `SRCROOT:rootfs-overlay`
+
+With the exception of YAML `customize-hooks`, all overlays are applied before `customize` hook scripts execute.
 
 === Core
 

--- a/docs/execution/index.html
+++ b/docs/execution/index.html
@@ -622,10 +622,10 @@ $ rpi-image-gen build -S ./my-project/ -c kiosk.cfg</code></pre>
 <div class="sect2">
 <h3 id="_hook_classification_bundle"><a class="anchor" href="#_hook_classification_bundle"></a><a class="link" href="#_hook_classification_bundle">Hook Classification: bundle</a></h3>
 <div class="paragraph">
-<p>Runner scans for <code>setup*</code>, <code>extract*</code>, <code>essential*</code>, <code>customize*</code>, and <code>cleanup*</code> hooks inside <code>bdebstrap/</code> subdirectories of:</p>
+<p>Runner scans for <code>setup*</code>, <code>extract*</code>, <code>essential*</code>, <code>customize*</code>, and <code>cleanup*</code> hooks inside <code>bdebstrap/</code> subdirectories of the following in order:</p>
 </div>
-<div class="ulist">
-<ul>
+<div class="olist arabic">
+<ol class="arabic">
 <li>
 <p>Device asset directory (<code>DEVICE_ASSET</code>)</p>
 </li>
@@ -638,7 +638,7 @@ $ rpi-image-gen build -S ./my-project/ -c kiosk.cfg</code></pre>
 <li>
 <p>Built-in (<code>IGROOT/scripts/bdebstrap</code>)</p>
 </li>
-</ul>
+</ol>
 </div>
 <div class="paragraph">
 <p>It executes matching hooks (alphanumeric basename) in that order for each phase. Subdirectories aren’t traversed; the file extension is ignored.</p>
@@ -647,45 +647,60 @@ $ rpi-image-gen build -S ./my-project/ -c kiosk.cfg</code></pre>
 <div class="sect2">
 <h3 id="_hook_classification_single"><a class="anchor" href="#_hook_classification_single"></a><a class="link" href="#_hook_classification_single">Hook Classification: single</a></h3>
 <div class="paragraph">
-<p>With the exception of sbom and deploy, all <code>single</code> hooks are customisable and optional. Runner scans for <code>&lt;phase&gt;.sh</code> inside:</p>
+<p>Runner looks for <code>&lt;phase&gt;.sh</code> at each of the following locations in order:</p>
 </div>
-<div class="ulist">
-<ul>
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>Device asset directory (if set)</p>
+<p>Built-in root (<code>IGROOT</code>)</p>
 </li>
 <li>
-<p>Image asset directory (if set)</p>
+<p>Built-in device subdir (<code>IGROOT/device</code>)</p>
 </li>
 <li>
-<p>Built-in (IGROOT)</p>
+<p>Built-in image subdir (<code>IGROOT/image</code>)</p>
 </li>
 <li>
-<p>Source tree (SRCROOT)</p>
+<p>Device asset directory - <code>DEVICE_ASSET</code></p>
 </li>
-</ul>
+<li>
+<p>Image asset directory - <code>IMAGE_ASSET</code></p>
+</li>
+<li>
+<p>Source tree - <code>SRCROOT</code></p>
+</li>
+</ol>
 </div>
 <div class="paragraph">
-<p>Execution takes place from the parent directory of the hook.</p>
+<p>Each location is independent: all present hooks run. Execution takes place from the parent directory of the hook.</p>
+</div>
+<div class="paragraph">
+<p><code>sbom</code> and <code>deploy</code> are resolved differently - via config variables, which may point to any path.</p>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_overlays"><a class="anchor" href="#_overlays"></a><a class="link" href="#_overlays">Overlays</a></h3>
 <div class="paragraph">
-<p>Filesystem overlays are applied during <code>customize</code>. The following overlay directories are supported:</p>
+<p>Filesystem overlays are applied during <code>customize</code>, in the following order (later entries take precedence):</p>
 </div>
-<div class="ulist">
-<ul>
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p><code>DEVICE_ASSET:device/rootfs-overlay</code></p>
+<p><strong>Per-layer overlays</strong> - For each layer in build-plan order, if a directory named <code>&lt;layer-stem&gt;.rootfs-overlay</code> exists alongside the layer YAML file on disk (e.g. <code>my-layer.yaml</code> has <code>my-layer.rootfs-overlay/</code>), it is applied. This allows a layer to ship files into the target filesystem without hooks.</p>
 </li>
 <li>
-<p><code>IMAGE_ASSET:device/rootfs-overlay</code></p>
+<p><strong>Device asset overlay</strong> - <code>DEVICE_ASSET/device/rootfs-overlay</code></p>
 </li>
 <li>
-<p><code>SRCROOT:rootfs-overlay</code></p>
+<p><strong>Image asset overlay</strong> - <code>IMAGE_ASSET/device/rootfs-overlay</code></p>
 </li>
-</ul>
+<li>
+<p><strong>Source tree overlay</strong> - <code>SRCROOT:rootfs-overlay</code></p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>With the exception of YAML <code>customize-hooks</code>, all overlays are applied before <code>customize</code> hook scripts execute.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/layer/deploy-base.html
+++ b/docs/layer/deploy-base.html
@@ -165,7 +165,7 @@
  This setting affects how final assets (disk images, filesystem tarballs,
  SBOM, etc) are compressed for distribution or storage.</td>
                     <td>
-                           <code>none</code>
+                           <code>zstd</code>
                     </td>
                     <td>Must be one of: none, zstd</td>
                     <td>

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -399,6 +399,8 @@ generate_filesystem()
 
    local -n _benv="${ctx[ENV_BDEBSTRAP]}" # via nameref
 
+   runenv "${ctx[FINALENV]}" ns runner pre-build "${ctx[LAYER_PLAN]}"
+
    rund "${ctx[SRCROOT]}" ns bdebstrap \
       "${_benv[@]}" \
       --setup-hook     "runner setup     '${ctx[LAYER_PLAN]}' \"\$@\"" \

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -211,7 +211,7 @@ collect_layers()
       --layers "${layers[@]}" \
       --path "$HOST_LAYER_PATH" \
       --env-out "${TMPDIR}/env.out" \
-      --order-out "${TMPDIR}/layer.order" \
+      --plan-out "${TMPDIR}/layer.plan" \
       || die "pipeline failed"
 
    msg "PIPELINE: OK"
@@ -243,7 +243,7 @@ collect_layers()
       die "No bootstrap dir"
 
    mkdir -p "$bdir" || die
-   for f in final.env layer.order host.json ; do
+   for f in final.env layer.plan host.json ; do
       src="${TMPDIR}/$f"
       [[ -f "$src" ]] || die "Missing bootstrap file: $src"
       cp "$src" "$bdir" || die
@@ -253,7 +253,7 @@ collect_layers()
    fi
 
    ctx[FINALENV]="${bdir}/final.env"
-   ctx[LAYER_ORDER]="${bdir}/layer.order"
+   ctx[LAYER_PLAN]="${bdir}/layer.plan"
 }
 
 
@@ -346,24 +346,20 @@ prepare_build_config()
    msg "\nFINAL ENV"
    mapfile_kv "${ctx[FINALENV]}" process_conf_opt
 
-   # Translate layer paths and load those that contain an mmdebstrap mapping
+   # Load resolved layers from the plan that contain an mmdebstrap mapping
    msg "\nMMDEBSTRAP"
    local total=0 added=0 skipped=0
    local specs="${TMPDIR}/layer.resolved"
 
    : > $specs
-   while IFS='=' read -r layer spec; do
-      [[ -n $layer && -n $spec ]] || continue
+   while IFS=: read -r layer static resolved; do
+      [[ -n $layer && -n $resolved ]] || continue
       [[ $layer == \#* ]] && continue
-      spec=${spec#\"}
-      spec=${spec%\"}
-      [[ -n $spec ]] || continue
 
       ((total++))
-      local resolved=$(map_path "$spec") || die "Failed to resolve $spec"
       [[ -f $resolved ]] || die "Layer $layer ($resolved) not found"
       printf '%s="%s"\n' "$layer" "$resolved" >> "$specs"
-   done < "${ctx[LAYER_ORDER]}"
+   done < "${ctx[LAYER_PLAN]}"
 
    while IFS=: read -r layer yaml; do
       _bdebstrap+=( --config "$yaml" )
@@ -405,19 +401,19 @@ generate_filesystem()
 
    rund "${ctx[SRCROOT]}" ns bdebstrap \
       "${_benv[@]}" \
-      --setup-hook     'runner setup "$@"' \
-      --extract-hook   'runner extract "$@"' \
-      --essential-hook 'runner essential "$@"' \
-      --customize-hook 'runner customize "$@"' \
-      --cleanup-hook   'runner cleanup "$@"'
+      --setup-hook     "runner setup     '${ctx[LAYER_PLAN]}' \"\$@\"" \
+      --extract-hook   "runner extract   '${ctx[LAYER_PLAN]}' \"\$@\"" \
+      --essential-hook "runner essential '${ctx[LAYER_PLAN]}' \"\$@\"" \
+      --customize-hook "runner customize '${ctx[LAYER_PLAN]}' \"\$@\"" \
+      --cleanup-hook   "runner cleanup   '${ctx[LAYER_PLAN]}' \"\$@\""
 
-   runenv "${ctx[FINALENV]}" ns runner post-build
+   runenv "${ctx[FINALENV]}" ns runner post-build "${ctx[LAYER_PLAN]}"
 
    [[ ${ctx[INTERACTIVE]} == y ]] && \
       { ask "Filesystem complete. Proceed to SBOM?" y || exit 0 ; }
 
    msg "\nSBOM"
-   runenv "${ctx[FINALENV]}" ns runner sbom
+   runenv "${ctx[FINALENV]}" ns runner sbom "${ctx[LAYER_PLAN]}"
 }
 
 
@@ -439,7 +435,7 @@ generate_images() {
 
    msg "\nIMAGE"
 
-   runenv "${ctx[FINALENV]}" ns runner pre-image
+   runenv "${ctx[FINALENV]}" ns runner pre-image "${ctx[LAYER_PLAN]}"
 
    if [[ "$provider" == genimage && -d "$filesystem" ]] ; then
       mkdir -p "${TMPDIR}/genimage"
@@ -458,7 +454,7 @@ generate_images() {
       done
    fi
 
-   runenv "${ctx[FINALENV]}" ns runner post-image
+   runenv "${ctx[FINALENV]}" ns runner post-image "${ctx[LAYER_PLAN]}"
 }
 
 
@@ -468,12 +464,12 @@ generate_images() {
 #   Install build assets for distribution
 ###############################################################################
 deploy() {
-   runenv "${ctx[FINALENV]}" ns runner finalize
+   runenv "${ctx[FINALENV]}" ns runner finalize "${ctx[LAYER_PLAN]}"
 
    [[ ${ctx[INTERACTIVE]} == y ]] && { ask "Deploy assets?" y || exit 0 ; }
 
    msg "\nDEPLOY"
-   runenv "${ctx[FINALENV]}" ns runner deploy
+   runenv "${ctx[FINALENV]}" ns runner deploy "${ctx[LAYER_PLAN]}"
 }
 
 

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -44,7 +44,8 @@ class LayerManager:
         self.search_paths = [root.path for root in self.search_roots]
         self.file_patterns = file_patterns
         self.layers: Dict[str, Metadata] = {}  # layer_name -> Metadata object
-        self.layer_files: Dict[str, str] = {}  # layer_name -> file_path
+        self.layer_files: Dict[str, str] = {}  # layer_name -> file_path (resolved; may be tmpfs for dynamic)
+        self.layer_source_files: Dict[str, str] = {}  # layer_name -> original source file path (never updated)
         self.layer_tags: Dict[str, str] = {}  # layer_name -> search path tag
         self.layer_relpaths: Dict[str, str] = {}  # layer_name -> relative path under tagged root
         self.tag_to_path: Dict[str, Path] = {root.tag: root.path for root in self.search_roots}
@@ -251,6 +252,7 @@ class LayerManager:
 
                 self.layers[layer_name] = meta
                 self.layer_files[layer_name] = str(abs_file)
+                self.layer_source_files[layer_name] = str(abs_file)
                 self.layer_tags[layer_name] = tag
                 self.layer_relpaths[layer_name] = str(rel_path)
                 loaded_layers.add(layer_name)

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -32,7 +32,7 @@ def Pipeline_register_parser(subparsers, root=None):
     parser.add_argument("--layers", nargs="+", help="Layers to apply (names)")
     parser.add_argument("--path", "-p", default=default_paths, help=help_text)
     parser.add_argument("--env-out", required=True, help="Write fully resolved env (anchors expanded)")
-    parser.add_argument("--order-out", help="Write layer order (tag:relative) to this file (host mode only)")
+    parser.add_argument("--plan-out", help="Write layer build plan (name:static:resolved) to this file (host mode only)")
     parser.set_defaults(func=_pipeline_main)
 
 
@@ -108,8 +108,8 @@ def _pipeline_main(args):
         log_error("Error: Validation failed for target layers")
         raise SystemExit(1)
 
-    if args.order_out:
-        _write_layer_order(args.order_out, build_order, manager)
+    if args.plan_out:
+        _write_layer_plan(args.plan_out, build_order, manager)
 
     layer_anchor_map = _build_anchor_map_from_layers(manager, build_order)
     source_anchors = layer_anchor_map or {}
@@ -147,18 +147,16 @@ def _inject_root_anchors(anchor_map: Dict[str, Dict[str, Optional[str]]], env_as
             anchor_map.setdefault(f"@{root_var}", {"var": root_var, "value": value})
 
 
-def _write_layer_order(path: str, build_order: List[str], manager: LayerManager) -> None:
+def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) -> None:
     try:
         with open(path, "w", encoding="utf-8") as handle:
             for layer in build_order:
-                rel_spec = manager.get_layer_relative_spec(layer)
-                if rel_spec:
-                    handle.write(f'{layer}="{rel_spec}"\n')
-                else:
-                    handle.write(f"{layer}\n")
-        print(f"Layer order written to: {path}")
+                static = manager.layer_source_files.get(layer, "")
+                resolved = manager.layer_files.get(layer, "")
+                handle.write(f'{layer}:{static}:{resolved}\n')
+        print(f"Layer plan written to: {path}")
     except Exception as exc:
-        print(f"Error writing layer order to {path}: {exc}")
+        print(f"Error writing layer plan to {path}: {exc}")
         raise SystemExit(1)
 
 

--- a/test/layer/run-tests.sh
+++ b/test/layer/run-tests.sh
@@ -700,21 +700,21 @@ run_test "pipeline-build-order" \
     'TMP_ENV=$(mktemp) && TMP_ENV_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" && \
      ig pipeline --env-in "$TMP_ENV" --layers test-with-deps --path '"${PIPELINE_LAYER_DIR}"' \
-        --env-out "$TMP_ENV_OUT" --order-out "$TMP_ORDER" >/dev/null && \
-     grep -q "^test-basic=" "$TMP_ORDER" && \
-     grep -q "^test-with-deps=" "$TMP_ORDER" && \
+        --env-out "$TMP_ENV_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     grep -q "^test-basic:" "$TMP_ORDER" && \
+     grep -q "^test-with-deps:" "$TMP_ORDER" && \
      rm -f "$TMP_ENV" "$TMP_ENV_OUT" "$TMP_ORDER"' \
     0 \
-    "Pipeline should write build order for dependencies"
+    "Pipeline should write build plan for dependencies"
 
 run_test "pipeline-build-order-env-deps" \
     'TMP_ENV=$(mktemp) && TMP_ENV_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" "ARCH=arm64" "DISTRO=debian" && \
      ig pipeline --env-in "$TMP_ENV" --layers test-env-var-deps --path '"${PIPELINE_LAYER_DIR}"' \
-        --env-out "$TMP_ENV_OUT" --order-out "$TMP_ORDER" >/dev/null && \
-     grep -q "^test-basic=" "$TMP_ORDER" && \
-     grep -q "^arm64-toolchain=" "$TMP_ORDER" && \
-     grep -q "^debian-packages=" "$TMP_ORDER" && \
+        --env-out "$TMP_ENV_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     grep -q "^test-basic:" "$TMP_ORDER" && \
+     grep -q "^arm64-toolchain:" "$TMP_ORDER" && \
+     grep -q "^debian-packages:" "$TMP_ORDER" && \
      rm -f "$TMP_ENV" "$TMP_ENV_OUT" "$TMP_ORDER"' \
     0 \
     "Pipeline should resolve env-based deps and write build order"


### PR DESCRIPTION
- Add support for layers to define their own Filesystem Overlay. These overlays are applied in layer build order by `bin/runner` at the `customize` phase.
- Two bug fixes in hook execution.

The infrastructure added to support Layer Overlays lends itself towards being able to support a 'Yocto style' per-recipe task  where layers could participate in all build operations. Because `bin/runner` is now 'layer aware', it's possible to hook up things like per-layer hooks outside of what can be accomplished in the layer YAML itself.