### PR TITLE
Support auth with device identities by default

### DIFF
--- a/examples/ota/README.md
+++ b/examples/ota/README.md
@@ -1,12 +1,28 @@
-Build an image that can be deployed remotely using Raspberry Pi Connect's
-experimental remote update capability.
+Build an image that can be deployed remotely using Raspberry Pi Connect's experimental remote update capability.
 
 This is a skeleton system that:
 
 * Installs a minimal base Trixie OS
-* Installs Raspberry Pi Connect Lite, configured with a given auth key
+* Installs Raspberry Pi Connect Lite
 * Installs and configures Raspberry Pi experimental OTA functionality
 
-```bash
-rpi-image-gen build -S ./examples/ota/ -c ota.yaml -- IGconf_connect_authkey=rpuak_XXX
-```
+A device can auto-signin with Raspberry Pi Connect on first boot in one of two ways:
+
+1. **Device identity** (Raspberry Pi Connect for Organisations only). The device authenticates using the unique identity in its OTP (one time programmable) memory. The identity must first be registered with your organisation via the [Raspberry Pi Connect Organisations Management API][management-api]. No credentials need to be embedded in the image:
+
+   ```bash
+   rpi-image-gen build -S ./examples/ota/ -c ota.yaml
+   ```
+
+2. **Auth key.** Embed a single-use auth key generated via your Raspberry Pi Connect dashboard:
+
+   ```bash
+   rpi-image-gen build -S ./examples/ota/ -c ota.yaml -- IGconf_connect_authkey=rpuak_XXX
+   ```
+
+If an auth key is embedded on a device that is also registered with an organisation, the auth key takes precedence.
+
+For further details, see the [Raspberry Pi Connect documentation][connect-docs].
+
+[management-api]: https://www.raspberrypi.com/documentation/services/connect.html#organisations-management-api
+[connect-docs]: https://www.raspberrypi.com/documentation/services/connect.html

--- a/layer/rpi/device/services/rpi-connect-lite.yaml
+++ b/layer/rpi/device/services/rpi-connect-lite.yaml
@@ -28,6 +28,7 @@
 mmdebstrap:
   packages:
     - rpi-connect-lite
+    - rpifwcrypto
   customize-hooks:
     - |-
       set -eu

--- a/layer/rpi/device/services/rpi-connect.yaml
+++ b/layer/rpi/device/services/rpi-connect.yaml
@@ -29,6 +29,7 @@
 mmdebstrap:
   packages:
     - rpi-connect
+    - rpifwcrypto
     - wayvnc
   customize-hooks:
     - |-


### PR DESCRIPTION
Include rpifwcrypto in the rpi-connect and rpi-connect-lite layers so images support authentication using the device-identity feature within Connect for Organisations by default.
