### PR TITLE
IDP: schema: restrict luks2 volume label to 36 chars

### DIFF
--- a/layer/rpi/device/ab-slots.yaml
+++ b/layer/rpi/device/ab-slots.yaml
@@ -4,7 +4,8 @@
 # X-Env-Layer-Desc: Dynamic slot device management for A/B boot: udev rules and
 #  helpers that create stable by-slot symlinks from GPT PARTLABELs (preferred)
 #  or a static slot map (fallback), with device-mapper and initramfs support.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
+# X-Env-Layer-Requires: rpi-storage-binder
 #
 # X-Env-VarPrefix: abslot
 #
@@ -13,7 +14,7 @@
 #  support slot management and selection.
 # X-Env-Var-overlay-Required: n
 # X-Env-Var-overlay-Valid: string
-# X-Env-Var-overlay-Set: y
+# X-Env-Var-overlay-Set: force
 # METAEND
 ---
 mmdebstrap:

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-label
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-label
@@ -4,6 +4,7 @@
 set -u
 
 # Map GPT PARTLABEL to slot for udev IMPORT.
+# Any incoming device is assumed boot-device qualified.
 # This script is boot critical and must be compatible with minimal shell
 # environments such as klibc, and be as POSIX compliant as possible.
 
@@ -22,14 +23,12 @@ udev_fmt=0
 
 ID_PART_ENTRY_NAME=${ID_PART_ENTRY_NAME-}
 DEVNAME=${DEVNAME-}
-DM_NAME=${DM_NAME-}
 
 
-while getopts "d:l:m:u" opt; do
+while getopts "d:l:u" opt; do
    case $opt in
       d) DEVNAME="$OPTARG";;
       l) ID_PART_ENTRY_NAME="$OPTARG";;
-      m) DM_NAME="$OPTARG";;
       u) udev_fmt=1;;
       *) ;;
    esac
@@ -77,60 +76,11 @@ ALT_BOOT="boot${alt_suffix}"
 ALT_SYS="system${alt_suffix}"
 
 
-# Slow-path (supports DM devices)
-# Walk sysfs to check if a device is on the boot device.
-on_bootdev() {
-   dev=${1#/dev/}
-   boot=${2#/dev/}
-
-   # Try fast path
-   is_boot_kname "$dev" "$boot" && return 0
-
-   d="/sys/class/block/$dev/slaves"
-   [ -d "$d" ] || return 1
-
-   for s in "$d"/*; do
-      [ -e "$s" ] || continue
-      sname=${s##*/}
-      on_bootdev "$sname" "$boot" && return 0
-   done
-
-   return 1
-}
-
-
-# Fast-path (non-DM)
-# Check if a kernel name is a boot device partition.
-is_boot_kname() {
-   dev=${1#/dev/}
-   boot=${2#/dev/}
-
-   case "$dev" in
-      "$boot"p[0-9]*) return 0 ;;
-   esac
-   return 1
-}
-
-
-# To be considered for a slot, the incoming device must be on the boot device.
-if [ -n "$DM_NAME" ]; then
-   on_bootdev "$DEVNAME" "$BOOT_DEV" || exit 1
-else
-   is_boot_kname "$DEVNAME" "$BOOT_DEV" || exit 1
-fi
-
-
-# Emit boot device membership marker
-if [ "$udev_fmt" -eq 1 ]; then
-   echo "RPI_ONBOOTDEV=1"
-fi
-
-
 case "$ID_PART_ENTRY_NAME" in
-   "$ACTIVE_BOOT")       slot="active/boot" ;;
-   "$ACTIVE_SYS")     slot="active/system" ;;
-   "$ALT_BOOT")   slot="other/boot" ;;
-   "$ALT_SYS") slot="other/system" ;;
+   "$ACTIVE_BOOT") slot="active/boot" ;;
+   "$ACTIVE_SYS")  slot="active/system" ;;
+   "$ALT_BOOT")    slot="other/boot" ;;
+   "$ALT_SYS")     slot="other/system" ;;
    *) exit 0 ;; # valid device but ignored
 esac
 

--- a/layer/rpi/device/slot-mapper/bin/rpi-slot-static
+++ b/layer/rpi/device/slot-mapper/bin/rpi-slot-static
@@ -4,6 +4,7 @@
 set -u
 
 # Classify an incoming device using udev env vars and map file for udev IMPORT.
+# Any incoming device is assumed boot-device qualified.
 # This script is boot critical and must be compatible with minimal shell
 # environments such as klibc, and be as POSIX compliant as possible.
 
