### PR TITLE
slot-mapper: Fix dracut regression

### DIFF
--- a/layer/rpi/device/slot-mapper/dracut/modules.d/90rpi-ab-root/module-setup.sh
+++ b/layer/rpi/device/slot-mapper/dracut/modules.d/90rpi-ab-root/module-setup.sh
@@ -7,6 +7,6 @@ install() {
    inst_binary /usr/bin/rpi-slot-label
    inst_binary /usr/bin/rpi-slot-static
    inst_simple /boot/slot.map /boot/slot.map 2>/dev/null || :
-   inst_rules /etc/udev/rules.d/99-rpi-slot.rules
+   inst /etc/udev/rules.d/99-rpi-01-abslot.rules
    inst_hook pre-mount 50 "$moddir/root-check.sh"
 }


### PR DESCRIPTION
The slot rules file was renamed from 99-rpi-slot.rules to 99-rpi-01-abslot.rules but the dracut module setup wasn't updated to match, and inst_rules doesn't complain if the named file is not found. This caused the initramfs to be built without the slot rules, causing all dracut AB boots to fail as no by-slot system symlink was created for the root device. Install the correct filename using inst as it's noisier about missing files.