### PR TITLE
connectivity: device wlan support and slot-shared OTA app infrastructure

### DIFF
--- a/docs/layer/bookworm-minbase.html
+++ b/docs/layer/bookworm-minbase.html
@@ -139,6 +139,7 @@
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             <a href="fake-hwclock.html" class="dep-badge">fake-hwclock</a>
             <a href="openssh-server.html" class="dep-badge">openssh-server</a>
+            <a href="systemd-timesyncd.html" class="dep-badge">systemd-timesyncd</a>
         </div>
     </div>
 

--- a/docs/layer/chrony.html
+++ b/docs/layer/chrony.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>chrony - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,16 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
+        <h1>chrony</h1>
         <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <span class="badge">v1.0.0</span>
+        <p>Chrony NTP client and server
+ https://chrony-project.org</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <p><strong>Provides:</strong> time-daemon</p>
+        <p><strong>Requires Provider:</strong> systemd</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,13 +138,13 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>chrony</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>net-misc/chrony-systemd.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/image-rota.html
+++ b/docs/layer/image-rota.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-rota</h1>
         <span class="badge">image</span>
-        <span class="badge">v5.4.0</span>
+        <span class="badge">v5.5.0</span>
         <p>Immutable GPT A/B layout for rotational OTA updates,
  boot/system redundancy, and a shared persistent data partition.</p>
     </div>
@@ -193,6 +193,12 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/log/journal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Single log directory used by both slots</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;slot-shared paths&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/persistent/shared/&lt;path&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bind</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Application data shared across slots (layer-declared, see <a href="#slot-shared">Slot-shared application data</a>)</p></td>
 </tr>
 </tbody>
 </table>
@@ -286,6 +292,78 @@
 </td>
 </tr>
 </table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="slot-shared">Slot-shared application data</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Any layer can declare filesystem paths whose application data should be shared across slots. At boot, each declared path is bind-mounted from a common location on the persistent partition so the same data is visible regardless of which slot is active.</p>
