### PR TITLE
Better metadata conditional expressions and layer version reporting

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -192,8 +192,8 @@ apply_layer_overlays() {
    local plan=${PLAN:-}
    [[ -n $plan && -f $plan ]] || return 0
 
-   local layer static resolved overlay
-   while IFS=: read -r layer static resolved; do
+   local layer version static resolved overlay
+   while IFS=: read -r layer version static resolved; do
       [[ -n $layer && -n $static ]] || continue
       [[ $layer == \#* ]] && continue
       overlay="${static%.yaml}.rootfs-overlay"

--- a/device/cm4/device.yaml
+++ b/device/cm4/device.yaml
@@ -19,8 +19,8 @@
 # X-Env-Var-variant-Required: n
 # X-Env-Var-variant-Valid: 8G,16G,32G,lite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
-# X-Env-Var-variant-Triggers: when=lite set IGconf_device_storage_type=sd policy=lazy
+# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
+# X-Env-Var-variant-Triggers: when=IGconf_device_variant == 'lite' set IGconf_device_storage_type=sd policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen

--- a/device/cm5/device.yaml
+++ b/device/cm5/device.yaml
@@ -19,8 +19,8 @@
 # X-Env-Var-variant-Required: n
 # X-Env-Var-variant-Valid: 16G,32G,64G,lite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
-# X-Env-Var-variant-Triggers: when=lite set IGconf_device_storage_type=sd policy=lazy
+# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
+# X-Env-Var-variant-Triggers: when=IGconf_device_variant == 'lite' set IGconf_device_storage_type=sd policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -211,30 +211,44 @@ Variable values support dynamic placeholders:
 
 `${FILEPATH}`: Full path to the layer file
 
+[[conditional-expressions]]
+=== Conditional Expressions
+
+Conditional expressions are supported in trigger `when=` clauses and conflict expressions. They use standard https://docs.python.org/3/reference/expressions.html#comparisons[Python comparison syntax,window=_blank]. Variable names must be fully qualified `IGconf_*` names. Comparison values must be quoted strings. An unquoted value such as `pi5` would be interpreted as a variable name and rejected at lint time.
+
+[cols="1,3",options="header"]
+|===
+|Operator |Example
+
+|`==`     |`IGconf_device_class == 'pi5'`
+|`!=`     |`IGconf_device_user1pass != ''`
+|`in`     |`IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5']`
+|`not in` |`IGconf_device_class not in ['zero2w']`
+|`and`    |`IGconf_a == 'x' and IGconf_b == 'y'`
+|`or`     |`IGconf_a == 'x' or IGconf_b == 'y'`
+|===
+
+To check for a non-empty value, use `!= ''`. Syntax errors and unknown variable references are caught at lint time, not at build time.
+
 === Triggers
 
-Triggers (`X-Env-Var-*-Triggers`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
+Triggers (`+X-Env-Var-*-Triggers+`) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):
 
-* Conditional (same variable): `when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
-* Conditional (same variable, wildcard): `when=* set TARGET=VALUE [policy=force|immediate|lazy]`
-* Conditional (cross-variable): `when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
-* Conditional (cross-variable): `when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]`
-* Conditional (cross-variable, wildcard): `when=VAR=* set TARGET=VALUE [policy=force|immediate|lazy]`
+* Conditional: `when=<expr> set TARGET=VALUE [policy=force|immediate|lazy]`
 * Unconditional: `set TARGET=VALUE [policy=force|immediate|lazy]`
 
-For same-variable conditions, matching is an exact string comparison against the source variable's resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable's resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.
-
-The wildcard `*` matches any non-empty value. It will not fire if the variable is unset or set to an empty string.
+`<expr>` is a conditional expression as described in <<conditional-expressions>>. Unconditional rules always fire. The first token after the action must be `TARGET=VALUE`. `policy=` is optional and defaults to `immediate` if not specified.
 
 Lint will fail on:
 
+* Syntax errors or unsupported operators in condition expressions.
 * Unknown actions.
 * Actions that do not start with `TARGET=VALUE`.
 * Target names that are not POSIX identifiers.
 
 Values containing spaces must be quoted (single or double quotes):
 
-* `when=erofs set IGconf_fs_erofs_mkfs_args="-b 4096 -z zstd,3" policy=lazy`
+* `when=IGconf_image_rootfs_type == ‘erofs’ set IGconf_fs_erofs_mkfs_args="-b 4096 -z zstd,3" policy=lazy`
 
 Quoted values have the quotes stripped during parsing, with the stored value being the unquoted content. Variable expansion (`${VAR}`) within trigger values is deferred and resolved during the expansion phase, not at parse time.
 
@@ -256,7 +270,7 @@ Usage:
 
 * Conditional:
 +
-`# X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force`
+`# X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == ‘btrfs’ set IG_HAS_BTRFS_PROGS=1 policy=force`
 
 * Unconditional:
 +
@@ -266,19 +280,23 @@ Usage:
 +
 ```
 # X-Env-Var-rootfs_type-Triggers:
-#  when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
-#  when=ext4 set IG_HAS_E2FS_PROGS=1 policy=force
+#  when=IGconf_image_rootfs_type == ‘btrfs’ set IG_HAS_BTRFS_PROGS=1 policy=force
+#  when=IGconf_image_rootfs_type == ‘ext4’ set IG_HAS_E2FS_PROGS=1 policy=force
 ```
+
+* Non-empty check (fires whenever the variable is set to any non-empty value):
++
+`# X-Env-Var-compression-Triggers: when=IGconf_image_compression != ‘’ set IG_ENABLE_HOST_COMPRESSION=y policy=force`
 
 * Quoted value with deferred variable expansion:
 +
-`# X-Env-Var-rootfs_type-Triggers: when=erofs set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy`
+`# X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == ‘erofs’ set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy`
 
 [IMPORTANT]
 ====
 Trigger precedence is determined by layer order, not file order.
 
-* Variable declarations in the same layer share that layer's position.
+* Variable declarations in the same layer share that layer’s position.
 * If a trigger sets a variable, it adds a new definition for the target variable at the same layer position.
 * Any definition of that target variable from a later layer (higher position) wins via the normal force/immediate/lazy policy rules.
 
@@ -296,7 +314,7 @@ Within a single layer:
 # X-Env-Var-deploy_type: develop
 # X-Env-Var-deploy_type-Valid: develop,production
 # X-Env-Var-deploy_type-Set: y
-# X-Env-Var-deploy_type-Triggers: when=production set IGconf_image_pmap=crypt policy=force
+# X-Env-Var-deploy_type-Triggers: when=IGconf_image_deploy_type == ‘production’ set IGconf_image_pmap=crypt policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Valid: clear,crypt
@@ -306,7 +324,7 @@ Within a single layer:
 
 If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGconf_image_pmap=crypt` after the source variable, overriding `pmap: clear` in the same layer. A later layer defining `IGconf_image_pmap` with `force` would still win over the trigger.
 
-==== Example (cross-var across layers)
+==== Example (cross-layer condition)
 
 ```
 # X-Env-VarPrefix: device
@@ -317,7 +335,7 @@ If `IGconf_image_deploy_type` resolves to `production`, the trigger injects `IGc
 ```
 # X-Env-VarPrefix: image
 # X-Env-Var-ptable_protect: n
-# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type == ‘emmc’ set IGconf_image_ptable_protect=y
 ```
 
 If `IGconf_device_storage_type` resolves to `emmc`, the trigger injects `IGconf_image_ptable_protect=y`.
@@ -325,30 +343,33 @@ If `IGconf_device_storage_type` resolves to `emmc`, the trigger injects `IGconf_
 
 === Variable Conflicts
 
-Variable conflicts (`X-Env-Var-*-Conflicts`) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved `IGconf` prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.
+Variable conflicts (`+X-Env-Var-*-Conflicts+`) allow a variable to declare conditions under which a conflict should be reported. The conflict expression is evaluated against the final resolved set of `+IGconf_*+` variables. If it evaluates to `true`, the build is rejected with a conflict error. Cross-layer conflict detection is supported - the expression can reference any `+IGconf_*+` variable in the final set, regardless of which layer declared it. If a variable is overridden in a consumer layer, conflicts belong to the winning definition - earlier definitions do not carry their conflict expressions forward.
 
-Conflict expressions adhere to `<precursor> <condition>` syntax. The precursor is optional (`when=<value>`) and a single expression may only include one precursor. The condition can be unconditional (`name`) or conditional (`name=value` / `name!=value`). Multiple expressions can be specified, separated by commas, and may be wrapped across multiple lines. Each expression may include only one precursor.
+Each `+X-Env-Var-*-Conflicts+` entry is a conditional expression as described in <<conditional-expressions>>. Multiple expressions can be specified one per line using the DEB822 continuation syntax (indent continuation lines with a single space). Each expression is evaluated independently - any one firing reports a conflict.
+
+Lint will fail on syntax errors or unsupported operators in conflict expressions.
+
+Identical expressions declared by more than one variable (eg. symmetric mutual-exclusion pairs) are deduplicated and reported only once.
 
 Examples:
 
 ```
-# Unconditional:
+# Mutual exclusion - conflict if both user1pass and user1passhash are set:
 # X-Env-Var-user1pass:
-# X-Env-Var-user1pass-Conflicts: user1hashpass
+# X-Env-Var-user1pass-Conflicts: IGconf_device_user1pass != '' and IGconf_device_user1passhash != ''
 #
-# X-Env-Var-user1hashpass:
-# X-Env-Var-user1hashpass-Conflicts: user1pass
+# X-Env-Var-user1passhash:
+# X-Env-Var-user1passhash-Conflicts: IGconf_device_user1passhash != '' and IGconf_device_user1pass != ''
 
-# Conditional (no precursor):
-# X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Valid: sd,emmc,nvme
-#
-# X-Env-Var-lockemmc: y
-# X-Env-Var-lockemmc-Valid: bool
-# X-Env-Var-lockemmc-Conflicts: storage_type!=emmc
+# Conditional - lite variant cannot be used with emmc storage:
+# X-Env-Var-variant: none
+# X-Env-Var-variant-Valid: none,lite
+# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
 
-# Conditional (with precursor):
-# X-Env-Var-lockemmc-Conflicts: when=y storage_type!=emmc
+# Multi-line - two independent conflict expressions for one variable:
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Conflicts: IGconf_image_ptable_protect == 'y' and IGconf_device_storage_type != 'emmc'
+#  IGconf_image_ptable_protect == 'y' and IGconf_image_type == 'raw'
 ```
 
 == Configuration Variables

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -157,12 +157,13 @@
 <li><a href="#_environment_variables">Environment Variables</a></li>
 <li><a href="#_variable_naming_convention">Variable Naming Convention</a></li>
 <li><a href="#_placeholder_support">Placeholder Support</a></li>
+<li><a href="#conditional-expressions">Conditional Expressions</a></li>
 <li><a href="#_triggers">Triggers</a>
 <ul class="sectlevel3">
 <li><a href="#_supported_actions">Supported actions</a></li>
 <li><a href="#_examples">Examples</a></li>
 <li><a href="#_example_same_layer">Example (same layer)</a></li>
-<li><a href="#_example_cross_var_across_layers">Example (cross-var across layers)</a></li>
+<li><a href="#_example_cross_layer_condition">Example (cross-layer condition)</a></li>
 </ul>
 </li>
 <li><a href="#_variable_conflicts">Variable Conflicts</a></li>
@@ -605,6 +606,53 @@ mmdebstrap:
 </div>
 </div>
 <div class="sect2">
+<h3 id="conditional-expressions"><a class="anchor" href="#conditional-expressions"></a><a class="link" href="#conditional-expressions">Conditional Expressions</a></h3>
+<div class="paragraph">
+<p>Conditional expressions are supported in trigger <code>when=</code> clauses and conflict expressions. They use standard <a href="https://docs.python.org/3/reference/expressions.html#comparisons" target="<em>blank">Python comparison syntax</a>. Variable names must be fully qualified <code>IGconf</em>*</code> names. Comparison values must be quoted strings. An unquoted value such as <code>pi5</code> would be interpreted as a variable name and rejected at lint time.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-even stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Operator</th>
+<th class="tableblock halign-left valign-top">Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>==</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_device_class == 'pi5'</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>!=</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_device_user1pass != ''</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>in</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5']</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>not in</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_device_class not in ['zero2w']</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>and</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_a == 'x' and IGconf_b == 'y'</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>or</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>IGconf_a == 'x' or IGconf_b == 'y'</code></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>To check for a non-empty value, use <code>!= ''</code>. Syntax errors and unknown variable references are caught at lint time, not at build time.</p>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_triggers"><a class="anchor" href="#_triggers"></a><a class="link" href="#_triggers">Triggers</a></h3>
 <div class="paragraph">
 <p>Triggers (<code>X-Env-Var-*-Triggers</code>) allow a variable’s resolved value to automatically perform actions, meaning that derived settings can be injected based on that value. Format as follows (one rule per line):</p>
@@ -612,19 +660,7 @@ mmdebstrap:
 <div class="ulist">
 <ul>
 <li>
-<p>Conditional (same variable): <code>when=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
-</li>
-<li>
-<p>Conditional (same variable, wildcard): <code>when=* set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
-</li>
-<li>
-<p>Conditional (cross-variable): <code>when=VAR=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
-</li>
-<li>
-<p>Conditional (cross-variable): <code>when=VAR!=VALUE set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
-</li>
-<li>
-<p>Conditional (cross-variable, wildcard): <code>when=VAR=* set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
+<p>Conditional: <code>when=&lt;expr&gt; set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
 </li>
 <li>
 <p>Unconditional: <code>set TARGET=VALUE [policy=force|immediate|lazy]</code></p>
@@ -632,16 +668,16 @@ mmdebstrap:
 </ul>
 </div>
 <div class="paragraph">
-<p>For same-variable conditions, matching is an exact string comparison against the source variable&#8217;s resolved value. For cross-variable conditions, matching is an exact string comparison against the referenced variable&#8217;s resolved value (ie, the referenced variable is used as-is). Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code> if not specified. If a cross-variable condition references an unknown variable, resolution fails with an error.</p>
-</div>
-<div class="paragraph">
-<p>The wildcard <code>*</code> matches any non-empty value. It will not fire if the variable is unset or set to an empty string.</p>
+<p><code>&lt;expr&gt;</code> is a conditional expression as described in <a href="#conditional-expressions">Conditional Expressions</a>. Unconditional rules always fire. The first token after the action must be <code>TARGET=VALUE</code>. <code>policy=</code> is optional and defaults to <code>immediate</code> if not specified.</p>
 </div>
 <div class="paragraph">
 <p>Lint will fail on:</p>
 </div>
 <div class="ulist">
 <ul>
+<li>
+<p>Syntax errors or unsupported operators in condition expressions.</p>
+</li>
 <li>
 <p>Unknown actions.</p>
 </li>
@@ -659,7 +695,7 @@ mmdebstrap:
 <div class="ulist">
 <ul>
 <li>
-<p><code>when=erofs set IGconf_fs_erofs_mkfs_args="-b 4096 -z zstd,3" policy=lazy</code></p>
+<p><code>when=IGconf_image_rootfs_type == ‘erofs’ set IGconf_fs_erofs_mkfs_args="-b 4096 -z zstd,3" policy=lazy</code></p>
 </li>
 </ul>
 </div>
@@ -713,7 +749,7 @@ mmdebstrap:
 <li>
 <p>Conditional:</p>
 <div class="paragraph">
-<p><code># X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force</code></p>
+<p><code># X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == ‘btrfs’ set IG_HAS_BTRFS_PROGS=1 policy=force</code></p>
 </div>
 </li>
 <li>
@@ -727,15 +763,21 @@ mmdebstrap:
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code># X-Env-Var-rootfs_type-Triggers:
-#  when=btrfs set IG_HAS_BTRFS_PROGS=1 policy=force
-#  when=ext4 set IG_HAS_E2FS_PROGS=1 policy=force</code></pre>
+#  when=IGconf_image_rootfs_type == ‘btrfs’ set IG_HAS_BTRFS_PROGS=1 policy=force
+#  when=IGconf_image_rootfs_type == ‘ext4’ set IG_HAS_E2FS_PROGS=1 policy=force</code></pre>
 </div>
+</div>
+</li>
+<li>
+<p>Non-empty check (fires whenever the variable is set to any non-empty value):</p>
+<div class="paragraph">
+<p><code># X-Env-Var-compression-Triggers: when=IGconf_image_compression != ‘’ set IG_ENABLE_HOST_COMPRESSION=y policy=force</code></p>
 </div>
 </li>
 <li>
 <p>Quoted value with deferred variable expansion:</p>
 <div class="paragraph">
-<p><code># X-Env-Var-rootfs_type-Triggers: when=erofs set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy</code></p>
+<p><code># X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == ‘erofs’ set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy</code></p>
 </div>
 </li>
 </ul>
@@ -753,7 +795,7 @@ mmdebstrap:
 <div class="ulist">
 <ul>
 <li>
-<p>Variable declarations in the same layer share that layer&#8217;s position.</p>
+<p>Variable declarations in the same layer share that layer’s position.</p>
 </li>
 <li>
 <p>If a trigger sets a variable, it adds a new definition for the target variable at the same layer position.</p>
@@ -790,7 +832,7 @@ mmdebstrap:
 # X-Env-Var-deploy_type: develop
 # X-Env-Var-deploy_type-Valid: develop,production
 # X-Env-Var-deploy_type-Set: y
-# X-Env-Var-deploy_type-Triggers: when=production set IGconf_image_pmap=crypt policy=force
+# X-Env-Var-deploy_type-Triggers: when=IGconf_image_deploy_type == ‘production’ set IGconf_image_pmap=crypt policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Valid: clear,crypt
@@ -803,7 +845,7 @@ mmdebstrap:
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_cross_var_across_layers"><a class="anchor" href="#_example_cross_var_across_layers"></a><a class="link" href="#_example_cross_var_across_layers">Example (cross-var across layers)</a></h4>
+<h4 id="_example_cross_layer_condition"><a class="anchor" href="#_example_cross_layer_condition"></a><a class="link" href="#_example_cross_layer_condition">Example (cross-layer condition)</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code># X-Env-VarPrefix: device
@@ -816,7 +858,7 @@ mmdebstrap:
 <div class="content">
 <pre class="highlight"><code># X-Env-VarPrefix: image
 # X-Env-Var-ptable_protect: n
-# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y</code></pre>
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_device_storage_type == ‘emmc’ set IGconf_image_ptable_protect=y</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -827,33 +869,38 @@ mmdebstrap:
 <div class="sect2">
 <h3 id="_variable_conflicts"><a class="anchor" href="#_variable_conflicts"></a><a class="link" href="#_variable_conflicts">Variable Conflicts</a></h3>
 <div class="paragraph">
-<p>Variable conflicts (<code>X-Env-Var-*-Conflicts</code>) allow a variable to declare that it cannot be set when other variables are also set, or when other variables do/do not have a particular value. Conflict resolution takes place on the final set of resolved <code>IGconf</code> prefixed variables. When declaring conflicts, any variable name can be specified (fully prefixed) that exists in the final set - not just variables declared in the same layer, ie cross-layer conflict resolution is supported. If a variable is set in a base layer and overridden in a consumer layer, conflicts are defined by the winning definition, ie conflicts from the earlier definition are not inherited.</p>
+<p>Variable conflicts (<code>X-Env-Var-*-Conflicts</code>) allow a variable to declare conditions under which a conflict should be reported. The conflict expression is evaluated against the final resolved set of <code>IGconf_*</code> variables. If it evaluates to <code>true</code>, the build is rejected with a conflict error. Cross-layer conflict detection is supported - the expression can reference any <code>IGconf_*</code> variable in the final set, regardless of which layer declared it. If a variable is overridden in a consumer layer, conflicts belong to the winning definition - earlier definitions do not carry their conflict expressions forward.</p>
 </div>
 <div class="paragraph">
-<p>Conflict expressions adhere to <code>&lt;precursor&gt; &lt;condition&gt;</code> syntax. The precursor is optional (<code>when=&lt;value&gt;</code>) and a single expression may only include one precursor. The condition can be unconditional (<code>name</code>) or conditional (<code>name=value</code> / <code>name!=value</code>). Multiple expressions can be specified, separated by commas, and may be wrapped across multiple lines. Each expression may include only one precursor.</p>
+<p>Each <code>X-Env-Var-*-Conflicts</code> entry is a conditional expression as described in <a href="#conditional-expressions">Conditional Expressions</a>. Multiple expressions can be specified one per line using the DEB822 continuation syntax (indent continuation lines with a single space). Each expression is evaluated independently - any one firing reports a conflict.</p>
+</div>
+<div class="paragraph">
+<p>Lint will fail on syntax errors or unsupported operators in conflict expressions.</p>
+</div>
+<div class="paragraph">
+<p>Identical expressions declared by more than one variable (eg. symmetric mutual-exclusion pairs) are deduplicated and reported only once.</p>
 </div>
 <div class="paragraph">
 <p>Examples:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code># Unconditional:
+<pre class="highlight"><code># Mutual exclusion - conflict if both user1pass and user1passhash are set:
 # X-Env-Var-user1pass:
-# X-Env-Var-user1pass-Conflicts: user1hashpass
+# X-Env-Var-user1pass-Conflicts: IGconf_device_user1pass != '' and IGconf_device_user1passhash != ''
 #
-# X-Env-Var-user1hashpass:
-# X-Env-Var-user1hashpass-Conflicts: user1pass
+# X-Env-Var-user1passhash:
+# X-Env-Var-user1passhash-Conflicts: IGconf_device_user1passhash != '' and IGconf_device_user1pass != ''
 
-# Conditional (no precursor):
-# X-Env-Var-storage_type: sd
-# X-Env-Var-storage_type-Valid: sd,emmc,nvme
-#
-# X-Env-Var-lockemmc: y
-# X-Env-Var-lockemmc-Valid: bool
-# X-Env-Var-lockemmc-Conflicts: storage_type!=emmc
+# Conditional - lite variant cannot be used with emmc storage:
+# X-Env-Var-variant: none
+# X-Env-Var-variant-Valid: none,lite
+# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
 
-# Conditional (with precursor):
-# X-Env-Var-lockemmc-Conflicts: when=y storage_type!=emmc</code></pre>
+# Multi-line - two independent conflict expressions for one variable:
+# X-Env-Var-ptable_protect: n
+# X-Env-Var-ptable_protect-Conflicts: IGconf_image_ptable_protect == 'y' and IGconf_device_storage_type != 'emmc'
+#  IGconf_image_ptable_protect == 'y' and IGconf_image_type == 'raw'</code></pre>
 </div>
 </div>
 </div>

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -38,7 +38,7 @@
 # X-Env-Var-rootfs_type-Set: y
 # X-Env-Var-rootfs_type-Triggers:
 #  set IGconf_fs_ext4_mkfs_args="-F -b ${IGconf_linux_page_size}" policy=lazy
-#  when=erofs set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy
+#  when=IGconf_image_rootfs_type == 'erofs' set IGconf_fs_erofs_mkfs_args="-b ${IGconf_linux_page_size} -z zstd,3" policy=lazy
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image specific asset directory
@@ -63,9 +63,9 @@
 # X-Env-Var-ptable_protect-Required: n
 # X-Env-Var-ptable_protect-Valid: bool
 # X-Env-Var-ptable_protect-Set: lazy
-# X-Env-Var-ptable_protect-Conflicts: when=y IGconf_device_storage_type!=emmc
+# X-Env-Var-ptable_protect-Conflicts: IGconf_image_ptable_protect == 'y' and IGconf_device_storage_type != 'emmc'
 # X-Env-Var-ptable_protect-Triggers:
-#  when=IGconf_device_storage_type=emmc set IGconf_image_ptable_protect=y policy=lazy
+#  when=IGconf_device_storage_type == 'emmc' set IGconf_image_ptable_protect=y policy=lazy
 #
 # X-Env-Var-compression: zstd
 # X-Env-Var-compression-Desc: Compression scheme used for update payloads.

--- a/image/mbr/simple_dual/image.yaml
+++ b/image/mbr/simple_dual/image.yaml
@@ -15,8 +15,8 @@
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
 # X-Env-Var-rootfs_type-Triggers:
-#  when=ext4 set IGconf_fs_ext4_mkfs_args="-F -b ${IGconf_linux_page_size}" policy=lazy
-#  when=btrfs set IGconf_fs_btrfs_mkfs_args="" policy=lazy
+#  when=IGconf_image_rootfs_type == 'ext4' set IGconf_fs_ext4_mkfs_args="-F -b ${IGconf_linux_page_size}" policy=lazy
+#  when=IGconf_image_rootfs_type == 'btrfs' set IGconf_fs_btrfs_mkfs_args="" policy=lazy
 #
 # X-Env-Var-boot_part_size: 100%
 # X-Env-Var-boot_part_size-Desc: Boot partition size

--- a/layer/base/deploy-base.yaml
+++ b/layer/base/deploy-base.yaml
@@ -18,7 +18,7 @@
 # X-Env-Var-compression-Required: n
 # X-Env-Var-compression-Valid: none,zstd
 # X-Env-Var-compression-Set: y
-# X-Env-Var-compression-Triggers: when=zstd set IG_ENABLE_HOST_ZSTD=y policy=force
+# X-Env-Var-compression-Triggers: when=IGconf_deploy_compression == 'zstd' set IG_ENABLE_HOST_ZSTD=y policy=force
 #
 # X-Env-Var-dir: ${IGconf_sys_workroot}/deploy-${IGconf_artefact_version}
 # X-Env-Var-dir-Desc: Final deployment directory for completed build assets.

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -51,8 +51,8 @@
 # X-Env-Var-user1pass-Required: n
 # X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
 # X-Env-Var-user1pass-Set: n
-# X-Env-Var-user1pass-Conflicts: user1passhash
-# X-Env-Var-user1pass-Triggers: when=* set IGconf_device_user1sudo=passwd policy=lazy
+# X-Env-Var-user1pass-Conflicts: IGconf_device_user1pass != '' and IGconf_device_user1passhash != ''
+# X-Env-Var-user1pass-Triggers: when=IGconf_device_user1pass != '' set IGconf_device_user1sudo=passwd policy=lazy
 #
 # X-Env-Var-user1passhash:
 # X-Env-Var-user1passhash-Desc: A pre-hashed password for the user1 account.
@@ -62,8 +62,8 @@
 # X-Env-Var-user1passhash-Required: n
 # X-Env-Var-user1passhash-Valid: string
 # X-Env-Var-user1passhash-Set: n
-# X-Env-Var-user1passhash-Conflicts: user1pass
-# X-Env-Var-user1passhash-Triggers: when=* set IGconf_device_user1sudo=passwd policy=lazy
+# X-Env-Var-user1passhash-Conflicts: IGconf_device_user1passhash != '' and IGconf_device_user1pass != ''
+# X-Env-Var-user1passhash-Triggers: when=IGconf_device_user1passhash != '' set IGconf_device_user1sudo=passwd policy=lazy
 #
 # X-Env-Var-user1sudo: none
 # X-Env-Var-user1sudo-Desc: Controls sudo access for the user1 account. 'none' disables

--- a/layer/base/image-base.yaml
+++ b/layer/base/image-base.yaml
@@ -23,7 +23,7 @@
 # X-Env-Var-compression-Required: n
 # X-Env-Var-compression-Valid: string
 # X-Env-Var-compression-Set: n
-# X-Env-Var-compression-Triggers: when=zstd set IG_ENABLE_HOST_ZSTD=y policy=force
+# X-Env-Var-compression-Triggers: when=IGconf_image_compression == 'zstd' set IG_ENABLE_HOST_ZSTD=y policy=force
 #
 # X-Env-Var-version: ${IGconf_artefact_version}
 # X-Env-Var-version-Desc: Version string of generated images. This always maps
@@ -71,7 +71,7 @@
 # X-Env-Var-provider-Required: n
 # X-Env-Var-provider-Valid: keywords:genimage
 # X-Env-Var-provider-Set: lazy
-# X-Env-Var-provider-Triggers: when=genimage set IG_ENABLE_HOST_GENIMAGE=y policy=force
+# X-Env-Var-provider-Triggers: when=IGconf_image_provider == 'genimage' set IG_ENABLE_HOST_GENIMAGE=y policy=force
 #
 # X-Env-Var-assetdir: /dev/null
 # X-Env-Var-assetdir-Desc: Image specific asset location. Use this directory
@@ -88,7 +88,7 @@
 # X-Env-Var-rootfs_type-Valid: string
 # X-Env-Var-rootfs_type-Set: n
 # X-Env-Var-rootfs_type-Triggers:
-#  when=erofs set IG_ENABLE_HOST_EROFS_UTILS=y policy=force
+#  when=IGconf_image_rootfs_type == 'erofs' set IG_ENABLE_HOST_EROFS_UTILS=y policy=force
 #
 # METAEND
 ---

--- a/layer/rpi/device/provisioning/luks2.yaml
+++ b/layer/rpi/device/provisioning/luks2.yaml
@@ -18,12 +18,8 @@
 # X-Env-Var-luks2_cipher-Valid: string
 # X-Env-Var-luks2_cipher-Set: lazy
 # X-Env-Var-luks2_cipher-Triggers:
-#  when=IGconf_device_class=pi5 set IGconf_device_luks2_cipher=aes-xts-plain64 policy=lazy
-#  when=IGconf_device_class=cm5 set IGconf_device_luks2_cipher=aes-xts-plain64 policy=lazy
-#  when=IGconf_device_class=pi4 set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
-#  when=IGconf_device_class=cm4 set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
-#  when=IGconf_device_class=pi3 set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
-#  when=IGconf_device_class=zero2w set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
+#  when=IGconf_device_class in ['pi5','cm5'] set IGconf_device_luks2_cipher=aes-xts-plain64 policy=lazy
+#  when=IGconf_device_class in ['pi4','cm4','pi3','zero2w'] set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
 #
 # X-Env-Var-luks2_hash: sha256
 # X-Env-Var-luks2_hash-Desc: The hash algorithm used for LUKS2 metadata integrity.
@@ -37,8 +33,8 @@
 # X-Env-Var-luks2_keysize-Valid: 128,256,512
 # X-Env-Var-luks2_keysize-Set: lazy
 # X-Env-Var-luks2_keysize-Triggers:
-#  when=IGconf_device_luks2_cipher=aes-xts-plain64 set IGconf_device_luks2_keysize=512 policy=lazy
-#  when=IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 set IGconf_device_luks2_keysize=256 policy=lazy
+#  when=IGconf_device_luks2_cipher == 'aes-xts-plain64' set IGconf_device_luks2_keysize=512 policy=lazy
+#  when=IGconf_device_luks2_cipher == 'xchacha12,aes-adiantum-plain64' set IGconf_device_luks2_keysize=256 policy=lazy
 #
 # METAEND
 ---

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -352,27 +352,27 @@ prepare_build_config()
    local specs="${TMPDIR}/layer.resolved"
 
    : > $specs
-   while IFS=: read -r layer static resolved; do
+   while IFS=: read -r layer version static resolved; do
       [[ -n $layer && -n $resolved ]] || continue
       [[ $layer == \#* ]] && continue
 
       ((total++))
       [[ -f $resolved ]] || die "Layer $layer ($resolved) not found"
-      printf '%s="%s"\n' "$layer" "$resolved" >> "$specs"
+      printf '%s:%s="%s"\n' "$layer" "$version" "$resolved" >> "$specs"
    done < "${ctx[LAYER_PLAN]}"
 
-   while IFS=: read -r layer yaml; do
+   while IFS=: read -r layer version yaml; do
       _bdebstrap+=( --config "$yaml" )
-      msg "Loaded $layer"
+      msg "Loaded $layer${version:+ v${version}}"
       ((added++))
    done < <(python3 - "$specs" <<'PY'
 import sys, yaml, pathlib
 for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
-    layer, path = raw.split('=', 1)
+    layer_ver, path = raw.split('=', 1)
     path = path.strip().strip('"')
     data = yaml.safe_load(pathlib.Path(path).read_bytes())
     if isinstance(data, dict) and data.get("mmdebstrap"):
-        print(f"{layer}:{path}")
+        print(f"{layer_ver}:{path}")
 PY
 )
    local skipped=$((total - added))

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -59,6 +59,10 @@ Provides dependency graph operations (get build order, provider checks, reverse 
 
 Main orchestrator for the application. Loads the base env file produced by config_loader, asks LayerManager for the dependency order, runs pre-resolution schema validation, runs the policy resolver (VariableResolver) to apply env vars, then validates env values against the resolved winning variable definitions before writing env/order outputs.
 
+== site/conditions.py
+
+Expression parser and evaluator for build-time conditions. Used by both trigger rules and conflict expressions to validate syntax at layer-load time and evaluate conditions against the resolved variable set at build time. Expressions use standard Python comparison syntax. See https://docs.python.org/3/reference/expressions.html#comparisons
+
 == site/validators.py
 
 Contains the validation rule parser/implementations referenced by Metadata.

--- a/site/conditions.py
+++ b/site/conditions.py
@@ -1,0 +1,179 @@
+"""
+Condition expression parsing and evaluation.
+
+Conditions appear in layer metadata to make behaviour depend on variable
+values at build time, eg in trigger rules and conflict mgmt, eg:
+
+    when=IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5']
+    when=IGconf_hardening_apparmor == 'y'
+    when=IGconf_device_user1pass != ''
+
+The expression syntax is standard Python comparison syntax, parsed using
+Python's own ast module. Operators and their semantics are precisely
+defined by the Python language specification:
+
+    https://docs.python.org/3/reference/expressions.html#comparisons
+
+Supported comparison operators:  ==  !=  in  not in
+Supported boolean operators:     and  or
+
+Variable names in expressions are resolved from a plain dict[str, str]
+passed in by the caller. The caller is responsible for building that dict
+(typically from resolved layer variables with os.environ overrides applied).
+"""
+
+import ast
+from typing import Dict, List, NamedTuple
+
+
+class SyntaxExample(NamedTuple):
+    operator: str   # operator or keyword, e.g. '==' or 'and'
+    example: str    # complete when= form ready for use in layer metadata
+
+
+# One entry per supported operator, and bare for documentation purposes.
+SYNTAX_EXAMPLES: List[SyntaxExample] = [
+    SyntaxExample("==",     "IGconf_device_class == 'pi5'"),
+    SyntaxExample("!=",     "IGconf_device_user1pass != ''"),
+    SyntaxExample("in",     "IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5']"),
+    SyntaxExample("not in", "IGconf_device_class not in ['zero2w']"),
+    SyntaxExample("and",    "IGconf_a == 'x' and IGconf_b == 'y'"),
+    SyntaxExample("or",     "IGconf_a == 'x' or IGconf_b == 'y'"),
+]
+
+
+def syntax_examples() -> List[SyntaxExample]:
+    """Return the list of supported condition syntax examples.
+    Intended for docgen / help text renderers.
+    """
+    return SYNTAX_EXAMPLES
+
+
+def validate(condition: str) -> None:
+    """
+    Parse and validate a condition expression string.
+    """
+    try:
+        tree = ast.parse(condition, mode='eval')
+    except SyntaxError as e:
+        raise ValueError(f"Invalid condition '{condition}': {e}") from e
+    if not isinstance(tree.body, (ast.Compare, ast.BoolOp)):
+        raise ValueError(
+            f"Invalid condition '{condition}': must be a comparison or boolean expression"
+            f" — e.g. IGconf_x == 'value' or IGconf_x in ['a', 'b']"
+        )
+    _check_node(tree.body, condition)
+
+
+def evaluate(condition: str, variables: Dict[str, str]) -> bool:
+    """
+    Evaluate a condition expression against a variable dict.
+    Parses the expression and walks the AST, resolving variable names against
+    the provided dict. Assumes validate() has already been called.
+    """
+    tree = ast.parse(condition, mode='eval')
+    return bool(_eval_node(tree.body, variables, condition))
+
+
+# -----------------------------------------------------------------------------
+# Internal helpers
+# -----------------------------------------------------------------------------
+# Both helpers walk the AST produced by ast.parse(). Only the node types that
+# correspond to the supported expression forms are handled, anything else
+# raises an error so it's easy to report what a condition can/cannot do.
+
+
+def _check_node(node, condition: str) -> None:
+    """
+    Recursively walk an AST node and raise ValueError for any node type that
+    is outside the supported subset.
+    """
+    if isinstance(node, ast.Compare):
+        # Chained comparisons (e.g. a < b < c) parse as a single Compare node
+        # with multiple ops. We do not support them - one comparison per expression.
+        if len(node.ops) != 1:
+            raise ValueError(
+                f"Chained comparisons are not supported in '{condition}'"
+            )
+        if not isinstance(node.ops[0], (ast.Eq, ast.NotEq, ast.In, ast.NotIn)):
+            raise ValueError(
+                f"Unsupported operator '{type(node.ops[0]).__name__}' in '{condition}'"
+                f" — supported operators are ==, !=, in, not in"
+            )
+        _check_node(node.left, condition)
+        _check_node(node.comparators[0], condition)
+
+    elif isinstance(node, ast.BoolOp):
+        # BoolOp covers 'and' and 'or'. Both are supported for compound conditions
+        # such as: IGconf_a == 'x' and IGconf_b == 'y'
+        for value in node.values:
+            _check_node(value, condition)
+
+    elif isinstance(node, ast.Name):
+        # A bare name is a variable reference, looked up in the variables dict
+        # at evaluation time. No validation of the name itself happens here -
+        # unknown names are caught by evaluate().
+        pass
+
+    elif isinstance(node, ast.Constant):
+        # Only string constants are permitted. An unquoted value like pi5 would
+        # be parsed as a Name node (variable lookup), not a Constant. If someone
+        # writes a numeric or boolean literal it is almost certainly a mistake,
+        # so reject it with a clear message.
+        if not isinstance(node.value, str):
+            raise ValueError(
+                f"Non-string constant {node.value!r} in '{condition}'"
+                f" — comparison values must be quoted strings, e.g. 'pi5'"
+            )
+
+    elif isinstance(node, (ast.List, ast.Tuple)):
+        # Lists and tuples are the right-hand side of 'in' / 'not in', e.g.
+        # IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5'].
+        # Each element must itself be a valid (typically Constant) node.
+        for elt in node.elts:
+            _check_node(elt, condition)
+
+    else:
+        raise ValueError(
+            f"Unsupported expression '{type(node).__name__}' in '{condition}'"
+        )
+
+
+def _eval_node(node, variables: Dict[str, str], condition: str):
+    """
+    Recursively evaluate an AST node and return a Python value.
+
+    Compare nodes return bool. Name and Constant nodes return str.
+    List and Tuple nodes return list[str] for use with 'in' / 'not in'.
+    """
+    if isinstance(node, ast.Compare):
+        left = _eval_node(node.left, variables, condition)
+        right = _eval_node(node.comparators[0], variables, condition)
+        op = node.ops[0]
+        if isinstance(op, ast.Eq):    return left == right
+        if isinstance(op, ast.NotEq): return left != right
+        if isinstance(op, ast.In):    return left in right
+        if isinstance(op, ast.NotIn): return left not in right
+
+    if isinstance(node, ast.BoolOp):
+        # Use all() / any() so that short-circuit eval is preserved
+        if isinstance(node.op, ast.And):
+            return all(_eval_node(v, variables, condition) for v in node.values)
+        return any(_eval_node(v, variables, condition) for v in node.values)
+
+    if isinstance(node, ast.Name):
+        if node.id not in variables:
+            raise ValueError(
+                f"Unknown variable '{node.id}' in condition '{condition}'"
+            )
+        return variables[node.id]
+
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_eval_node(e, variables, condition) for e in node.elts]
+
+    raise ValueError(
+        f"Unsupported node '{type(node).__name__}' in condition '{condition}'"
+    )

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -264,6 +264,31 @@ def _parse_set_action(args: List[str], var_name: str, line: str) -> Tuple[str, s
 ACTION_PARSERS["set"] = _parse_set_action
 
 
+def _split_condition_and_action(line: str, var_name: str) -> Tuple[str, str]:
+    """
+    Split a conditional trigger line 'when=<expr> ACTION ...' into
+    (condition_expr, 'ACTION ...').
+
+    Searches from the right so that an action keyword appearing inside a
+    list literal in the condition (e.g. IGconf_x in ['a set b']) is
+    skipped — the real action keyword is always the rightmost one.
+    """
+    after_when = line[len("when="):]
+    for kw in ACTION_PARSERS:
+        marker = f' {kw} '
+        if marker in after_when:
+            idx = after_when.rindex(marker)
+            condition = after_when[:idx].strip()
+            if not condition:
+                raise ValueError(
+                    f"Trigger rule '{line}' for '{var_name}' has empty condition after when="
+                )
+            return condition, after_when[idx + 1:].strip()
+    raise ValueError(
+        f"Trigger rule '{line}' for '{var_name}' is missing a recognised action keyword"
+    )
+
+
 @dataclass(frozen=True)
 class TriggerRule:
     """Represents a conditional trigger to perform an action."""
@@ -359,65 +384,16 @@ class EnvVariable:
         conflicts_raw = _get_metadata_value(conflicts_key, "")
         conflicts: List[str] = []
         if conflicts_raw and isinstance(conflicts_raw, str):
-            # Parse conflict expressions - only support "=" or "!=" as conditional operators
-            conflicts_raw_list: List[str] = []
+            import conditions as _cond
             for line in str(conflicts_raw).splitlines():
-                conflicts_raw_list.extend([c.strip() for c in line.split(",") if c.strip()])
-            for c in conflicts_raw_list:
-                precursor_value = None
-                if c.startswith("when="):
-                    parts = c.split(None, 1)
-                    if len(parts) < 2:
-                        raise ValueError(f"Invalid conflict expr '{c}' (missing condition after precursor)")
-                    precursor_value = parts[0][len("when="):].strip()
-                    if not precursor_value:
-                        raise ValueError(f"Invalid conflict expr '{c}' (missing precursor value)")
-                    c = parts[1].strip()
-                    if not c:
-                        raise ValueError(f"Invalid conflict expr '{c}' (invalid condition after precursor)")
-
-                operator = None
-                name_part = ""
-                value_part = ""
-                if "!=" in c:
-                    operator = "!="
-                    name_part, value_part = c.split("!=", 1)
-                elif "=" in c:
-                    operator = "="
-                    name_part, value_part = c.split("=", 1)
-                # Add other operators as needed
-
-                if operator:
-                    # Conditional conflict: "var=value" or "var!=value"
-                    name_part = name_part.strip()
-                    value_part = value_part.strip()
-                    if "=" in value_part or "!" in value_part:
-                        raise ValueError(f"Invalid conflict expr '{c}' (unsupported operator)")
-                    if not name_part or not value_part:
-                        raise ValueError(f"Invalid conflict expr '{c}' (missing name or value)")
-                    if name_part.startswith("IGconf_"):
-                        conflict_name = name_part
-                    else:
-                        conflict_name = f"IGconf_{prefix}_{name_part.lower()}" if prefix else name_part
-                    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", conflict_name):
-                        raise ValueError(f"Invalid conflict expr '{c}' (invalid variable name)")
-                    conflict_spec = f"{conflict_name}{operator}{value_part}"
-                else:
-                    # Unconditional conflict: just a variable name
-                    if "!" in c or "=" in c:
-                        raise ValueError(f"Invalid conflict expr '{c}' (unsupported operator)")
-                    if c.startswith("IGconf_"):
-                        conflict_spec = c
-                    else:
-                        conflict_name = f"IGconf_{prefix}_{c.lower()}" if prefix else c
-                        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", conflict_name):
-                            raise ValueError(f"Invalid conflict expr '{c}' (invalid variable name)")
-                        conflict_spec = conflict_name
-
-                if precursor_value is not None:
-                    conflicts.append(f"when={precursor_value} {conflict_spec}")
-                else:
-                    conflicts.append(conflict_spec)
+                expr = line.strip()
+                if not expr:
+                    continue
+                try:
+                    _cond.validate(expr)
+                except ValueError as e:
+                    raise ValueError(f"Invalid conflict expression for variable '{var_name}': {e}") from e
+                conflicts.append(expr)
 
         return cls(
             name=full_name,
@@ -455,29 +431,34 @@ class EnvVariable:
         """
         Parse trigger rules.
         Syntax (one rule per line):
-          - "when=VALUE set TARGET=VAL [policy=...]"  # conditional
-          - "set TARGET=VAL [policy=...]"             # unconditional
+          - "when=<python-expr> set TARGET=VAL [policy=...]"  # conditional
+          - "set TARGET=VAL [policy=...]"                     # unconditional
+
+        The when= expression is a standard Python comparison expression.
+        See: https://docs.python.org/3/reference/expressions.html#comparisons
+        Variable names must be fully qualified (e.g. IGconf_device_class).
+        Comparison values must be quoted strings.
         """
+        import conditions as _cond
+
         rules: List[TriggerRule] = []
         lines = [line.strip() for line in str(raw).splitlines() if line.strip()]
 
         for line in lines:
-            tokens = shlex.split(line)
+            condition: Optional[str] = None
+
+            if line.startswith("when="):
+                condition, action_line = _split_condition_and_action(line, var_name)
+                _cond.validate(condition)
+            else:
+                action_line = line
+
+            tokens = shlex.split(action_line)
             if not tokens:
                 continue
 
-            condition: Optional[str] = None
-            if tokens[0].startswith("when="):
-                condition = tokens[0][len("when="):].strip()
-                if not condition:
-                    raise ValueError(f"Trigger rule '{line}' for {var_name} is missing value in when=")
-                if len(tokens) < 2:
-                    raise ValueError(f"Trigger rule '{line}' for {var_name} is missing an action keyword")
-                action = tokens[1]
-                action_args = tokens[2:]
-            else:
-                action = tokens[0]
-                action_args = tokens[1:]
+            action = tokens[0]
+            action_args = tokens[1:]
 
             parser = ACTION_PARSERS.get(action)
             if not parser:
@@ -1016,17 +997,11 @@ class VariableResolver:
 
     def _collect_trigger_definitions(self, resolved: Dict[str, EnvVariable]) -> Dict[str, List[EnvVariable]]:
         """Build trigger-sourced definitions based on resolved values."""
-        import os
-
         trigger_defs: Dict[str, List[EnvVariable]] = {}
         for env_var in resolved.values():
-            # Trigger conditions evaluate against the effective runtime value.
-            effective_value = os.environ.get(env_var.name, env_var.value)
             for rule in getattr(env_var, "triggers", []) or []:
                 if rule.condition is not None and not self._trigger_condition_matches(
                     rule.condition,
-                    env_var.name,
-                    str(effective_value),
                     resolved,
                     env_var.source_layer,
                 ):
@@ -1062,61 +1037,35 @@ class VariableResolver:
     def _trigger_condition_matches(
         self,
         condition: str,
-        source_var_name: str,
-        source_effective_value: str,
         resolved: Dict[str, EnvVariable],
         source_layer: Optional[str] = None,
     ) -> bool:
         """
-        Evaluate trigger condition.
+        Evaluate a trigger condition expression against resolved variables.
 
-        Supported forms:
-        - same-variable value condition: "btrfs"
-        - same-variable wildcard: "*" (matches any non-empty value)
-        - cross-variable equality: "IGconf_device_storage_type=emmc"
-        - cross-variable inequality: "IGconf_device_storage_type!=emmc"
-        - cross-variable wildcard: "IGconf_device_storage_type=*" (matches any non-empty value)
+        Delegates to conditions.evaluate(). Builds the variable lookup dict
+        from resolved variables with os.environ overrides applied, so that
+        env-level overrides (e.g. IGconf_device_class=pi5 on the command line)
+        are honoured when evaluating trigger conditions.
+
+        See conditions.py for expression syntax.
         """
         import os
+        import conditions as _cond
 
-        def _is_set(v: str) -> bool:
-            """Return True if the value is meaningfully set (non-empty, non-None)."""
-            return v not in ("", "None")
+        variables = {
+            name: str(os.environ.get(name, var.value) or "")
+            for name, var in resolved.items()
+        }
+        for k, v in os.environ.items():
+            if k not in variables:
+                variables[k] = v
 
-        if "!=" in condition:
-            lhs, rhs = condition.split("!=", 1)
-            op = "!="
-        elif "=" in condition:
-            lhs, rhs = condition.split("=", 1)
-            op = "="
-        else:
-            if condition == "*":
-                return _is_set(source_effective_value)
-            return source_effective_value == condition
-
-        lhs = lhs.strip()
-        rhs = rhs.strip()
-        if not lhs:
-            return False
-
-        if lhs == source_var_name:
-            lhs_value = source_effective_value
-        elif lhs in os.environ:
-            lhs_value = str(os.environ.get(lhs, ""))
-        elif lhs in resolved:
-            raw = resolved[lhs].value
-            lhs_value = "" if raw is None else str(raw)
-        else:
-            layer_note = f" (layer: {source_layer})" if source_layer else ""
-            raise ValueError(
-                f"Unknown variable '{lhs}' referenced in trigger condition '{condition}'{layer_note}"
-            )
-
-        if op == "=":
-            if rhs == "*":
-                return _is_set(lhs_value)
-            return lhs_value == rhs
-        return lhs_value != rhs
+        layer_note = f" (layer: {source_layer})" if source_layer else ""
+        try:
+            return _cond.evaluate(condition, variables)
+        except ValueError as e:
+            raise ValueError(f"{e}{layer_note}") from e
 
     def _resolve_single_variable(self, var_name: str, definitions: List[EnvVariable]) -> Optional[EnvVariable]:
         """Resolve a single variable using policy rules."""

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -497,111 +497,41 @@ class Metadata:
 
         return results
 
-    @staticmethod
-    def _parse_conflict_spec(spec: str):
-        """Parse a conflict spec into (name, op, value, when_value). op is None for unconditional."""
-        if not spec:
-            return None, None, None, None
-        when_value = None
-        spec = spec.strip()
-        if spec.startswith("when="):
-            parts = spec.split(None, 1)
-            if len(parts) < 2:
-                return None, None, None, None
-            when_value = parts[0][len("when="):].strip()
-            if not when_value:
-                return None, None, None, None
-            spec = parts[1].strip()
-            if not spec:
-                return None, None, None, None
-
-        if "!=" in spec:
-            name, value = spec.split("!=", 1)
-            op = "!="
-        elif "=" in spec:
-            name, value = spec.split("=", 1)
-            op = "="
-        else:
-            # Unconditional conflict (just the variable name).
-            return spec, None, None, when_value
-        name = name.strip()
-        value = value.strip()
-        if not name or not value:
-            return None, None, None, None
-        return name, op, value, when_value
-
     def _validate_conflicts(self):
-        """Validate that conflicting variables are not both set (final resolved values)."""
-        results = {}
+        """Evaluate conflict expressions against resolved variables; report any that fire."""
+        import conditions as _cond
 
-        # Ensure we have resolved variables available for validation.
+        results = {}
         if self._resolved_vars is None:
             resolver = VariableResolver()
             variable_definitions = {name: [env_var] for name, env_var in self._container.variables.items()}
             self._resolved_vars = resolver.resolve(variable_definitions)
 
-        # Track unconditional pairs to avoid duplicate conditional reporting.
-        unconditional_pairs = set()
+        # Build variable dict; skip-policy vars use the env value only.
+        variables = {}
+        for name, var in self._resolved_vars.items():
+            if getattr(var, "set_policy", None) == "skip":
+                variables[name] = str(os.environ.get(name, ""))
+            else:
+                variables[name] = str(var.value or "")
+        for k, v in os.environ.items():
+            if k not in variables:
+                variables[k] = v
+
+        seen = set()
         for var_name, env_var in self._resolved_vars.items():
-            conflicts = getattr(env_var, "conflicts", None) or []
-            for other in conflicts:
-                conflict_var_name, op, _, when_value = self._parse_conflict_spec(other)
-                if not conflict_var_name or op is not None or when_value is not None:
+            for expr in (getattr(env_var, "conflicts", None) or []):
+                if expr in seen:
                     continue
-                pair = tuple(sorted([var_name, conflict_var_name]))
-                unconditional_pairs.add(pair)
-
-        # Track reported pairs (including conditional spec string) to dedupe.
-        seen_pairs = set()
-        for var_name, env_var in self._resolved_vars.items():
-            conflicts = getattr(env_var, "conflicts", None) or []
-            if not conflicts:
-                continue
-            for conflict in conflicts:
-                conflict_var_name, op, conflict_value, when_value = self._parse_conflict_spec(conflict)
-                if not conflict_var_name:
+                seen.add(expr)
+                try:
+                    fired = _cond.evaluate(expr, variables)
+                except ValueError:
                     continue
-                if op is not None:
-                    # If an unconditional conflict exists for the same pair, it wins.
-                    pair_base = tuple(sorted([var_name, conflict_var_name]))
-                    if pair_base in unconditional_pairs:
-                        continue
-
-                pair = tuple(sorted([var_name, conflict]))
-                if pair in seen_pairs:
-                    continue
-                seen_pairs.add(pair)
-
-                # Retrieve the conflicting var from the final resolved variable set
-                conflict_var = self._resolved_vars.get(conflict_var_name)
-                if not conflict_var:
-                    continue
-
-                # A unconditional conflict only applies if this variable and the conflicting
-                # variable are both set. For skip policy, only env counts as "set".
-                if getattr(env_var, "set_policy", None) == "skip":
-                    this_value = str(os.environ.get(var_name, ""))
-                else:
-                    this_value = str(env_var.value)
-                if when_value is not None and this_value != when_value:
-                    continue
-                if getattr(conflict_var, "set_policy", None) == "skip":
-                    conflict_target_value = str(os.environ.get(conflict_var_name, ""))
-                else:
-                    conflict_target_value = str(conflict_var.value)
-                if not this_value or not conflict_target_value:
-                    continue
-
-                # For conditional conflicts, the conflicting variable must match / not match
-                # the specified conflicting value for the conflict to apply.
-                if op == "=" and conflict_target_value != conflict_value:
-                    continue
-                if op == "!=" and conflict_target_value == conflict_value:
-                    continue
-
-                results[f"CONFLICT_{var_name}_{conflict}"] = self._result_builder.conflict(
-                    var_name, conflict_var_name, this_value, conflict_target_value
-                )
+                if fired:
+                    results[f"CONFLICT_{var_name}_{expr}"] = self._result_builder.conflict(
+                        var_name, expr, variables.get(var_name, ""), ""
+                    )
         return results
 
     def _validate_defined_variables(self):
@@ -892,6 +822,12 @@ class Metadata:
         # 4) Validation rule sanity checks (schema-only)
         results.update(self._lint_validation_rules(raw_meta))
 
+        # 5) Trigger rule syntax (condition expressions and action keywords)
+        results.update(self._lint_trigger_rules(raw_meta))
+
+        # 6) Conflict expression syntax
+        results.update(self._lint_conflict_rules(raw_meta))
+
         return results
 
     def _lint_validation_rules(self, raw_meta: dict) -> dict:
@@ -938,6 +874,57 @@ class Metadata:
         _check_rule_list(XEnv.var_requires_valid())
         _check_rule_list(XEnv.var_optional_valid())
 
+        return issues
+
+    def _lint_conflict_rules(self, raw_meta: dict) -> dict:
+        """Check conflict expression syntax at lint time."""
+        import conditions as _cond
+        issues = {}
+        for field_name, raw in raw_meta.items():
+            if not (field_name.startswith(XEnv.VAR_PREFIX) and field_name.endswith("-Conflicts")):
+                continue
+            rule_str = (raw or "").strip()
+            if not rule_str:
+                continue
+            var_name = field_name[len(XEnv.VAR_PREFIX):-len("-Conflicts")]
+            for line in rule_str.splitlines():
+                expr = line.strip()
+                if not expr:
+                    continue
+                try:
+                    _cond.validate(expr)
+                except ValueError as exc:
+                    issues[f"INVALID_CONFLICT_{var_name}"] = self._result_builder.build_result(
+                        status="invalid_conflict_rule",
+                        value=None,
+                        valid=False,
+                        required=False,
+                        rule=expr,
+                        message=f"{self.filepath}: Invalid conflict expression for {var_name}: {exc}",
+                    )
+        return issues
+
+    def _lint_trigger_rules(self, raw_meta: dict) -> dict:
+        """Check trigger rule syntax at lint time, before any environment is available."""
+        issues = {}
+        for field_name, raw in raw_meta.items():
+            if not (field_name.startswith(XEnv.VAR_PREFIX) and field_name.endswith("-Triggers")):
+                continue
+            rule_str = (raw or "").strip()
+            if not rule_str:
+                continue
+            var_name = field_name[len(XEnv.VAR_PREFIX):-len("-Triggers")]
+            try:
+                EnvVariable._parse_trigger_rules(rule_str, var_name)
+            except ValueError as exc:
+                issues[f"INVALID_TRIGGER_{var_name}"] = self._result_builder.build_result(
+                    status="invalid_trigger_rule",
+                    value=None,
+                    valid=False,
+                    required=False,
+                    rule=rule_str,
+                    message=f"{self.filepath}: Invalid specifier for variable {var_name}: {exc}",
+                )
         return issues
 
     def _collect_schema_errors(self):

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -32,7 +32,7 @@ def Pipeline_register_parser(subparsers, root=None):
     parser.add_argument("--layers", nargs="+", help="Layers to apply (names)")
     parser.add_argument("--path", "-p", default=default_paths, help=help_text)
     parser.add_argument("--env-out", required=True, help="Write fully resolved env (anchors expanded)")
-    parser.add_argument("--plan-out", help="Write layer build plan (name:static:resolved) to this file (host mode only)")
+    parser.add_argument("--plan-out", help="Write layer build plan to this file")
     parser.set_defaults(func=_pipeline_main)
 
 
@@ -151,9 +151,11 @@ def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) 
     try:
         with open(path, "w", encoding="utf-8") as handle:
             for layer in build_order:
+                info = manager.get_layer_info(layer) or {}
+                version = info.get("version", "")
                 static = manager.layer_source_files.get(layer, "")
                 resolved = manager.layer_files.get(layer, "")
-                handle.write(f'{layer}:{static}:{resolved}\n')
+                handle.write(f'{layer}:{version}:{static}:{resolved}\n')
         print(f"Layer plan written to: {path}")
     except Exception as exc:
         print(f"Error writing layer plan to {path}: {exc}")

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -269,40 +269,6 @@ def _validate_layers(manager: LayerManager, layer_names: List[str]) -> bool:
     return True
 
 
-def _parse_conflict_spec(spec: str):
-    """Parse a conflict spec into (name, op, value, when_value)."""
-    if not spec:
-        return None, None, None, None
-
-    when_value = None
-    spec = spec.strip()
-    if spec.startswith("when="):
-        parts = spec.split(None, 1)
-        if len(parts) < 2:
-            return None, None, None, None
-        when_value = parts[0][len("when="):].strip()
-        if not when_value:
-            return None, None, None, None
-        spec = parts[1].strip()
-        if not spec:
-            return None, None, None, None
-
-    if "!=" in spec:
-        name, value = spec.split("!=", 1)
-        op = "!="
-    elif "=" in spec:
-        name, value = spec.split("=", 1)
-        op = "="
-    else:
-        return spec, None, None, when_value
-
-    name = name.strip()
-    value = value.strip()
-    if not name or not value:
-        return None, None, None, None
-    return name, op, value, when_value
-
-
 def _is_var_effectively_set(env_var: EnvVariable, current: Optional[str]) -> bool:
     """Return True if variable should be considered set for conflict checks."""
     if getattr(env_var, "set_policy", None) == "skip":
@@ -387,59 +353,32 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
                 )
                 ok = False
 
-    # Validate conflicts against the selected winning definitions.
-    unconditional_pairs = set()
+    # Validate conflict expressions against resolved variable values.
+    import conditions as _cond
+
+    variables: Dict[str, str] = {}
+    for name, env_var in selected.items():
+        if getattr(env_var, "set_policy", None) == "skip":
+            variables[name] = str(os.environ.get(name, ""))
+        else:
+            variables[name] = _effective_var_value(env_var, os.environ.get(name))
+    for k, v in os.environ.items():
+        if k not in variables:
+            variables[k] = v
+
+    seen_exprs: set = set()
     for var_name, env_var in selected.items():
-        conflicts = getattr(env_var, "conflicts", None) or []
-        for other in conflicts:
-            conflict_var_name, op, _, when_value = _parse_conflict_spec(other)
-            if not conflict_var_name or op is not None or when_value is not None:
+        for expr in (getattr(env_var, "conflicts", None) or []):
+            if expr in seen_exprs:
                 continue
-            pair = tuple(sorted([var_name, conflict_var_name]))
-            unconditional_pairs.add(pair)
-
-    seen_pairs = set()
-    for var_name, env_var in selected.items():
-        conflicts = getattr(env_var, "conflicts", None) or []
-        if not conflicts:
-            continue
-
-        current = os.environ.get(var_name)
-        if not _is_var_effectively_set(env_var, current):
-            continue
-        this_value = _effective_var_value(env_var, current)
-
-        for conflict in conflicts:
-            conflict_var_name, op, conflict_value, when_value = _parse_conflict_spec(conflict)
-            if not conflict_var_name:
+            seen_exprs.add(expr)
+            try:
+                fired = _cond.evaluate(expr, variables)
+            except ValueError:
                 continue
-            conflict_var = selected.get(conflict_var_name)
-            if not conflict_var:
-                continue
-            if when_value is not None and this_value != when_value:
-                continue
-            if op is not None:
-                pair_base = tuple(sorted([var_name, conflict_var_name]))
-                if pair_base in unconditional_pairs:
-                    continue
-
-            pair = tuple(sorted([var_name, conflict]))
-            if pair in seen_pairs:
-                continue
-            seen_pairs.add(pair)
-
-            conflict_current = os.environ.get(conflict_var_name)
-            if not _is_var_effectively_set(conflict_var, conflict_current):
-                continue
-            conflict_target_value = _effective_var_value(conflict_var, conflict_current)
-
-            if op == "=" and conflict_target_value != conflict_value:
-                continue
-            if op == "!=" and conflict_target_value == conflict_value:
-                continue
-
-            log_error(f"[FAIL] Conflict: {var_name}={this_value} {conflict_var_name}={conflict_target_value}")
-            ok = False
+            if fired:
+                log_error(f"[FAIL] Conflict: {expr}")
+                ok = False
     return ok
 
 

--- a/test/layer/trigger-env-override.yaml
+++ b/test/layer/trigger-env-override.yaml
@@ -16,5 +16,5 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_trig_pmap=shouldfail policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_trig_rootfs_type == 'btrfs' set IGconf_trig_pmap=shouldfail policy=force
 # METAEND

--- a/test/layer/trigger-same-layer-force.yaml
+++ b/test/layer/trigger-same-layer-force.yaml
@@ -10,7 +10,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_trig2_pmap=crypt policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_trig2_rootfs_type == 'btrfs' set IGconf_trig2_pmap=crypt policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Desc: Provisioning map

--- a/test/meta/fixtures/trigger-cascade-cross-layer/device-cm4.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/device-cm4.yaml
@@ -8,7 +8,7 @@
 # X-Env-Var-variant: 8G
 # X-Env-Var-variant-Valid: none,lite,8G
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Triggers: when=lite set IGconf_cascade_storage_type=sd policy=lazy
+# X-Env-Var-variant-Triggers: when=IGconf_cascade_variant == 'lite' set IGconf_cascade_storage_type=sd policy=lazy
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Valid: sd,emmc
 # X-Env-Var-storage_type-Set: lazy

--- a/test/meta/fixtures/trigger-cascade-cross-layer/image-rota.yaml
+++ b/test/meta/fixtures/trigger-cascade-cross-layer/image-rota.yaml
@@ -8,5 +8,5 @@
 # X-Env-Var-ptable_protect: n
 # X-Env-Var-ptable_protect-Valid: bool
 # X-Env-Var-ptable_protect-Set: lazy
-# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type=emmc set IGconf_cascade_ptable_protect=y policy=lazy
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type == 'emmc' set IGconf_cascade_ptable_protect=y policy=lazy
 # METAEND

--- a/test/meta/invalid-conflicts-conditional-not-eq.yaml
+++ b/test/meta/invalid-conflicts-conditional-not-eq.yaml
@@ -5,7 +5,7 @@
 #
 # X-Env-Var-class: cm5
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class!=cm4
+# X-Env-Var-test-Conflicts: IGconf_cft_test != '' and IGconf_cft_class != 'cm4'
 # METAEND
 
 conflict_conditional:

--- a/test/meta/invalid-conflicts-conditional.yaml
+++ b/test/meta/invalid-conflicts-conditional.yaml
@@ -5,7 +5,7 @@
 #
 # X-Env-Var-class: cm4
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class=cm4
+# X-Env-Var-test-Conflicts: IGconf_cft_test != '' and IGconf_cft_class == 'cm4'
 # METAEND
 
 conflict_conditional:

--- a/test/meta/invalid-conflicts-malformed.yaml
+++ b/test/meta/invalid-conflicts-malformed.yaml
@@ -1,11 +1,11 @@
 # METABEGIN
 # X-Env-Layer-Name: test-conflict-malformed
-# X-Env-Layer-Desc: Malformed conflict specs should fail to parse
+# X-Env-Layer-Desc: Malformed conflict expression should fail to parse
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-class: cm4
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class!=
+# X-Env-Var-test-Conflicts: IGconf_cft_class !=
 # METAEND
 
 conflict_conditional:

--- a/test/meta/invalid-conflicts-operator.yaml
+++ b/test/meta/invalid-conflicts-operator.yaml
@@ -1,11 +1,11 @@
 # METABEGIN
 # X-Env-Layer-Name: test-conflict-operator
-# X-Env-Layer-Desc: Unsupported operator should fail to parse
+# X-Env-Layer-Desc: Unsupported comparison operator should fail to parse
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-class: cm4
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class==cm4
+# X-Env-Var-test-Conflicts: IGconf_cft_class > 'cm4'
 # METAEND
 
 conflict_conditional:

--- a/test/meta/invalid-conflicts-skip.yaml
+++ b/test/meta/invalid-conflicts-skip.yaml
@@ -5,11 +5,11 @@
 #
 # X-Env-Var-a: 1
 # X-Env-Var-a-Set: n
-# X-Env-Var-a-Conflicts: b
+# X-Env-Var-a-Conflicts: IGconf_cft_a != '' and IGconf_cft_b != ''
 #
 # X-Env-Var-b: 2
 # X-Env-Var-b-Set: n
-# X-Env-Var-b-Conflicts: a
+# X-Env-Var-b-Conflicts: IGconf_cft_b != '' and IGconf_cft_a != ''
 # METAEND
 
 conflict_skip:

--- a/test/meta/invalid-conflicts-when-missing-conflict.yaml
+++ b/test/meta/invalid-conflicts-when-missing-conflict.yaml
@@ -1,10 +1,10 @@
 # METABEGIN
 # X-Env-Layer-Name: test-conflict-when-missing-conflict
-# X-Env-Layer-Desc: when= missing conflict should fail parsing
+# X-Env-Layer-Desc: Non-string constant in conflict expression should fail to parse
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: zstd
-# X-Env-Var-compression-Conflicts: when=zstd
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 1
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/invalid-conflicts-when-missing-value.yaml
+++ b/test/meta/invalid-conflicts-when-missing-value.yaml
@@ -1,10 +1,10 @@
 # METABEGIN
 # X-Env-Layer-Name: test-conflict-when-missing-value
-# X-Env-Layer-Desc: when= missing value should fail parsing
+# X-Env-Layer-Desc: Incomplete conflict expression should fail to parse
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: zstd
-# X-Env-Var-compression-Conflicts: when= rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression ==
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/invalid-conflicts-when-multiline-missing-conflict.yaml
+++ b/test/meta/invalid-conflicts-when-multiline-missing-conflict.yaml
@@ -1,11 +1,11 @@
 # METABEGIN
 # X-Env-Layer-Name: test-conflict-when-multiline-missing-conflict
-# X-Env-Layer-Desc: when= on its own line should fail parsing
+# X-Env-Layer-Desc: Invalid operator in multiline conflict expression should fail to parse
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: zstd
-# X-Env-Var-compression-Conflicts: when=zstd
-#  rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
+#  IGconf_cft_compression > 'lzma'
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/invalid-conflicts-when.yaml
+++ b/test/meta/invalid-conflicts-when.yaml
@@ -4,7 +4,7 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: zstd
-# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/invalid-conflicts.yaml
+++ b/test/meta/invalid-conflicts.yaml
@@ -4,10 +4,10 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-a: 1
-# X-Env-Var-a-Conflicts: b
+# X-Env-Var-a-Conflicts: IGconf_cft_a != '' and IGconf_cft_b != ''
 #
 # X-Env-Var-b: 2
-# X-Env-Var-b-Conflicts: a
+# X-Env-Var-b-Conflicts: IGconf_cft_b != '' and IGconf_cft_a != ''
 # METAEND
 
 conflict:

--- a/test/meta/invalid-trigger-env-override.yaml
+++ b/test/meta/invalid-trigger-env-override.yaml
@@ -16,7 +16,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=invalid policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == 'btrfs' set IGconf_image_pmap=invalid policy=force
 # METAEND
 
 trigger_invalid_env_override:

--- a/test/meta/invalid-trigger-validation-force.yaml
+++ b/test/meta/invalid-trigger-validation-force.yaml
@@ -18,7 +18,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=invalid policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == 'btrfs' set IGconf_image_pmap=invalid policy=force
 #
 # X-Env-Var-boot_part_size: 100%
 # X-Env-Var-boot_part_size-Desc: Boot partition size

--- a/test/meta/invalid-trigger-validation.yaml
+++ b/test/meta/invalid-trigger-validation.yaml
@@ -10,7 +10,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: ext4,btrfs
 # X-Env-Var-rootfs_type-Set: y
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IGconf_image_pmap=overridden policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_image_rootfs_type == 'btrfs' set IGconf_image_pmap=overridden policy=force
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Desc: Provisioning map identifier for this image layout

--- a/test/meta/invalid-triggers-cross-var-missing-var.yaml
+++ b/test/meta/invalid-triggers-cross-var-missing-var.yaml
@@ -9,7 +9,7 @@
 # X-Env-Var-switch-Desc: Switch value
 # X-Env-Var-switch-Valid: on,off
 # X-Env-Var-switch-Set: y
-# X-Env-Var-switch-Triggers: when=IGconf_does_not_exist=on set IG_TRIG_SHOULD_NOT_EXIST=1 policy=force
+# X-Env-Var-switch-Triggers: when=IGconf_does_not_exist == 'on' set IG_TRIG_SHOULD_NOT_EXIST=1 policy=force
 # METAEND
 
 triggers:

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -180,27 +180,27 @@ run_test "valid-conflicts-conditional-not-eq" \
 run_test "valid-conflicts-when" \
     "ig metadata --validate ${META}/valid-conflicts-when.yaml" \
     0 \
-    "when= conflicts should pass when condition does not match"
+    "Conflicts should pass when condition does not match"
 
 run_test "valid-conflicts-when-multiple" \
     "ig metadata --validate ${META}/valid-conflicts-when-multiple.yaml" \
     0 \
-    "when= conflicts should coexist with other conflicts"
+    "Conflicts should support multiple expressions per variable"
 
 run_test "valid-conflicts-when-whitespace" \
     "ig metadata --validate ${META}/valid-conflicts-when-whitespace.yaml" \
     0 \
-    "when= conflicts should tolerate extra whitespace"
+    "Conflict expressions should tolerate extra whitespace"
 
 run_test "valid-conflicts-when-igconf" \
     "ig metadata --validate ${META}/valid-conflicts-when-igconf.yaml" \
     0 \
-    "when= conflicts should accept IGconf_ targets"
+    "Conflict expressions should accept IGconf_ variable names"
 
 run_test "valid-conflicts-when-multiline" \
     "ig metadata --validate ${META}/valid-conflicts-when-multiline.yaml" \
     0 \
-    "when= conflicts should support multi-line specs"
+    "Conflicts should support multi-line expressions"
 
 run_test "valid-all-types-set" \
     "ig metadata --parse ${META}/valid-all-types.yaml" \
@@ -242,7 +242,7 @@ run_test "triggers-set-skip-env-override" \
 run_test "triggers-set-cross-var-when" \
     'cleanup_env; TMP_OUT=$(mktemp); IGconf_trigx_mode=fast ig metadata --parse ${META}/valid-triggers-cross-var-when.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_X=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
     0 \
-    "Trigger rules should support when=VAR=VALUE cross-variable conditions"
+    "Trigger rules should support when=VAR == 'VALUE' cross-variable conditions"
 
 run_test "triggers-fixpoint-cascade" \
     'cleanup_env; TMP_OUT=$(mktemp); IGconf_cascade_variant=lite ig metadata --parse ${META}/valid-triggers-fixpoint-cascade.yaml --write-out "$TMP_OUT" && grep "^IGconf_cascade_storage_type=\"sd\"$" "$TMP_OUT" && grep "^IGconf_cascade_ptable_protect=\"n\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
@@ -272,12 +272,12 @@ run_test "triggers-quoted-ext4-not-set" \
 run_test "triggers-wildcard-fires-when-set" \
     'cleanup_env; TMP_OUT=$(mktemp); IGconf_trigw_source=hello ig metadata --parse ${META}/valid-triggers-wildcard.yaml --write-out "$TMP_OUT" && grep "^IG_TRIG_WILDCARD_SAME=\"1\"$" "$TMP_OUT" && grep "^IG_TRIG_WILDCARD_CROSS=\"1\"$" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
     0 \
-    "Wildcard trigger (when=*) should fire when variable is set to a non-empty value"
+    "Trigger should fire when variable is set to a non-empty value"
 
 run_test "triggers-wildcard-silent-when-unset" \
     'cleanup_env; TMP_OUT=$(mktemp); ig metadata --parse ${META}/valid-triggers-wildcard.yaml --write-out "$TMP_OUT" && ! grep "^IG_TRIG_WILDCARD_SAME=" "$TMP_OUT" && ! grep "^IG_TRIG_WILDCARD_CROSS=" "$TMP_OUT"; status=$?; rm -f "$TMP_OUT"; exit $status' \
     0 \
-    "Wildcard trigger (when=*) should not fire when variable is unset"
+    "Trigger should not fire when variable is unset"
 
 # ---------------------------------------------------------------------------
 print_header "INVALID METADATA TESTS"
@@ -331,32 +331,32 @@ run_test "invalid-conflicts-conditional-not-eq" \
 run_test "invalid-conflicts-when" \
     "ig metadata --validate ${META}/invalid-conflicts-when.yaml" \
     1 \
-    "when= conflicts should fail when condition matches"
+    "Conflicts should fail when condition matches"
 
 run_test "invalid-conflicts-when-missing-value" \
     "ig metadata --parse ${META}/invalid-conflicts-when-missing-value.yaml" \
     1 \
-    "when= conflicts should fail when value is missing"
+    "Incomplete conflict expression should fail to parse"
 
 run_test "invalid-conflicts-when-missing-conflict" \
     "ig metadata --parse ${META}/invalid-conflicts-when-missing-conflict.yaml" \
     1 \
-    "when= conflicts should fail when conflict is missing"
+    "Non-string constant in conflict expression should fail to parse"
 
 run_test "invalid-conflicts-when-multiline-missing-conflict" \
     "ig metadata --parse ${META}/invalid-conflicts-when-multiline-missing-conflict.yaml" \
     1 \
-    "when= conflicts should fail when split across lines"
+    "Invalid operator in multiline conflict expression should fail to parse"
 
 run_test "invalid-conflicts-malformed" \
     "ig metadata --parse ${META}/invalid-conflicts-malformed.yaml" \
     1 \
-    "Malformed conflict specifiers should fail to parse"
+    "Malformed conflict expression should fail to parse"
 
 run_test "invalid-conflicts-operator" \
     "ig metadata --parse ${META}/invalid-conflicts-operator.yaml" \
     1 \
-    "Unsupported conflict operators should fail to parse"
+    "Unsupported comparison operator in conflict expression should fail to parse"
 
 run_test "invalid-conflicts-skip" \
     "ig metadata --validate ${META}/invalid-conflicts-skip.yaml" \
@@ -552,7 +552,7 @@ EOF
 # X-Env-Var-variant: 8G
 # X-Env-Var-variant-Valid: 8G,16G,32G,lite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Conflicts: when=lite storage_type=emmc
+# X-Env-Var-variant-Conflicts: IGconf_cflt_variant == 'lite' and IGconf_cflt_storage_type == 'emmc'
 # METAEND
 EOF
      make_pipeline_env "$TMP_ENV" "IGconf_cflt_variant=lite" "IGconf_cflt_storage_type=emmc" && \

--- a/test/meta/valid-conflicts-conditional-not-eq.yaml
+++ b/test/meta/valid-conflicts-conditional-not-eq.yaml
@@ -5,7 +5,7 @@
 #
 # X-Env-Var-class: cm4
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class!=cm4
+# X-Env-Var-test-Conflicts: IGconf_cft_test != '' and IGconf_cft_class != 'cm4'
 # METAEND
 
 conflict_conditional:

--- a/test/meta/valid-conflicts-conditional.yaml
+++ b/test/meta/valid-conflicts-conditional.yaml
@@ -5,7 +5,7 @@
 #
 # X-Env-Var-class: cm5
 # X-Env-Var-test: foo
-# X-Env-Var-test-Conflicts: class=cm4
+# X-Env-Var-test-Conflicts: IGconf_cft_test != '' and IGconf_cft_class == 'cm4'
 # METAEND
 
 conflict_conditional:

--- a/test/meta/valid-conflicts-when-igconf.yaml
+++ b/test/meta/valid-conflicts-when-igconf.yaml
@@ -4,7 +4,7 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Conflicts: when=zstd IGconf_cft_rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
 #
 # X-Env-Var-rootfs_type: btrfs
 # METAEND

--- a/test/meta/valid-conflicts-when-multiline.yaml
+++ b/test/meta/valid-conflicts-when-multiline.yaml
@@ -4,8 +4,8 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4,
-#  when=lzma rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
+#  IGconf_cft_compression == 'lzma' and IGconf_cft_rootfs_type == 'ext4'
 #
 # X-Env-Var-rootfs_type: btrfs
 # METAEND

--- a/test/meta/valid-conflicts-when-multiple.yaml
+++ b/test/meta/valid-conflicts-when-multiple.yaml
@@ -4,7 +4,8 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4,rootfs_type!=btrfs
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
+#  IGconf_cft_rootfs_type != 'btrfs'
 #
 # X-Env-Var-rootfs_type: btrfs
 # METAEND

--- a/test/meta/valid-conflicts-when-whitespace.yaml
+++ b/test/meta/valid-conflicts-when-whitespace.yaml
@@ -4,7 +4,7 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Conflicts: when=zstd    rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/valid-conflicts-when.yaml
+++ b/test/meta/valid-conflicts-when.yaml
@@ -4,7 +4,7 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-compression: none
-# X-Env-Var-compression-Conflicts: when=zstd rootfs_type=ext4
+# X-Env-Var-compression-Conflicts: IGconf_cft_compression == 'zstd' and IGconf_cft_rootfs_type == 'ext4'
 #
 # X-Env-Var-rootfs_type: ext4
 # METAEND

--- a/test/meta/valid-conflicts.yaml
+++ b/test/meta/valid-conflicts.yaml
@@ -4,10 +4,10 @@
 # X-Env-VarPrefix: cft
 #
 # X-Env-Var-a: 1
-# X-Env-Var-a-Conflicts: b
+# X-Env-Var-a-Conflicts: IGconf_cft_a != '' and IGconf_cft_b != ''
 #
 # X-Env-Var-b:
-# X-Env-Var-b-Conflicts: a
+# X-Env-Var-b-Conflicts: IGconf_cft_b != '' and IGconf_cft_a != ''
 # METAEND
 
 conflict:

--- a/test/meta/valid-resolved-validator-consumer.yaml
+++ b/test/meta/valid-resolved-validator-consumer.yaml
@@ -12,9 +12,9 @@
 # X-Env-Var-storage_type-Valid: sd,nvme,emmc8G,emmc16G,emmc32G
 # X-Env-Var-storage_type-Set: lazy
 # X-Env-Var-storage_type-Triggers:
-#  when=emmc8G  set IGconf_image_size=8G  policy=force
-#  when=emmc16G set IGconf_image_size=16G policy=force
-#  when=emmc32G set IGconf_image_size=32G policy=force
+#  when=IGconf_device_storage_type == 'emmc8G'  set IGconf_image_size=8G  policy=force
+#  when=IGconf_device_storage_type == 'emmc16G' set IGconf_image_size=16G policy=force
+#  when=IGconf_device_storage_type == 'emmc32G' set IGconf_image_size=32G policy=force
 # METAEND
 
 storage:

--- a/test/meta/valid-triggers-cross-var-when.yaml
+++ b/test/meta/valid-triggers-cross-var-when.yaml
@@ -14,7 +14,7 @@
 # X-Env-Var-switch-Desc: Switch value
 # X-Env-Var-switch-Valid: on,off
 # X-Env-Var-switch-Set: y
-# X-Env-Var-switch-Triggers: when=IGconf_trigx_mode=fast set IG_TRIG_X=1 policy=force
+# X-Env-Var-switch-Triggers: when=IGconf_trigx_mode == 'fast' set IG_TRIG_X=1 policy=force
 # METAEND
 
 triggers:

--- a/test/meta/valid-triggers-fixpoint-cascade.yaml
+++ b/test/meta/valid-triggers-fixpoint-cascade.yaml
@@ -9,7 +9,7 @@
 # X-Env-Var-variant-Desc: Device variant
 # X-Env-Var-variant-Valid: normal,lite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Triggers: when=lite set IGconf_cascade_storage_type=sd policy=lazy
+# X-Env-Var-variant-Triggers: when=IGconf_cascade_variant == 'lite' set IGconf_cascade_storage_type=sd policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage type
@@ -20,7 +20,7 @@
 # X-Env-Var-ptable_protect-Desc: Partition table protection
 # X-Env-Var-ptable_protect-Valid: bool
 # X-Env-Var-ptable_protect-Set: lazy
-# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type=emmc set IGconf_cascade_ptable_protect=y policy=lazy
+# X-Env-Var-ptable_protect-Triggers: when=IGconf_cascade_storage_type == 'emmc' set IGconf_cascade_ptable_protect=y policy=lazy
 # METAEND
 ---
 trigger_fixpoint:

--- a/test/meta/valid-triggers-quoted-values.yaml
+++ b/test/meta/valid-triggers-quoted-values.yaml
@@ -10,13 +10,13 @@
 # X-Env-Var-fstype-Valid: ext4,erofs
 # X-Env-Var-fstype-Set: y
 # X-Env-Var-fstype-Triggers:
-#  when=erofs set IG_TRIG_EROFS_ARGS="-b 4096 -z zstd,3" policy=force
-#  when=ext4 set IG_TRIG_EXT4_ARGS="-O has_journal,extent" policy=force
+#  when=IGconf_trigq_fstype == 'erofs' set IG_TRIG_EROFS_ARGS="-b 4096 -z zstd,3" policy=force
+#  when=IGconf_trigq_fstype == 'ext4' set IG_TRIG_EXT4_ARGS="-O has_journal,extent" policy=force
 #
 # X-Env-Var-mode: active
 # X-Env-Var-mode-Desc: Single-quoted trigger value
 # X-Env-Var-mode-Set: y
-# X-Env-Var-mode-Triggers: when=active set IG_TRIG_SINGLE='-v --force' policy=force
+# X-Env-Var-mode-Triggers: when=IGconf_trigq_mode == 'active' set IG_TRIG_SINGLE='-v --force' policy=force
 # METAEND
 
 triggers_quoted:

--- a/test/meta/valid-triggers-skip-env-override.yaml
+++ b/test/meta/valid-triggers-skip-env-override.yaml
@@ -10,7 +10,7 @@
 # X-Env-Var-rootfs_type-Required: n
 # X-Env-Var-rootfs_type-Valid: none,btrfs
 # X-Env-Var-rootfs_type-Set: n
-# X-Env-Var-rootfs_type-Triggers: when=btrfs set IG_TRIG_SKIP=1 policy=force
+# X-Env-Var-rootfs_type-Triggers: when=IGconf_trigskip_rootfs_type == 'btrfs' set IG_TRIG_SKIP=1 policy=force
 # METAEND
 
 triggers:

--- a/test/meta/valid-triggers-wildcard.yaml
+++ b/test/meta/valid-triggers-wildcard.yaml
@@ -11,6 +11,6 @@
 # X-Env-Var-source-Required: n
 # X-Env-Var-source-Set: n
 # X-Env-Var-source-Triggers:
-#  when=* set IG_TRIG_WILDCARD_SAME=1 policy=force
-#  when=IGconf_trigw_source=* set IG_TRIG_WILDCARD_CROSS=1 policy=force
+#  when=IGconf_trigw_source != '' set IG_TRIG_WILDCARD_SAME=1 policy=force
+#  when=IGconf_trigw_source != '' set IG_TRIG_WILDCARD_CROSS=1 policy=force
 # METAEND

--- a/test/meta/valid-triggers.yaml
+++ b/test/meta/valid-triggers.yaml
@@ -8,9 +8,9 @@
 # X-Env-Var-mode: fast
 # X-Env-Var-mode-Desc: Execution mode
 # X-Env-Var-mode-Valid: fast,slow
-# X-Env-Var-mode-Triggers: when=fast set IG_TRIG_FAST=1 policy=force
-#  when=fast set IG_TRIG_FAST2=1
-#  when=fast set IG_TRIG_ANY=1 policy=lazy
+# X-Env-Var-mode-Triggers: when=IGconf_trig_mode == 'fast' set IG_TRIG_FAST=1 policy=force
+#  when=IGconf_trig_mode == 'fast' set IG_TRIG_FAST2=1
+#  when=IGconf_trig_mode == 'fast' set IG_TRIG_ANY=1 policy=lazy
 #
 # X-Env-Var-extra: on
 # X-Env-Var-extra-Desc: Another variable to prove unconditional triggers


### PR DESCRIPTION
Replace the old custom conditional expressions used in `X-Env-Var-*-Triggers` and `X-Env-Var-*-Conflicts` with standard [Python expression syntax](https://docs.python.org/3/reference/expressions.html#comparisons) parsed via [AST](https://docs.python.org/3/library/ast.html). Moving this to a new dedicated module (`site/conditions.py`) means methods can be scaled and used in future metadata enhancements. Parsing like this reduces maintenance, bugs, code size and complication, and sticks to standard industry syntax widely understood and adopted outside of rpi-image-gen.

Improve visibility and scaling of layer version support by not only reporting the layer and its version when assembled into the bdebstrap args, but also by propagating the version down to `bin/runner`. This allows it to be used when processing layer hooks and overlays etc, therefore enabling those downstream operations to support versioned actions.