### PR TITLE
Boot device qualification of all block devices, including LUKS volumes

### DIFF
--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-rota</h1>
         <span class="badge">image</span>
-        <span class="badge">v5.3.0</span>
+        <span class="badge">v5.4.0</span>
         <p>Immutable GPT A/B layout for rotational OTA updates,
  boot/system redundancy, and a shared persistent data partition.</p>
     </div>
@@ -507,6 +507,7 @@
         <ul>
             <li><code>dosfstools</code></li>
             <li><code>e2fsprogs</code></li>
+            <li><code>initramfs-tools</code></li>
         </ul>
     </div>
 

--- a/docs/layer/image-rpios.html
+++ b/docs/layer/image-rpios.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-rpios</h1>
         <span class="badge">image</span>
-        <span class="badge">v2.1.0</span>
+        <span class="badge">v2.2.0</span>
         <p>Raspberry Pi OS style image layout with MBR, vfat
  boot partition, and a root partition that can be ext4 or btrfs.</p>
     </div>
@@ -132,6 +132,7 @@
         <p><strong>Depends on:</strong></p>
         <div class="deps">
             <a href="image-base.html" class="dep-badge">image-base</a>
+            <a href="rpi-storage-binder.html" class="dep-badge">rpi-storage-binder</a>
         </div>
         <p><strong>Provides:</strong> image</p>
     </div>
@@ -208,6 +209,15 @@
                 </tr>
             </tbody>
         </table>
+    </div>
+    <div class="section">
+        <h2>mmdebstrap</h2>
+        
+        <h3>Packages</h3>
+        <p>Installs:</p>
+        <ul>
+            <li><code>initramfs-tools</code></li>
+        </ul>
     </div>
 
     <div class="section">

--- a/docs/layer/rpi-storage-binder.html
+++ b/docs/layer/rpi-storage-binder.html
@@ -132,6 +132,8 @@
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
+            <a href="image-rpios.html" class="dep-badge">image-rpios</a>
+            
             <a href="rpi-ab-slot-mapper.html" class="dep-badge">rpi-ab-slot-mapper</a>
             
         </div>

--- a/image/gpt/ab_userdata/bdebstrap/customize15-cryptroot
+++ b/image/gpt/ab_userdata/bdebstrap/customize15-cryptroot
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eu
+
+
+# Fetch all crypt information from the pmap
+pmap --schema "$IGconf_image_pmap_schema" \
+   --file "${IGconf_image_outputdir}/provisionmap.json" \
+   --cryptvars > "${IGconf_image_outputdir}/crypt.containers"
+
+source "${IGconf_image_outputdir}/crypt.containers"
+
+
+# Emit a matching udev rule and crypttab entry per LUKS volume
+if [ -n "$CONTAINERS" ]; then
+   rules="${1}/etc/udev/rules.d/99-rpi-06-image-crypt.rules"
+   : > "$rules"
+   : > "${1}/etc/crypttab"
+
+   for container in $CONTAINERS; do
+      label_var="${container}_LABEL"
+      echo "SUBSYSTEM==\"block\", ENV{RPI_ONBOOTDEV}==\"1\", ENV{ID_FS_LABEL}==\"${!label_var}\", SYMLINK+=\"disk/by-slot/${container}\"" >> "$rules"
+
+      if [ -d "$1/etc/initramfs-tools" ]; then
+         echo "$container /dev/disk/by-slot/${container} none luks,initramfs,keyscript=/lib/cryptsetup/keyscripts/hwkey" >> "${1}/etc/crypttab"
+      elif [ -d "$1/usr/lib/dracut" ]; then
+         echo "$container /dev/disk/by-slot/${container} none luks" >> "${1}/etc/crypttab"
+      fi
+   done
+fi

--- a/image/gpt/ab_userdata/device/dracut.modules.d/95rpi-image-crypt/module-setup.sh
+++ b/image/gpt/ab_userdata/device/dracut.modules.d/95rpi-image-crypt/module-setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+check() { return 0; }
+depends() { echo "udev-rules"; }
+install() {
+   inst_rules /etc/udev/rules.d/99-rpi-06-image-crypt.rules
+}

