### PR TITLE
AB: boot-time robustness improvements

### DIFF
--- a/image/gpt/ab_userdata/device/provisionmap-clear.json
+++ b/image/gpt/ab_userdata/device/provisionmap-clear.json
@@ -9,7 +9,7 @@
       "partitions": [
          {
             "comment": "boot configuration",
-            "image": "config"
+            "image": "bootconfig"
          }
       ]
    },

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -9,7 +9,7 @@
       "partitions": [
          {
             "comment": "boot configuration",
-            "image": "config"
+            "image": "bootconfig"
          }
       ]
    },

--- a/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
@@ -9,7 +9,7 @@
       "partitions": [
          {
             "comment": "boot configuration",
-            "image": "config"
+            "image": "bootconfig"
          }
       ]
    },

--- a/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
@@ -9,7 +9,7 @@
       "partitions": [
          {
             "comment": "boot configuration",
-            "image": "config"
+            "image": "bootconfig"
          }
       ]
    },

--- a/image/gpt/ab_userdata/device/rootfs-overlay/etc/udev/rules.d/99-rpi-05-image.rules
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/etc/udev/rules.d/99-rpi-05-image.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="block", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}=="bootconfig", SYMLINK+="disk/by-slot/bootconfig"
+SUBSYSTEM=="block", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}=="persistent", SYMLINK+="disk/by-slot/persistent"

--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-perst-generator
@@ -1,16 +1,13 @@
 #!/bin/sh
-# systemd generator to bind per-slot /var based on GPT PARTLABEL
+# systemd generator to bind per-slot /var based on the persistent by-slot alias
 
 set -eu
 
 OUT_DIR="/run/systemd/generator"
 mkdir -p "$OUT_DIR"
 
-# Label of the shared persistent partition
-PERSIST_LABEL="${PERSIST_LABEL:-PERSISTENT}"
-
-# Corresponding fsck unit
-path=$(systemd-escape --path "/dev/disk/by-label/${PERSIST_LABEL}")
+# fsck unit
+path=$(systemd-escape --path "/dev/disk/by-slot/persistent")
 FSCK_UNIT="systemd-fsck@${path}.service"
 
 # 1) Determine current slot
@@ -44,7 +41,7 @@ Requires=${FSCK_UNIT}
 After=${FSCK_UNIT}
 
 [Mount]
-What=/dev/disk/by-label/${PERSIST_LABEL}
+What=/dev/disk/by-slot/persistent
 Where=/persistent
 Type=ext4
 Options=rw,noatime,lazytime,commit=60,errors=remount-ro

--- a/image/gpt/ab_userdata/genimage.cfg.in.erofs
+++ b/image/gpt/ab_userdata/genimage.cfg.in.erofs
@@ -4,9 +4,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
    }
 }
 
-image config.sparse {
+image bootconfig.sparse {
    android-sparse {
-      image = config.vfat
+      image = bootconfig.vfat
    }
 }
 
@@ -35,9 +35,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       fill = true
    }
 
-   partition config {
+   partition bootconfig {
       in-partition-table = true
-      image = config.vfat
+      image = bootconfig.vfat
       partition-type-uuid = F
       bootable = true
    }
@@ -75,9 +75,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    }
 }
 
-image config.vfat {
+image bootconfig.vfat {
    vfat {
-      label = "BOOTFS"
+      label = "BOOTCONFIG"
       file "autoboot.txt" { image = "autoboot.txt" }
       extraargs = "-s 1 -S <SECTOR_SIZE>"
    }

--- a/image/gpt/ab_userdata/genimage.cfg.in.ext4
+++ b/image/gpt/ab_userdata/genimage.cfg.in.ext4
@@ -4,9 +4,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX>.sparse {
    }
 }
 
-image config.sparse {
+image bootconfig.sparse {
    android-sparse {
-      image = config.vfat
+      image = bootconfig.vfat
    }
 }
 
@@ -35,9 +35,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       fill = true
    }
 
-   partition config {
+   partition bootconfig {
       in-partition-table = true
-      image = config.vfat
+      image = bootconfig.vfat
       partition-type-uuid = F
       bootable = true
    }
@@ -75,9 +75,9 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
    }
 }
 