@@ -157,56 +158,12 @@ read_static_map() {
 read_static_map || die "Unable to load configuration from slot map"
 
 
-# Slow-path (supports DM devices)
-# Walk sysfs to check if a device is on the boot device.
-on_bootdev() {
-   dev=${1#/dev/}
-   boot=${2#/dev/}
-
-   # Try fast path
-   is_boot_kname "$dev" "$boot" && return 0
-
-   d="/sys/class/block/$dev/slaves"
-   [ -d "$d" ] || return 1
-
-   for s in "$d"/*; do
-      [ -e "$s" ] || continue
-      sname=${s##*/}
-      on_bootdev "$sname" "$boot" && return 0
-   done
-
-   return 1
-}
-
-
-# Fast-path (non-DM)
-# Check if a kernel name is a boot device partition.
-is_boot_kname() {
-   dev=${1#/dev/}
-   boot=${2#/dev/}
-
-   case "$dev" in
-      "$boot"p[0-9]*) return 0 ;;
-   esac
-   return 1
-}
-
-
-# To be considered for a slot, the incoming device must be on the boot device.
 # If a DM name is provided, construct mapper alias, else use raw device.
 alias=""
 if [ -n "$DM_NAME" ]; then
-   on_bootdev "$DEVNAME" "$BOOT_DEV" || exit 1
    alias="/dev/mapper/${DM_NAME}"
 else
-   is_boot_kname "$DEVNAME" "$BOOT_DEV" || exit 1
    alias="$DEVNAME"
-fi
-
-
-# Emit boot device membership marker
-if [ "$udev_fmt" -eq 1 ]; then
-   echo "RPI_ONBOOTDEV=1"
 fi
 
 

--- a/layer/rpi/device/slot-mapper/udev/rules.d/slot.rules
+++ b/layer/rpi/device/slot-mapper/udev/rules.d/slot.rules
@@ -1,28 +1,28 @@
 # Boot devices with GPT label (non-DM)
-SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
+SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
 
-SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
+SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}=="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
 
 # DM with GPT label
-SUBSYSTEM=="block", KERNEL=="dm-*", ENV{ID_PART_ENTRY_NAME}=="?*", ENV{DM_NAME}=="?*", ACTION=="add|change", \
-  IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME} -m $env{DM_NAME}", \
+SUBSYSTEM=="block", KERNEL=="dm-*", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}=="?*", ENV{DM_NAME}=="?*", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-slot-label -u -L $env{ID_PART_ENTRY_NAME} -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
 
 
 # Boot devices without GPT label (non-DM)
-SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
+SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-static -u -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
 
-SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
+SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-static -u -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"
 
 # DM without GPT label
-SUBSYSTEM=="block", KERNEL=="dm-*", ENV{DM_NAME}=="?*", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
+SUBSYSTEM=="block", KERNEL=="dm-*", ENV{RPI_ONBOOTDEV}=="1", ENV{DM_NAME}=="?*", ENV{ID_PART_ENTRY_NAME}!="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-slot-static -u -m $env{DM_NAME} -p $env{ID_PART_ENTRY_NUMBER} -d $env{DEVNAME}", \
   SYMLINK+="$env{SLOT}"

--- a/layer/rpi/device/storage-binder.yaml
+++ b/layer/rpi/device/storage-binder.yaml
@@ -1,0 +1,32 @@
+# METABEGIN
+# X-Env-Layer-Name: rpi-storage-binder
+# X-Env-Layer-Category: image
+# X-Env-Layer-Desc: Boot-device membership tagging for partitions and
+#  DM devices backed by the boot storage device, with initramfs support.
+# X-Env-Layer-Version: 1.0.0
+#
+# X-Env-VarPrefix: storagebinder
+#
+# X-Env-Var-overlay: ${DIRECTORY}/storage-binder
+# X-Env-Var-overlay-Desc: Directory holding filesystem assets installed to
+#  support boot-device membership tagging.
+# X-Env-Var-overlay-Required: n
+# X-Env-Var-overlay-Valid: string
+# X-Env-Var-overlay-Set: force
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - udev
+    - coreutils
+  customize-hooks:
+    - install -D -m 0755 "${IGconf_storagebinder_overlay}/bin/rpi-bootdev-tag" "$1/usr/bin/rpi-bootdev-tag"
+    - install -D -m 0644 "${IGconf_storagebinder_overlay}/udev/rules.d/storage-binder.rules" "$1/etc/udev/rules.d/99-rpi-00-bootdev.rules"
+    - |
+      set -eu
+      if [ -d "$1/etc/initramfs-tools" ]; then
+        rsync -a --chmod=F755,D755 "${IGconf_storagebinder_overlay}/initramfs-tools/" "$1/etc/initramfs-tools/";
+      fi
+      if [ -d "$1/usr/lib/dracut" ]; then
+        rsync -a --chmod=F755,D755 "${IGconf_storagebinder_overlay}/dracut/" "$1/usr/lib/dracut/";
+      fi

--- a/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
+++ b/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
@@ -1,0 +1,105 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+set -u
+
+# Tag an incoming block device as boot-device-backed for udev IMPORT.
+# This script is boot critical and must be compatible with minimal shell
+# environments such as klibc, and be as POSIX compliant as possible.
+
+err() {
+   msg="ERROR: $*"
+   if [ -w /dev/kmsg ]; then
+      echo "$msg" > /dev/kmsg 2>/dev/null || :
+   fi
+   echo "$msg" >&2
+}
+
+die() { err "$@"; exit 1; }
+
+udev_fmt=0
+
+DEVNAME=${DEVNAME-}
+DM_NAME=${DM_NAME-}
+
+while getopts "d:m:u" opt; do
+   case $opt in
+      d) DEVNAME="$OPTARG";;
+      m) DM_NAME="$OPTARG";;
+      u) udev_fmt=1;;
+      *) ;;
+   esac
+done
+
+[ -n "$DEVNAME" ] || die "missing dev"
+
+
+read_dt_u32() {
+   # shellcheck disable=SC2046
+   # shellcheck disable=SC2312
+   set -- $(od -An -tu1 -N4 "$1" 2>/dev/null)
+   [ $# -eq 4 ] || return 1
+   echo $(( $1*16777216 + $2*65536 + $3*256 + $4 ))
+}
+
+
+BOOT_MODE=$(read_dt_u32 /proc/device-tree/chosen/bootloader/boot-mode) || die "no boot-mode"
+BOOT_PARTN=$(read_dt_u32 /proc/device-tree/chosen/bootloader/partition) || die "no boot-part"
+
+case $BOOT_MODE in
+   1) BOOT_DEV=mmcblk0; PART_SEP=p;;
+   4) BOOT_DEV=sda;     PART_SEP=;;
+   6) BOOT_DEV=nvme0n1; PART_SEP=p;;
+   *) die "unsupported bootmode $BOOT_MODE";;
+esac
+
+BOOT_BLKDEV="/dev/${BOOT_DEV}${PART_SEP}${BOOT_PARTN}"
+test -b "$BOOT_BLKDEV" || die "Invalid boot blkdev $BOOT_BLKDEV"
+
+
+# Slow-path (supports DM devices).
+# Walk sysfs slaves chain to check if a device is backed by the boot device.
+on_bootdev() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   is_boot_kname "$dev" "$boot" && return 0
+
+   d="/sys/class/block/$dev/slaves"
+   [ -d "$d" ] || return 1
+
+   for s in "$d"/*; do
+      [ -e "$s" ] || continue
+      sname=${s##*/}
+      on_bootdev "$sname" "$boot" && return 0
+   done
+
+   return 1
+}
+
+
+# Fast-path (non-DM).
+# Check if a kernel name is a partition of the boot device.
+is_boot_kname() {
+   dev=${1#/dev/}
+   boot=${2#/dev/}
+
+   case "$dev" in
+      "$boot"p[0-9]*) return 0 ;;   # mmc / nvme  (mmcblk0p1, nvme0n1p1)
+      "$boot"[0-9]*)  return 0 ;;   # scsi / usb  (sda1, sda2)
+   esac
+   return 1
+}
+
+
+if [ -n "$DM_NAME" ]; then
+   on_bootdev "$DEVNAME" "$BOOT_DEV" || exit 1
+else
+   is_boot_kname "$DEVNAME" "$BOOT_DEV" || exit 1
+fi
+
+if [ "$udev_fmt" -eq 1 ]; then
+   echo "RPI_ONBOOTDEV=1"
+fi
+
+exit 0

