### PR TITLE
Fix doubled version in OTA bundle name

### DIFF
--- a/examples/ota/config/ota.yaml
+++ b/examples/ota/config/ota.yaml
@@ -3,19 +3,15 @@
 include:
   file: trixie-minbase-ab.yaml
 
-env:
-  APPLICATION_NAME: myapp
-  VERSION: 1.0.0
-
 device:
   # This will set the name of the device in Raspberry Pi Connect
   hostname: ota-device-1
 
 artefact:
-  version: ${VERSION}
+  version: 1.0.0
 
 image:
-  name: ${APPLICATION_NAME}-${VERSION}
+  name: myapp
 
 layer:
   app: example-ota


### PR DESCRIPTION
The deploy layer already appends the version to the bundle name, so `image.name` shouldn't repeat it. Was `myapp-1.0.0-1.0.0.tar.zst`, now `myapp-1.0.0.tar.zst`.