-image config.vfat {
+image bootconfig.vfat {
    vfat {
-      label = "BOOTFS"
+      label = "BOOTCONFIG"
       file "autoboot.txt" { image = "autoboot.txt" }
       extraargs = "-s 1 -S <SECTOR_SIZE>"
    }

--- a/image/gpt/ab_userdata/slot-post-process.sh
+++ b/image/gpt/ab_userdata/slot-post-process.sh
@@ -24,8 +24,8 @@ EOF
 
       # remainder is constant
       cat << EOF >> $IMAGEMOUNTPATH/etc/fstab
-/dev/disk/by-slot/active/boot   /boot/firmware vfat defaults,ro,noatime,nofail  0 2
-LABEL=BOOTFS                    /bootfs        vfat defaults,rw,noatime,errors=panic 0 2
+/dev/disk/by-slot/active/boot  /boot/firmware  vfat defaults,ro,noatime,nofail  0 2
+/dev/disk/by-slot/bootconfig   /bootfs         vfat defaults,rw,noatime,nofail 0 2
 
 # Bespoke systemd generators mount /persistent, /var and bind mount into it
 # for per-slot storage. See slot-perst-generator.

--- a/layer/rpi/device/ab-slots.yaml
+++ b/layer/rpi/device/ab-slots.yaml
@@ -25,7 +25,7 @@ mmdebstrap:
     - install -D -m 0755 "${IGconf_abslot_overlay}/bin/rpi-slot-label" "$1/usr/bin/rpi-slot-label"
     - install -D -m 0755 "${IGconf_abslot_overlay}/bin/rpi-slot-static" "$1/usr/bin/rpi-slot-static"
     - install -D -m 0755 "${IGconf_abslot_overlay}/bin/rpi-slot-tryboot" "$1/usr/bin/rpi-slot-tryboot"
-    - install -D -m 0644 "${IGconf_abslot_overlay}/udev/rules.d/slot.rules" "$1/etc/udev/rules.d/99-rpi-slot.rules"
+    - install -D -m 0644 "${IGconf_abslot_overlay}/udev/rules.d/slot.rules" "$1/etc/udev/rules.d/99-rpi-01-abslot.rules"
     - |
       set -eu
       if [ -d "$1/etc/initramfs-tools" ]; then

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-label
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-label
@@ -120,6 +120,12 @@ else
 fi
 
 
+# Emit boot device membership marker
+if [ "$udev_fmt" -eq 1 ]; then
+   echo "RPI_ONBOOTDEV=1"
+fi
+
+
 case "$ID_PART_ENTRY_NAME" in
    "$ACTIVE_BOOT")       slot="active/boot" ;;
    "$ACTIVE_SYS")     slot="active/system" ;;

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-static
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-static
@@ -204,6 +204,12 @@ else
 fi
 
 
+# Emit boot device membership marker
+if [ "$udev_fmt" -eq 1 ]; then
+   echo "RPI_ONBOOTDEV=1"
+fi
+
+
 slot=""
 case "$alias" in
    "$ACTIVE_BOOT") slot="active/boot" ;;


### PR DESCRIPTION
Previously, only the boot and system slot components were qualified as being on the boot device.
Now, the AB layout uses GPT labels for all devices and ensures all mounted devices are boot device qualified.
This:
1. Promotes all mounted devices to exist under `/dev/disk/by-slot/`.
2. Ensures the backing block device can always be resolved (which is not true if using filesystem labels).
3. Ensures we unambiguously mount the devices we expect.

Also, ensure `nofail` is used to mount the bootconfig partition to help ensure the system boots to completion and doesn't stall. Doing so improves the chance of 'health management' tasks starting.