--- a/image/gpt/ab_userdata/device/initramfs-tools/hooks/rpi-image-crypt-install
+++ b/image/gpt/ab_userdata/device/initramfs-tools/hooks/rpi-image-crypt-install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+case $1 in
+   prereqs) echo ""; exit 0;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+copy_file config /etc/udev/rules.d/99-rpi-06-image-crypt.rules || true

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -51,7 +51,7 @@
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
             "hash": "${LUKS_HASH}",
-            "label": "OSDATA",
+            "label": "OSDATA_CRYPT",
             "uuid": "${CRYPT_UUID}",
             "mname": "osdata_crypt",
             "etype": "partitioned"

--- a/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
@@ -83,7 +83,7 @@
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
             "hash": "${LUKS_HASH}",
-            "label": "USERDATA",
+            "label": "USERDATA_CRYPT",
             "uuid": "${CRYPT_UUID}",
             "mname": "userdata_crypt",
             "etype": "partitioned"

--- a/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
@@ -51,7 +51,7 @@
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
             "hash": "${LUKS_HASH}",
-            "label": "OSAB",
+            "label": "OSAB_CRYPT",
             "uuid": "${CRYPT_UUID}",
             "mname": "osab_crypt",
             "etype": "partitioned"

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
 #  boot/system redundancy, and a shared persistent data partition.
-# X-Env-Layer-Version: 5.3.0
+# X-Env-Layer-Version: 5.4.0
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
@@ -79,3 +79,4 @@ mmdebstrap:
   packages:
     - dosfstools
     - e2fsprogs
+    - initramfs-tools

--- a/image/mbr/simple_dual/bdebstrap/customize15-cryptroot
+++ b/image/mbr/simple_dual/bdebstrap/customize15-cryptroot
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+# Set devices requiring cryptroot unlock
+if [[ $IGconf_image_pmap == crypt ]]; then
+   if [ -d "$1/etc/initramfs-tools" ]; then
+      echo "cryptroot /dev/disk/by-slot/cryptroot none luks,initramfs,keyscript=/lib/cryptsetup/keyscripts/hwkey" > "${1}/etc/crypttab"
+   elif [ -d "$1/usr/lib/dracut" ]; then
+      echo "cryptroot /dev/disk/by-slot/cryptroot none luks" > "${1}/etc/crypttab"
+   fi
+fi

--- a/image/mbr/simple_dual/device/dracut.modules.d/95rpi-image-rpios/module-setup.sh
+++ b/image/mbr/simple_dual/device/dracut.modules.d/95rpi-image-rpios/module-setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+check() { return 0; }
+depends() { echo "udev-rules"; }
+install() {
+   inst_rules /etc/udev/rules.d/99-rpi-05-image.rules
+}

--- a/image/mbr/simple_dual/device/initramfs-tools/hooks/rpi-image-install
+++ b/image/mbr/simple_dual/device/initramfs-tools/hooks/rpi-image-install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+case $1 in
+   prereqs) echo ""; exit 0;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+copy_file config /etc/udev/rules.d/99-rpi-05-image.rules

--- a/image/mbr/simple_dual/device/provisionmap-crypt.json
+++ b/image/mbr/simple_dual/device/provisionmap-crypt.json
@@ -18,7 +18,7 @@
          "luks2": {
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
-            "label": "OSROOT",
+            "label": "OSROOT_CRYPT",
             "uuid": "${CRYPT_UUID}",
             "hash": "${LUKS_HASH}",
             "mname": "osroot_crypt",

--- a/image/mbr/simple_dual/device/rootfs-overlay/etc/udev/rules.d/99-rpi-05-image.rules
+++ b/image/mbr/simple_dual/device/rootfs-overlay/etc/udev/rules.d/99-rpi-05-image.rules
@@ -1,0 +1,3 @@
+SUBSYSTEM=="block", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_FS_LABEL}=="BOOT", SYMLINK+="disk/by-slot/boot"
+SUBSYSTEM=="block", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_FS_LABEL}=="ROOT", SYMLINK+="disk/by-slot/system"
+SUBSYSTEM=="block", ENV{RPI_ONBOOTDEV}=="1", ENV{ID_FS_LABEL}=="OSROOT_CRYPT", SYMLINK+="disk/by-slot/cryptroot"

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -44,7 +44,7 @@ image boot.vfat {
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"
-   exec-pre = "<SETUP> BOOT <BOOT_UUID> <ROOT_UUID>"
+   exec-pre = "<SETUP> BOOT"
 }
 
 image root.btrfs {
@@ -54,5 +54,5 @@ image root.btrfs {
    }
    size = <ROOT_SIZE>
    mountpoint = "/"
-   exec-pre = "<SETUP> ROOT <BOOT_UUID> <ROOT_UUID>"
+   exec-pre = "<SETUP> ROOT"
 }

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -44,7 +44,7 @@ image boot.vfat {
    }
    size = <FW_SIZE>
    mountpoint = "/boot/firmware"
