### PR TITLE
IDP: Enable partition expansion in all PMAPs

### DIFF
--- a/image/gpt/ab_userdata/device/provisionmap-clear.json
+++ b/image/gpt/ab_userdata/device/provisionmap-clear.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.3.1",
+         "PMAPversion": "1.4.0",
          "system_type": "slotted"
       }
    },
@@ -81,7 +81,8 @@
       "partitions": [
          {
             "comment": "user data - shared between slots",
-            "image": "persistent"
+            "image": "persistent",
+            "expand-to-fit": true
          }
       ]
    }

--- a/image/gpt/ab_userdata/device/provisionmap-crypt.json
+++ b/image/gpt/ab_userdata/device/provisionmap-crypt.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.4.2",
+         "PMAPversion": "1.5.0",
          "system_type": "slotted"
       }
    },
@@ -47,6 +47,7 @@
    },
    {
       "encrypted": {
+         "expand-to-fit": true,
          "luks2": {
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
@@ -85,7 +86,8 @@
          "partitions": [
             {
                "comment": "Encrypted user data - shared between slots",
-               "image": "persistent"
+               "image": "persistent",
+               "expand-to-fit": true
             }
          ]
       }

--- a/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptdata.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.1.1",
+         "PMAPversion": "1.2.0",
          "system_type": "slotted"
       }
    },
@@ -79,6 +79,7 @@
    },
    {
       "encrypted": {
+         "expand-to-fit": true,
          "luks2": {
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
@@ -91,7 +92,8 @@
          "partitions": [
             {
                "comment": "Encrypted user data - shared between slots",
-               "image": "persistent"
+               "image": "persistent",
+               "expand-to-fit": true
             }
          ]
       }

--- a/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
+++ b/image/gpt/ab_userdata/device/provisionmap-cryptslots.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.1.1",
+         "PMAPversion": "1.2.0",
          "system_type": "slotted"
       }
    },
@@ -88,7 +88,8 @@
       "partitions": [
          {
             "comment": "user data - shared between slots",
-            "image": "persistent"
+            "image": "persistent",
+            "expand-to-fit": true
          }
       ]
    }

--- a/image/mbr/simple_dual/device/provisionmap-clear.json
+++ b/image/mbr/simple_dual/device/provisionmap-clear.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.1.0",
+         "PMAPversion": "1.2.0",
          "system_type": "flat"
       }
    },
@@ -13,7 +13,8 @@
          },
          {
             "image": "root",
-            "comment": "root filesystem"
+            "comment": "root filesystem",
+            "expand-to-fit": true
          }
       ]
    }

--- a/image/mbr/simple_dual/device/provisionmap-crypt.json
+++ b/image/mbr/simple_dual/device/provisionmap-crypt.json
@@ -1,7 +1,7 @@
 [
    {
       "attributes": {
-         "PMAPversion": "1.2.1",
+         "PMAPversion": "1.3.0",
          "system_type": "flat"
       }
    },
@@ -15,6 +15,7 @@
    },
    {
       "encrypted": {
+         "expand-to-fit": true,
          "luks2": {
             "key_size": ${LUKS_KEYSIZE},
             "cipher": "${LUKS_CIPHER}",
@@ -27,7 +28,8 @@
          "partitions": [
             {
                "comment": "Encrypted root filesystem",
-               "image": "root"
+               "image": "root",
+               "expand-to-fit": true
             }
          ]
       }


### PR DESCRIPTION
Enable expand-to-fit on applicable partitions in all provisioning maps so the provisioner extends the partition table entry to the end of the target device. For crypt PMAPs, expand-to-fit is set on both the encrypted volume (so its partition entry grows on disk) and the last partition within the volume (so the encapsulated partition entry reaches the end of the volume).