### PR TITLE
Ship VideoCore udev rules in rpi-connect layers

### DIFF
--- a/layer/rpi/device/services/rpi-connect-lite.yaml
+++ b/layer/rpi/device/services/rpi-connect-lite.yaml
@@ -31,6 +31,13 @@ mmdebstrap:
     - rpifwcrypto
   customize-hooks:
     - |-
+      cat > "$1/usr/lib/udev/rules.d/10-vc.rules" << 'UDEVRULES'
+      KERNEL=="vcio",     GROUP="video", MODE="0660"
+      KERNEL=="vchiq",    GROUP="video", MODE="0660"
+      SUBSYSTEM=="vc-sm", GROUP="video", MODE="0660"
+      KERNEL=="vcsm-cma", GROUP="video", MODE="0660"
+      UDEVRULES
+    - |-
       set -eu
       uchroot "$1" 'mkdir -m 0700 -p ${HOME}/.config/com.raspberrypi.connect'
 

--- a/layer/rpi/device/services/rpi-connect.yaml
+++ b/layer/rpi/device/services/rpi-connect.yaml
@@ -33,6 +33,13 @@ mmdebstrap:
     - wayvnc
   customize-hooks:
     - |-
+      cat > "$1/usr/lib/udev/rules.d/10-vc.rules" << 'UDEVRULES'
+      KERNEL=="vcio",     GROUP="video", MODE="0660"
+      KERNEL=="vchiq",    GROUP="video", MODE="0660"
+      SUBSYSTEM=="vc-sm", GROUP="video", MODE="0660"
+      KERNEL=="vcsm-cma", GROUP="video", MODE="0660"
+      UDEVRULES
+    - |-
       set -eu
       uchroot "$1" 'mkdir -m 0700 -p ${HOME}/.config/com.raspberrypi.connect'
 


### PR DESCRIPTION
Minbase images don't include `raspberrypi-sys-mods`, so `/dev/vcio` stays `0600 root:root`. The non-root user is in the `video` group (via `rpi-user-credentials`) but without a udev rule the group has no permissions. As a result using `rpi-fw-crypto` fails with "Permission denied".

Pulling in `raspberrypi-sys-mods` would also fix this issue, but it brings a lot of baggage with it.