--- a/layer/rpi/device/storage-binder/dracut/modules.d/90rpi-bootdev/module-setup.sh
+++ b/layer/rpi/device/storage-binder/dracut/modules.d/90rpi-bootdev/module-setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+check() { return 0; }
+depends() { echo "udev-rules"; }
+install() {
+   inst_binary /usr/bin/od
+   inst_binary /usr/bin/rpi-bootdev-tag
+   inst_rules /etc/udev/rules.d/99-rpi-00-bootdev.rules
+}

--- a/layer/rpi/device/storage-binder/initramfs-tools/hooks/rpi-bootdev-install
+++ b/layer/rpi/device/storage-binder/initramfs-tools/hooks/rpi-bootdev-install
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+case $1 in
+   prereqs) echo ""; exit 0;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+copy_exec /usr/bin/od
+copy_exec /usr/bin/rpi-bootdev-tag
+copy_file config /etc/udev/rules.d/99-rpi-00-bootdev.rules /etc/udev/rules.d/99-rpi-00-bootdev.rules

--- a/layer/rpi/device/storage-binder/udev/rules.d/storage-binder.rules
+++ b/layer/rpi/device/storage-binder/udev/rules.d/storage-binder.rules
@@ -1,0 +1,18 @@
+# Tag partitions and DM devices backed by the boot storage device.
+# RPI_ONBOOTDEV=1 is set in the udev environment for any matching device.
+
+# Non-DM partitions: mmc
+SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME}"
+
+# Non-DM partitions: nvme
+SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME}"
+
+# Non-DM partitions: usb / scsi
+SUBSYSTEM=="block", KERNEL=="sd*[0-9]", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME}"
+
+# DM devices
+SUBSYSTEM=="block", KERNEL=="dm-*", ENV{DM_NAME}=="?*", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME} -m $env{DM_NAME}"

