### PR TITLE
IDP schema: include pi3 in device list

### DIFF
--- a/layer/rpi/schemas/idp/v2/schema.html
+++ b/layer/rpi/schemas/idp/v2/schema.html
@@ -122,7 +122,7 @@
 <span class="description"><p>The Raspberry Pi device family the image is intended for.</p>
 </span><div class="enum-value" id="IGmeta_IGconf_device_class_enum">
             <h4>Must be one of:</h4>
-            <ul class="list-group"><li class="list-group-item enum-item">"zero2w"</li><li class="list-group-item enum-item">"pi4"</li><li class="list-group-item enum-item">"cm4"</li><li class="list-group-item enum-item">"pi5"</li><li class="list-group-item enum-item">"cm5"</li></ul>
+            <ul class="list-group"><li class="list-group-item enum-item">"zero2w"</li><li class="list-group-item enum-item">"pi3"</li><li class="list-group-item enum-item">"pi4"</li><li class="list-group-item enum-item">"cm4"</li><li class="list-group-item enum-item">"pi5"</li><li class="list-group-item enum-item">"cm5"</li></ul>
             </div>
         
 
@@ -2046,6 +2046,6 @@
 </div>
 
     <footer>
-        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-03-05 at 17:39:34 +0000</p>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2026-04-20 at 09:37:47 +0100</p>
     </footer></body>
 </html>

--- a/layer/rpi/schemas/idp/v2/schema.json
+++ b/layer/rpi/schemas/idp/v2/schema.json
@@ -18,7 +18,7 @@
       "required": ["IGconf_device_class", "IGconf_device_variant", "IGconf_device_storage_type", "IGconf_device_sector_size", "IGconf_image_version"],
       "additionalProperties": false,
       "properties": {
-        "IGconf_device_class":        { "description": "The Raspberry Pi device family the image is intended for.", "type": "string", "enum": ["zero2w", "pi4", "cm4", "pi5", "cm5"] },
+        "IGconf_device_class":        { "description": "The Raspberry Pi device family the image is intended for.", "type": "string", "enum": ["zero2w", "pi3", "pi4", "cm4", "pi5", "cm5"] },
         "IGconf_device_variant":      { "description": "An optional device variant identifier, e.g. memory size or edition (8G, lite). Use 'none' if no variant applies.", "type": "string" },
         "IGconf_device_storage_type": { "description": "The storage media type the image is intended for, as seen by the OS. Determines which block device the provisioning tool will target.", "type": "string", "enum": ["sd", "emmc", "nvme"] },
         "IGconf_device_sector_size":  { "description": "The logical sector size in bytes of the target storage device. Used to guide image layout decisions such as alignment and padding.", "type": "integer", "enum": [512, 4096] },

--- a/layer/rpi/schemas/idp/v2/schema.md
+++ b/layer/rpi/schemas/idp/v2/schema.md
@@ -99,6 +99,7 @@
 
 Must be one of:
 * "zero2w"
+* "pi3"
 * "pi4"
 * "cm4"
 * "pi5"
@@ -550,4 +551,4 @@ Must be one of:
 | **Tuple validation** | N/A                |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-03-05 at 17:39:34 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-04-20 at 09:37:47 +0100


### PR DESCRIPTION
While currently not accepted for provisioning, Raspberry Pi 3 class devices are valid so a build should generate a conformant IDP doc.

Resolves #226