+</div>
+<div class="sect2">
+<h3 id="_how_it_works">How it works</h3>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p><code>slot-shared-generator</code> runs at early boot, reads every <code>/etc/rpi-image-gen/slot-shared.d/*.conf</code> file and emits a <code>.mount</code> systemd unit for each declared path, mounting <code>/persistent/shared/&lt;path&gt;</code> over <code>&lt;path&gt;</code> as a bind mount.</p>
+</li>
+<li>
+<p><code>persistent-shared-init.service</code> runs before the bind mounts activate. It creates any missing <code>/persistent/shared/&lt;path&gt;</code> directories on the persistent partition, handling first boot and disaster-recovery scenarios where the partition has been re-initialised.</p>
+</li>
+<li>
+<p>Bind mounts are guarded by <code>ConditionPathIsDirectory</code> on the source. If the directory is absent the mount is skipped and the service falls back to its local path - safe degradation with no boot failure.</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_declaring_a_shared_path">Declaring a shared path</h3>
+<div class="paragraph">
+<p>Drop a <code>.conf</code> file into <code>/etc/rpi-image-gen/slot-shared.d/</code>, eg via the layer&#8217;s rootfs overlay or script:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>Version=1
+Path=/var/lib/myapp
+Path=/etc/myapp/state</code></pre>
+</div>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>Version=1</code></dt>
+<dd>
+<p>Required. A generator that does not recognise the version skips the file with a warning rather than misprocessing it.</p>
+</dd>
+<dt class="hdlist1"><code>Path=</code></dt>
+<dd>
+<p>One or more absolute paths to share. Multiple <code>Path=</code> entries are supported in a single file. A missing leading <code>/</code> is corrected automatically. Only directory paths are supported.</p>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>Unknown keys are silently ignored, providing forward compatibility within version 1.
+A version increment signals a breaking change.
+The files are inert in non-AB configurations.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_persistent_partition_layout">Persistent partition layout</h3>
+<div class="paragraph">
+<p>Shared data is stored under <code>/persistent/shared/</code>, mirroring the full path hierarchy:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>/persistent/
+└── shared/
+    └── var/
+        └── lib/
+            └── myapp/    &lt;-- bind-mounted over /var/lib/myapp</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Because the immutable root retains a copy of each declared path, files baked into the image are pushed into the shared location by <code>rpi-persistent-shared-init</code>, before the bind mounts activate. Files are only pushed if missing from or different to the destination. This means an OTA update can deliver new or updated shared application data simply by including it in the rootfs - no separate data partition update is required.</p>
+</div>
 </div>
 </div>
 </div>
@@ -508,6 +586,7 @@
             <li><code>dosfstools</code></li>
             <li><code>e2fsprogs</code></li>
             <li><code>initramfs-tools</code></li>
+            <li><code>rsync</code></li>
         </ul>
     </div>
 

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -1136,6 +1136,27 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
+    <h3>Connectivity</h3>
+    <div class="layer-list">
+        
+        <div class="layer-item">
+            <a href="iwd.html">iwd</a><span class="layer-desc">- iNet wireless daemon for wifi management</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="wireless-debug.html">wireless-debug</a><span class="layer-desc">- Wireless diagnostic tools</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="wireless-regulatory.html">wireless-regulatory</a><span class="layer-desc">- Wireless regulatory database</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="wireless-utils.html">wireless-utils</a><span class="layer-desc">- Production wireless utilities</span>
+        </div>
+        
+    </div>
+    
     <h3>Container</h3>
     <div class="layer-list">
         
@@ -1303,6 +1324,11 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
+            <a href="chrony.html">chrony</a><span class="layer-desc">- Chrony NTP client and server
+ https://chrony-project.org</span>
+        </div>
+        
+        <div class="layer-item">
             <a href="fake-hwclock.html">fake-hwclock</a><span class="layer-desc">- Persistent time management for non-RTC systems.</span>
         </div>
         
@@ -1337,12 +1363,20 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
-            <a href="systemd-min.html">systemd-min</a><span class="layer-desc">- Core systemd components for init, SysV compatibility
- and timesyncd, without networkd and resolved services.</span>
+            <a href="systemd-min.html">systemd-min</a><span class="layer-desc">- Core systemd components for init and SysV compatibility,
+ without additional services</span>
         </div>
         
         <div class="layer-item">
             <a href="systemd-net-min.html">systemd-net-min</a><span class="layer-desc">- Systemd networking via networkd and resolved services</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="systemd-resolved.html">systemd-resolved</a><span class="layer-desc">- systemd's built-in DNS client</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="systemd-timesyncd.html">systemd-timesyncd</a><span class="layer-desc">- systemd's built-in NTP client</span>
         </div>
         
     </div>

--- a/docs/layer/iwd.html
+++ b/docs/layer/iwd.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>iwd - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,45 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
-        <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <h1>iwd</h1>
+        <span class="badge">connectivity</span>
+        <span class="badge">v1.0.1</span>
+        <p>iNet wireless daemon for wifi management</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <p><strong>Provides:</strong> wifi-supplicant</p>
+        <p><strong>Requires Provider:</strong> wireless-regdb, systemd, network-activator</p>
+    </div>
+    <div class="section">
+        <h2>Configuration Variables</h2>
+        <p><strong>Declares</strong> (prefix: <code>iwd</code>):</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>Variable</th>
+                    <th>Description</th>
+                    <th>Default</th>
+                    <th>Validation</th>
+                    <th>Policy</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>IGconf_iwd_profile</code></td>
+                    <td>Path to an iwd network profile file to bake
+ into the build. The file is installed into /var/lib/iwd/ preserving its
+ filename. See iwd.network(5)</td>
+                    <td>
+                           <code>&lt;empty&gt;</code>
+                    </td>
+                    <td>String value (may be empty)</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,14 +167,15 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>iwd</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>net-wireless/iwd-systemd.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
+        <p><strong>Overlay:</strong> base</p>
     </div>
 </body>
 </html>

--- a/docs/layer/rpi-device-base.html
+++ b/docs/layer/rpi-device-base.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-device-base</h1>
         <span class="badge">device</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v2.0.0</span>
         <p>Raspberry Pi device base layer and defaults</p>
     </div>
     <div class="section">
@@ -146,7 +146,7 @@
             
         </div>
         <p><strong>Provides:</strong> device</p>
-        <p><strong>Requires Provider:</strong> rpi-device</p>
+        <p><strong>Requires Provider:</strong> rpi-device, systemd, network-activator</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>

--- a/docs/layer/rpi-device-secpolicy.html
+++ b/docs/layer/rpi-device-secpolicy.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-device-secpolicy</h1>
         <span class="badge">security</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.0.1</span>
         <p>Raspberry Pi device family security policy baseline</p>
     </div>
     <div class="section">
@@ -134,7 +134,7 @@
             <a href="rpi-device-base.html" class="dep-badge">rpi-device-base</a>
             
         </div>
-        <p><strong>Requires Provider:</strong> rpi-device, image, systemd-sysv</p>
+        <p><strong>Requires Provider:</strong> rpi-device, image, systemd</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>

--- a/docs/layer/systemd-min.html
+++ b/docs/layer/systemd-min.html
@@ -123,9 +123,9 @@
     <div class="header">
         <h1>systemd-min</h1>
         <span class="badge">general</span>
-        <span class="badge">v1.1.1</span>
-        <p>Core systemd components for init, SysV compatibility
- and timesyncd, without networkd and resolved services.</p>
+        <span class="badge">v2.0.0</span>
+        <p>Core systemd components for init and SysV compatibility,
+ without additional services</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
@@ -140,8 +140,12 @@
             
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             
+            <a href="systemd-resolved.html" class="dep-badge">systemd-resolved</a>
+            
+            <a href="systemd-timesyncd.html" class="dep-badge">systemd-timesyncd</a>
+            
         </div>
-        <p><strong>Provides:</strong> systemd-sysv</p>
+        <p><strong>Provides:</strong> systemd</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -151,7 +155,6 @@
         <ul>
             <li><code>systemd</code></li>
             <li><code>systemd-sysv</code></li>
-            <li><code>systemd-timesyncd</code></li>
         </ul>
     </div>
 

--- a/docs/layer/systemd-resolved.html
+++ b/docs/layer/systemd-resolved.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>systemd-resolved - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,10 +121,10 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
+        <h1>systemd-resolved</h1>
         <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <span class="badge">v1.0.0</span>
+        <p>systemd's built-in DNS client</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
@@ -132,15 +132,6 @@
         <div class="deps">
             <a href="systemd-min.html" class="dep-badge">systemd-min</a>
         </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -154,7 +145,7 @@
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>sys-apps/systemd-resolved.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/systemd-timesyncd.html
+++ b/docs/layer/systemd-timesyncd.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>systemd-timesyncd - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,10 +121,10 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
+        <h1>systemd-timesyncd</h1>
         <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <span class="badge">v1.0.0</span>
+        <p>systemd's built-in NTP client</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
@@ -140,7 +140,7 @@
             <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
             
         </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <p><strong>Provides:</strong> time-daemon</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,13 +148,13 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>systemd-timesyncd</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>sys-apps/systemd-timesyncd.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/trixie-minbase.html
+++ b/docs/layer/trixie-minbase.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>trixie-minbase</h1>
         <span class="badge">suite</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Debian Trixie with apt, utils, wired networking, ssh.</p>
     </div>
     <div class="section">
@@ -138,6 +138,7 @@
             <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             <a href="openssh-server.html" class="dep-badge">openssh-server</a>
+            <a href="systemd-timesyncd.html" class="dep-badge">systemd-timesyncd</a>
         </div>
     </div>
 

--- a/docs/layer/wireless-debug.html
+++ b/docs/layer/wireless-debug.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>wireless-debug - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,14 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
-        <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <h1>wireless-debug</h1>
+        <span class="badge">connectivity</span>
+        <span class="badge">v1.0.0</span>
+        <p>Wireless diagnostic tools</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <p><strong>Requires Provider:</strong> wireless-regdb</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,13 +136,14 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>iw</code></li>
+            <li><code>wavemon</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>net-wireless/debug.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/wireless-regulatory.html
+++ b/docs/layer/wireless-regulatory.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>wireless-regulatory - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,14 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
-        <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
+        <h1>wireless-regulatory</h1>
+        <span class="badge">connectivity</span>
+        <span class="badge">v1.0.0</span>
+        <p>Wireless regulatory database</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <p><strong>Provides:</strong> wireless-regdb</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,13 +136,13 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>wireless-regdb</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>net-wireless/regulatory.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/wireless-utils.html
+++ b/docs/layer/wireless-utils.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>systemd-net-min - Layer Documentation</title>
+    <title>wireless-utils - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,10 @@
     </div>
 
     <div class="header">
-        <h1>systemd-net-min</h1>
-        <span class="badge">general</span>
-        <span class="badge">v3.0.0</span>
-        <p>Systemd networking via networkd and resolved services</p>
-    </div>
-    <div class="section">
-        <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-        </div>
-        <p><strong>Required by:</strong></p>
-        <div class="deps">
-            
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
-            
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
-        </div>
-        <p><strong>Provides:</strong> network-activator</p>
+        <h1>wireless-utils</h1>
+        <span class="badge">connectivity</span>
+        <span class="badge">v1.0.0</span>
+        <p>Production wireless utilities</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -148,13 +132,13 @@
         <h3>Packages</h3>
         <p>Installs:</p>
         <ul>
-            <li><code>systemd-resolved</code></li>
+            <li><code>rfkill</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>sys-apps/systemd-net-min.yaml</code></p>
+        <p><strong>File:</strong> <code>net-wireless/utils.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/examples/custom_layers/layer/acme-developer.yaml
+++ b/examples/custom_layers/layer/acme-developer.yaml
@@ -11,6 +11,7 @@
 #  rpi-misc-skel,
 #  rpi-user-credentials,
 #  systemd-net-min,
+#  systemd-timesyncd,
 #  fake-hwclock,
 #  example-sdk-setup
 # METAEND

--- a/examples/slim/layer/slim.yaml
+++ b/examples/slim/layer/slim.yaml
@@ -6,5 +6,6 @@
 # X-Env-Layer-Requires: debian-trixie-arm64-slim,
 #  rpi-debian-trixie,
 #  rpi-misc-skel,
-#  systemd-net-min
+#  systemd-net-min,
+#  systemd-timesyncd
 # METAEND

--- a/examples/webkiosk/layer/mykiosk.yaml
+++ b/examples/webkiosk/layer/mykiosk.yaml
@@ -5,7 +5,7 @@
 #  variables, declare packages and create a start up script. We depend on the
 #  RPi user creds layer as we want to run the kiosk as the user it creates, and
 #  we depend on systemd because we install a systemd service to start the kiosk.
-# X-Env-Layer-Requires: rpi-user-credentials,systemd-net-min
+# X-Env-Layer-Requires: rpi-user-credentials,systemd-net-min,systemd-timesyncd
 #
 # X-Env-VarPrefix: kiosk
 #

--- a/image/gpt/ab_userdata/device/rootfs-overlay/etc/systemd/system/persistent-shared-init.service
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/etc/systemd/system/persistent-shared-init.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Initialise persistent shared directories
+# TODO: if/when a top level persistent-ready.target is introduced, replace the
+# direct persistent.mount dependency below (and in machine-id-sync.service) with
+# After=persistent-ready.target, and add health-check service before it.
+DefaultDependencies=no
+Requires=persistent.mount
+After=persistent.mount
+Before=local-fs.target
+Before=var.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/rpi-persistent-shared-init

--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
@@ -1,0 +1,57 @@
+#!/bin/sh
+# systemd generator to bind-mount shared persistent paths declared by layers
+
+set -eu
+
+OUT_DIR="/run/systemd/generator"
+mkdir -p "$OUT_DIR"
+
+CONF_DIR=/etc/rpi-image-gen/slot-shared.d
+[ -d "$CONF_DIR" ] || exit 0
+
+for conf in "${CONF_DIR}"/*.conf; do
+    [ -f "$conf" ] || continue
+
+    # Single-pass key=value parse; accumulate Path= values space-separated
+    version=""
+    paths=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in ''|\#*) continue ;; esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        case "$key" in
+            Version) version="$value" ;;
+            Path)    paths="$paths /${value#/}" ;;
+        esac
+    done < "$conf"
+
+    if [ "$version" != "1" ]; then
+        printf 'slot-shared-generator: %s: unsupported version "%s", skipping\n' \
+            "$conf" "${version:-missing}" >&2
+        continue
+    fi
+
+    for path in $paths; do
+        unit_name="$(systemd-escape --path "$path").mount"
+        shared_path="/persistent/shared${path}"
+        cat >"${OUT_DIR}/${unit_name}" <<EOF
+[Unit]
+Description=Shared persistent data for ${path}
+Requires=persistent.mount
+After=persistent.mount var.mount
+Wants=persistent-shared-init.service
+After=persistent-shared-init.service
+ConditionPathIsDirectory=${shared_path}
+Before=local-fs.target
+
+[Mount]
+What=${shared_path}
+Where=${path}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target
+EOF
+    done
+done

--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/sbin/rpi-persistent-shared-init
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/sbin/rpi-persistent-shared-init
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Create shared directories under /persistent/shared for paths declared
+# by layers in /etc/rpi-image-gen/slot-shared.d/*.conf.
+
+set -eu
+
+CONF_DIR=/etc/rpi-image-gen/slot-shared.d
+SHARED_BASE=/persistent/shared
+
+[ -d "$CONF_DIR" ] || exit 0
+
+for conf in "${CONF_DIR}"/*.conf; do
+   [ -f "$conf" ] || continue
+
+   version=""
+   paths=""
+   while IFS= read -r line || [ -n "$line" ]; do
+       case "$line" in ''|\#*) continue ;; esac
+       key="${line%%=*}"
+       value="${line#*=}"
+       case "$key" in
+           Version) version="$value" ;;
+           Path)    paths="$paths /${value#/}" ;;
+       esac
+   done < "$conf"
+
+   if [ "$version" != "1" ]; then
+       printf 'persistent-shared-init: %s: unsupported version "%s", skipping\n' \
+           "$conf" "${version:-missing}" >&2
+       continue
+   fi
+
+   for path in $paths; do
+      printf 'persistent-shared-init: %s\n' "$path"
+      mkdir -p "${SHARED_BASE}${path}"
+      # Write files that differ or are missing into shared
+      [ -d "${path}" ] && rsync -av --checksum "${path}/" "${SHARED_BASE}${path}/"
+   done
+done

--- a/image/gpt/ab_userdata/image.adoc
+++ b/image/gpt/ab_userdata/image.adoc
@@ -15,6 +15,7 @@ This system uses an A/B, read‑only root with all writable state on a single pe
 | /home | /persistent/home | bind | User data shared across slots
 | /var | /persistent/slots/<slot>/var | bind | Per‑slot runtime state (systemd, caches, etc.)
 | /var/log/journal | /persistent/log/journal | bind | Single log directory used by both slots
+| _<slot-shared paths>_ | /persistent/shared/<path> | bind | Application data shared across slots (layer-declared, see <<slot-shared>>)
 |===
 
 * **Rationale (immutable root + A/B)**
@@ -47,6 +48,51 @@ If slot GPT labels are missing/duplicated, `/var` binding will fail.
 
 If slot GPT labels can’t be guaranteed, this layout is not suitable for your device.
 ====
+
+
+[[slot-shared]]
+== Slot-shared application data
+
+Any layer can declare filesystem paths whose application data should be shared across slots. At boot, each declared path is bind-mounted from a common location on the persistent partition so the same data is visible regardless of which slot is active.
+
+=== How it works
+
+. `slot-shared-generator` runs at early boot, reads every `/etc/rpi-image-gen/slot-shared.d/*.conf` file and emits a `.mount` systemd unit for each declared path, mounting `/persistent/shared/<path>` over `<path>` as a bind mount.
+. `persistent-shared-init.service` runs before the bind mounts activate. It creates any missing `/persistent/shared/<path>` directories on the persistent partition, handling first boot and disaster-recovery scenarios where the partition has been re-initialised.
+. Bind mounts are guarded by `ConditionPathIsDirectory` on the source. If the directory is absent the mount is skipped and the service falls back to its local path - safe degradation with no boot failure.
+
+=== Declaring a shared path
+
+Drop a `.conf` file into `/etc/rpi-image-gen/slot-shared.d/`, eg via the layer's rootfs overlay or script:
+
+[source]
+----
+Version=1
+Path=/var/lib/myapp
+Path=/etc/myapp/state
+----
+
+`Version=1`:: Required. A generator that does not recognise the version skips the file with a warning rather than misprocessing it.
+`Path=`:: One or more absolute paths to share. Multiple `Path=` entries are supported in a single file. A missing leading `/` is corrected automatically. Only directory paths are supported.
+
+Unknown keys are silently ignored, providing forward compatibility within version 1.
+A version increment signals a breaking change.
+The files are inert in non-AB configurations.
+
+=== Persistent partition layout
+
+Shared data is stored under `/persistent/shared/`, mirroring the full path hierarchy:
+
+[source]
+----
+/persistent/
+└── shared/
+    └── var/
+        └── lib/
+            └── myapp/    <-- bind-mounted over /var/lib/myapp
+----
+
+Because the immutable root retains a copy of each declared path, files baked into the image are pushed into the shared location by `rpi-persistent-shared-init`, before the bind mounts activate. Files are only pushed if missing from or different to the destination. This means an OTA update can deliver new or updated shared application data simply by including it in the rootfs - no separate data partition update is required.
 
 
 == Slot Selection (run-time)

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
 #  boot/system redundancy, and a shared persistent data partition.
-# X-Env-Layer-Version: 5.4.0
+# X-Env-Layer-Version: 5.5.0
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
@@ -80,3 +80,4 @@ mmdebstrap:
     - dosfstools
     - e2fsprogs
     - initramfs-tools
+    - rsync

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -68,7 +68,7 @@ install -d -m 1777 ${fs}/persistent/slots/system_a/var/tmp
 install -d -m 1777 ${fs}/persistent/slots/system_b/var/tmp
 
 
-# machine-id(5)
+# machine-id(5) needed by sysinit.target
 wants_dir="${fs}/etc/systemd/system/sysinit.target.wants"
 units=(
   "machine-id-sync.service"
@@ -85,6 +85,19 @@ rm -f "${fs}/etc/machine-id"
 rm -f "${fs}/var/lib/dbus/machine-id"
 install -m0644 -o root -g root /dev/null "${fs}/etc/machine-id"
 ln -s /etc/machine-id "${fs}/var/lib/dbus/machine-id"
+
+
+# persistent-shared-init needed by local-fs.target
+wants_dir="${fs}/etc/systemd/system/local-fs.target.wants"
+units=(
+  "persistent-shared-init.service"
+)
+install -d -m 0755 "${wants_dir}"
+for unit in "${units[@]}"; do
+  [ -f "${fs}/etc/systemd/system/${unit}" ] || die "missing ${unit}"
+  chmod 0644 "${fs}/etc/systemd/system/${unit}"
+  ln -sf "../${unit}" "${wants_dir}/${unit}"
+done
 
 
 # /var is per-slot, so synchronise
@@ -131,6 +144,7 @@ rsync -aHAXS --numeric-ids --delete "${fs}/home/" "${fs}/persistent/home/"
 # Reclaim /home
 find "${fs}/home" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 
+
 # Reclaim /var but ensure skeleton exists for services that need PrivateTmp
 # otherwise namespace setup will fail on the immutable root.
 find "${fs}/var" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
@@ -138,6 +152,41 @@ install -d -m 1777 ${fs}/var/tmp
 install -d -m 0755 ${fs}/var/log
 install -d -m 0755 ${fs}/var/cache
 install -d -m 0755 ${fs}/var/spool
+
+
+# For each slot-shared path: seed /persistent/shared and retain a copy in the
+# immutable root. Both use the slot-a copy (rsynced above) as the source.
+# Retaining in the immutable root lets persistent-shared-init push OTA-delivered
+# files into the shared location on each boot, before bind mounts activate.
+if ls "${fs}/etc/rpi-image-gen/slot-shared.d/"*.conf >/dev/null 2>&1; then
+   for conf in "${fs}/etc/rpi-image-gen/slot-shared.d/"*.conf; do
+      [ -f "$conf" ] || continue
+      version=""
+      paths=""
+      while IFS= read -r line || [ -n "$line" ]; do
+         case "$line" in ''|\#*) continue ;; esac
+           key="${line%%=*}"
+           value="${line#*=}"
+           case "$key" in
+               Version) version="$value" ;;
+               Path)    paths="$paths /${value#/}" ;;
+           esac
+      done < "$conf"
+
+      if [ "$version" != "1" ]; then
+         die "pre-image: $conf: unsupported slot-shared version '${version:-missing}'"
+      fi
+
+      for path in $paths; do
+         src="${fs}/persistent/slots/system_a${path}"
+         [ -d "$src" ] || continue
+         mkdir -p "${fs}/persistent/shared${path}"
+         rsync -aHAXS --numeric-ids --delete "${src}/" "${fs}/persistent/shared${path}/"
+         mkdir -p "${fs}${path}"
+         rsync -aHAXS --numeric-ids --delete "${src}/" "${fs}${path}/"
+      done
+   done
+fi
 
 
 # Older systemd (eg 252/Bookworm) sets up per‑service mount namespaces by

--- a/layer/net-misc/chrony-systemd.yaml
+++ b/layer/net-misc/chrony-systemd.yaml
@@ -1,0 +1,20 @@
+# METABEGIN
+# X-Env-Layer-Name: chrony
+# X-Env-Layer-Desc: Chrony NTP client and server
+#  https://chrony-project.org
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: time-daemon
+# X-Env-Layer-RequiresProvider: systemd
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - chrony
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" chrony
+    - |-
+      set -eu
+      if [ -n "${SOURCE_DATE_EPOCH:-}" ] ; then
+        install -d -m0755 $1/var/lib/systemd/timesync
+        touch -m -d "@${SOURCE_DATE_EPOCH}" $1/var/lib/systemd/timesync/clock
+      fi

--- a/layer/net-wireless/debug.yaml
+++ b/layer/net-wireless/debug.yaml
@@ -1,0 +1,12 @@
+# METABEGIN
+# X-Env-Layer-Name: wireless-debug
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-Desc: Wireless diagnostic tools
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-RequiresProvider: wireless-regdb
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - iw
+    - wavemon

--- a/layer/net-wireless/iwd-systemd.rootfs-overlay/etc/iwd/main.conf
+++ b/layer/net-wireless/iwd-systemd.rootfs-overlay/etc/iwd/main.conf
@@ -1,0 +1,2 @@
+[General]
+EnableNetworkConfiguration=false

--- a/layer/net-wireless/iwd-systemd.rootfs-overlay/etc/rpi-image-gen/slot-shared.d/iwd.conf
+++ b/layer/net-wireless/iwd-systemd.rootfs-overlay/etc/rpi-image-gen/slot-shared.d/iwd.conf
@@ -1,0 +1,2 @@
+Version=1
+Path=/var/lib/iwd

--- a/layer/net-wireless/iwd-systemd.yaml
+++ b/layer/net-wireless/iwd-systemd.yaml
@@ -2,9 +2,9 @@
 # X-Env-Layer-Name: iwd
 # X-Env-Layer-Category: connectivity
 # X-Env-Layer-Desc: iNet wireless daemon for wifi management
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
 # X-Env-Layer-Provides: wifi-supplicant
-# X-Env-Layer-RequiresProvider: wireless-regdb,systemd-sysv
+# X-Env-Layer-RequiresProvider: wireless-regdb,systemd,network-activator
 #
 # X-Env-VarPrefix: iwd
 #

--- a/layer/net-wireless/iwd-systemd.yaml
+++ b/layer/net-wireless/iwd-systemd.yaml
@@ -1,0 +1,33 @@
+# METABEGIN
+# X-Env-Layer-Name: iwd
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-Desc: iNet wireless daemon for wifi management
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: wifi-supplicant
+# X-Env-Layer-RequiresProvider: wireless-regdb,systemd-sysv
+#
+# X-Env-VarPrefix: iwd
+#
+# X-Env-Var-profile:
+# X-Env-Var-profile-Desc: Path to an iwd network profile file to bake
+#  into the build. The file is installed into /var/lib/iwd/ preserving its
+#  filename. See iwd.network(5)
+# X-Env-Var-profile-Required: n
+# X-Env-Var-profile-Valid: string-or-empty
+# X-Env-Var-profile-Set: y
+#
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - iwd
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" iwd
+    - install -d -m 0700 "$1/var/lib/iwd"
+    - install -d -m 0755 "$1/etc/iwd"
+    - |-
+      set -eu
+      if [ -n "${IGconf_iwd_profile:-}" ]; then
+        install -m 0600 "${IGconf_iwd_profile}" \
+          "$1/var/lib/iwd/$(basename "${IGconf_iwd_profile}")"
+      fi

--- a/layer/net-wireless/regulatory.yaml
+++ b/layer/net-wireless/regulatory.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: wireless-regulatory
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-Desc: Wireless regulatory database
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: wireless-regdb
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - wireless-regdb

--- a/layer/net-wireless/utils.yaml
+++ b/layer/net-wireless/utils.yaml
@@ -1,0 +1,10 @@
+# METABEGIN
+# X-Env-Layer-Name: wireless-utils
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-Desc: Production wireless utilities
+# X-Env-Layer-Version: 1.0.0
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - rfkill

--- a/layer/rpi/device/family-base.yaml
+++ b/layer/rpi/device/family-base.yaml
@@ -2,10 +2,10 @@
 # X-Env-Layer-Name: rpi-device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi device base layer and defaults
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-idp,rpi-device-secpolicy
 # X-Env-Layer-Provides: device
-# X-Env-Layer-RequiresProvider: rpi-device
+# X-Env-Layer-RequiresProvider: rpi-device,systemd,network-activator
 #
 # X-Env-VarPrefix: device
 #
@@ -33,3 +33,7 @@ mmdebstrap:
   packages:
     - udev
     - firmware-brcm80211
+  customize-hooks:
+    - mkdir -p $1/etc/systemd/network
+    - $LAYER_HOOKS/systemd/netgen eth0 > $1/etc/systemd/network/01-eth0.network
+    - $LAYER_HOOKS/systemd/netgen wlan0 > $1/etc/systemd/network/02-wlan0.network

--- a/layer/rpi/device/family-secpolicy-base.yaml
+++ b/layer/rpi/device/family-secpolicy-base.yaml
@@ -2,8 +2,8 @@
 # X-Env-Layer-Name: rpi-device-secpolicy
 # X-Env-Layer-Category: security
 # X-Env-Layer-Desc: Raspberry Pi device family security policy baseline
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-RequiresProvider: rpi-device,image,systemd-sysv
+# X-Env-Layer-Version: 1.0.1
+# X-Env-Layer-RequiresProvider: rpi-device,image,systemd
 #
 # X-Env-VarPrefix: rpisec
 #

--- a/layer/suite/debian/bookworm-minbase.yaml
+++ b/layer/suite/debian/bookworm-minbase.yaml
@@ -11,6 +11,7 @@
 #  rpi-user-credentials,
 #  systemd-net-min,
 #  fake-hwclock,
-#  openssh-server
+#  openssh-server,
+#  systemd-timesyncd
 # METAEND
 ---

--- a/layer/suite/debian/trixie-minbase.yaml
+++ b/layer/suite/debian/trixie-minbase.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: trixie-minbase
 # X-Env-Layer-Desc: Debian Trixie with apt, utils, wired networking, ssh.
 # X-Env-Layer-Category: suite
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Requires: debian-trixie-arm64-multi,
 #  rpi-debian-trixie,
 #  rpi-misc-utils,
@@ -10,6 +10,7 @@
 #  rpi-misc-skel,
 #  rpi-user-credentials,
 #  systemd-net-min,
-#  openssh-server
+#  openssh-server,
+#  systemd-timesyncd
 # METAEND
 ---

--- a/layer/sys-apps/systemd-min.yaml
+++ b/layer/sys-apps/systemd-min.yaml
@@ -1,23 +1,15 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-min
-# X-Env-Layer-Desc: Core systemd components for init, SysV compatibility
-#  and timesyncd, without networkd and resolved services.
-# X-Env-Layer-Version: 1.1.1
-# X-Env-Layer-Provides: systemd-sysv
+# X-Env-Layer-Desc: Core systemd components for init and SysV compatibility,
+#  without additional services
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Provides: systemd
 # METAEND
 ---
 mmdebstrap:
   packages:
     - systemd
     - systemd-sysv
-    - systemd-timesyncd
   customize-hooks:
-    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-timesyncd
-    - |-
-      set -eu
-      if [ -n "${SOURCE_DATE_EPOCH:-}" ] ; then
-        install -d -m0755 $1/var/lib/systemd/timesync
-        touch -m -d "@${SOURCE_DATE_EPOCH}" $1/var/lib/systemd/timesync/clock
-      fi
     - mkdir -p $1/etc/systemd/system/getty@tty1.service.d
     - $LAYER_HOOKS/systemd/ttyset noclear > $1/etc/systemd/system/getty@tty1.service.d/noclear.conf

--- a/layer/sys-apps/systemd-net-min.yaml
+++ b/layer/sys-apps/systemd-net-min.yaml
@@ -1,7 +1,7 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-net-min
 # X-Env-Layer-Desc: Systemd networking via networkd and resolved services
-# X-Env-Layer-Version: 2.1.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Provides: network-activator
 # X-Env-Layer-Requires: systemd-min
 # METAEND
@@ -15,5 +15,4 @@ mmdebstrap:
     - mkdir -p $1/etc/systemd/network
     - ln -sf /dev/null $1/etc/systemd/network/99-default.link
     - ln -sf /dev/null $1/etc/systemd/network/73-usb-net-by-mac.link
-    - $LAYER_HOOKS/systemd/netgen eth0 > $1/etc/systemd/network/01-eth0.network
     - '[ -e "$1/run/systemd/resolve/stub-resolv.conf" ] || install -Dm644 /etc/resolv.conf "$1/run/systemd/resolve/stub-resolv.conf"'

--- a/layer/sys-apps/systemd-net-min.yaml
+++ b/layer/sys-apps/systemd-net-min.yaml
@@ -1,7 +1,8 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-net-min
 # X-Env-Layer-Desc: Systemd networking via networkd and resolved services
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
+# X-Env-Layer-Provides: network-activator
 # X-Env-Layer-Requires: systemd-min
 # METAEND
 ---

--- a/layer/sys-apps/systemd-resolved.yaml
+++ b/layer/sys-apps/systemd-resolved.yaml
@@ -1,0 +1,13 @@
+# METABEGIN
+# X-Env-Layer-Name: systemd-resolved
+# X-Env-Layer-Desc: systemd's built-in DNS client
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: systemd-min
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - systemd-resolved
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-resolved
+    - '[ -e "$1/run/systemd/resolve/stub-resolv.conf" ] || install -Dm644 /etc/resolv.conf "$1/run/systemd/resolve/stub-resolv.conf"'

--- a/layer/sys-apps/systemd-timesyncd.yaml
+++ b/layer/sys-apps/systemd-timesyncd.yaml
@@ -1,0 +1,19 @@
+# METABEGIN
+# X-Env-Layer-Name: systemd-timesyncd
+# X-Env-Layer-Desc: systemd's built-in NTP client
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: time-daemon
+# X-Env-Layer-Requires: systemd-min
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - systemd-timesyncd
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-timesyncd
+    - |-
+      set -eu
+      if [ -n "${SOURCE_DATE_EPOCH:-}" ] ; then
+        install -d -m0755 $1/var/lib/systemd/timesync
+        touch -m -d "@${SOURCE_DATE_EPOCH}" $1/var/lib/systemd/timesync/clock
+      fi


### PR DESCRIPTION
Introduce the new 'slot-shared' infrastructure for AB configurations for layers that wish to share application data across slots. Drop a tiny config file into `/etc/rpi-image-gen/slot-shared.d/` to declare filesystem paths that should persist across slot rotations. Implementation is handled by new systemd generator that emits bind mount units at boot.

Add wifi layers under a new connectivity category. The iwd layer shares `/var/lib/iwd` across A/B slots via the new slot-shared convention and supports baking in a network profile at build time via `IGconf_iwd_profile`.

Automatic activation of wireless LAN is now possible using iwd as follows:

1. Add at least `wireless-regulatory` and `iwd` layers to an existing configuration.
2. Build with `IGconf_iwd_profile=/path/to/<my SSID>.psk` (or set the variable via config file)

This file must be named and have contents in accordance with iwd.network(5), eg

```
$ cat SSID.psk 
[Security]
Passphrase=dancingfrobulator
```
See https://manpages.debian.org/testing/iwd/iwd.network.5.en.html

The systemd layers have undergone some minor surgery with timesyncd now existing as a standalone layer so that configurations may use an alternative NTP client. A new `chrony` layer has been added as an alternative, as has a new layer that provides systemd + resolved without networkd for configurations that want to use an alternative network activator/manager (eg Network Manager).

Critically, network interface configuration has been moved out of `systemd-net-min` into the common rpi device layer where it belongs (network interfaces are device specific). This installs systemd network fragments for `eth0` and `wlan0` by default. Depending on usage, current consumers of `systemd-net-min` may find network activation broken after updating. The simple solution is to do what `rpi-device-base` now does (or what `systemd-net-min` did) in a custom device layer.