-   exec-pre = "<SETUP> BOOT <BOOT_UUID> <ROOT_UUID>"
+   exec-pre = "<SETUP> BOOT"
 }
 
 image root.ext4 {
@@ -56,5 +56,5 @@ image root.ext4 {
    }
    size = <ROOT_SIZE>
    mountpoint = "/"
-   exec-pre = "<SETUP> ROOT <BOOT_UUID> <ROOT_UUID>"
+   exec-pre = "<SETUP> ROOT"
 }

--- a/image/mbr/simple_dual/image.yaml
+++ b/image/mbr/simple_dual/image.yaml
@@ -3,8 +3,8 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Raspberry Pi OS style image layout with MBR, vfat
 #  boot partition, and a root partition that can be ext4 or btrfs.
-# X-Env-Layer-Version: 2.1.0
-# X-Env-Layer-Requires: image-base
+# X-Env-Layer-Version: 2.2.0
+# X-Env-Layer-Requires: image-base,rpi-storage-binder
 # X-Env-Layer-Provides: image
 #
 # X-Env-VarPrefix: image
@@ -45,3 +45,6 @@
 # X-Env-Var-pmap-Set: y
 # METAEND
 ---
+mmdebstrap:
+  packages:
+    - initramfs-tools

--- a/image/mbr/simple_dual/setup.sh
+++ b/image/mbr/simple_dual/setup.sh
@@ -3,20 +3,18 @@
 set -eu
 
 LABEL="$1"
-BOOTUUID="$2"
-ROOTUUID="$3"
 
 case $LABEL in
    ROOT)
       case $IGconf_image_rootfs_type in
          ext4)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-UUID=${ROOTUUID} /               ext4 rw,relatime,errors=remount-ro,commit=30 0 1
+/dev/disk/by-slot/system  /  ext4 rw,relatime,errors=remount-ro,commit=30 0 1
 EOF
             ;;
          btrfs)
             cat << EOF > $IMAGEMOUNTPATH/etc/fstab
-UUID=${ROOTUUID} /               btrfs defaults 0 0
+/dev/disk/by-slot/system  /  btrfs defaults 0 0
 EOF
             ;;
          *)
@@ -24,11 +22,11 @@ EOF
       esac
 
       cat << EOF >> $IMAGEMOUNTPATH/etc/fstab
-UUID=${BOOTUUID} /boot/firmware  vfat defaults,rw,noatime,errors=remount-ro 0 2
+/dev/disk/by-slot/boot  /boot/firmware  vfat defaults,rw,noatime,errors=remount-ro 0 2
 EOF
       ;;
    BOOT)
-      sed -i "s|root=\([^ ]*\)|root=UUID=${ROOTUUID}|" $IMAGEMOUNTPATH/cmdline.txt
+      sed -i "s|root=\([^ ]*\)|root=/dev/disk/by-slot/system|" $IMAGEMOUNTPATH/cmdline.txt
       ;;
    *)
       ;;


### PR DESCRIPTION
This change-set ensures all block devices that are part of the boot image, whether encrypted or not, are on the boot device. `image-rota` and `image-rpios` now create their own `/etc/crypttab` containing `by-slot` aliases for LUKS volumes requiring unlock with initramfs-tools and dracut support added for those initramfs generation frameworks. Usage of `by-slot` is widened to non-AB and denotes block devices which are special and boot-device qualified.