--- a/layer/rpi/schemas/provisionmap/v1/schema.html
+++ b/layer/rpi/schemas/provisionmap/v1/schema.html
@@ -2263,7 +2263,7 @@
         
 
         
-        
+        <p><span class="badge badge-light restriction max-length-restriction" id="oneOf_i0_items_oneOf_i2_slots_A_encrypted_luks2_label_maxLength">Must be at most <code>36</code> characters long</span></p>
 
         
             </div>
@@ -4073,6 +4073,6 @@
         
 
     <footer>
-        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-03-31 at 17:28:57 +0100</p>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-04-17 at 10:37:21 +0100</p>
     </footer></body>
 </html>

--- a/layer/rpi/schemas/provisionmap/v1/schema.json
+++ b/layer/rpi/schemas/provisionmap/v1/schema.json
@@ -104,7 +104,7 @@
         "key_size": { "description": "The encryption key size in bits.", "type": "integer", "enum": [128, 256, 512] },
         "cipher":   { "description": "The cipher and mode used for encryption, e.g. aes-xts-plain64.", "type": "string" },
         "hash":     { "description": "The hash algorithm used for metadata integrity, e.g. sha256.", "type": "string" },
-        "label":    { "description": "An optional human-readable label for the LUKS2 container.", "type": "string" },
+        "label":    { "description": "An optional human-readable label for the LUKS2 container.", "type": "string", "maxLength": 36 },
         "uuid":     { "description": "The UUID assigned to the LUKS2 container. Required so that the container can be identified and unlocked at runtime.", "type": "string", "pattern": "^[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$" },
         "mname":    { "description": "The device mapper name for the LUKS2 container, used as the mapped device name under /dev/mapper.", "type": "string" },
         "etype":    { "description": "The encrypted container type. 'raw' for a directly encrypted block device, 'partitioned' for a LUKS2 container that itself holds a partition table.", "type": "string", "enum": ["raw", "partitioned"] }

--- a/layer/rpi/schemas/provisionmap/v1/schema.md
+++ b/layer/rpi/schemas/provisionmap/v1/schema.md
@@ -484,6 +484,10 @@ Must be one of:
 
 **Description:** An optional human-readable label for the LUKS2 container.
 
+| Restrictions   |    |
+| -------------- | -- |
+| **Max length** | 36 |
+
 ###### <a name="oneOf_i0_items_oneOf_i2_slots_A_encrypted_luks2_uuid"></a>1.1.3.1.1.2.1.5. Property `Raspberry Pi Image Description Provisioning Map > oneOf > item 0 > item 0 items > oneOf > item 2 > slots > A > encrypted > luks2 > uuid`
 
 |              |          |
@@ -806,4 +810,4 @@ Must be one of:
 **Description:** A single PMAP entry.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-03-31 at 17:28:56 +0100
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-04-17 at 10:37:20 +0100


### PR DESCRIPTION
Restrict the luks2 volume label to 36 chars. IDP may also use this field for a partition's GPT label.

Refs:
https://github.com/raspberrypi/rpi-fastbootd/pull/9