### PR TITLE
layer (suite): Add wlan support to trixie minbase

### DIFF
--- a/layer/suite/debian/trixie-minbase.yaml
+++ b/layer/suite/debian/trixie-minbase.yaml
@@ -1,8 +1,8 @@
 # METABEGIN
 # X-Env-Layer-Name: trixie-minbase
-# X-Env-Layer-Desc: Debian Trixie with apt, utils, wired networking, ssh.
+# X-Env-Layer-Desc: Debian Trixie with apt, utils, wired and wifi networking, ssh.
 # X-Env-Layer-Category: suite
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Requires: debian-trixie-arm64-multi,
 #  rpi-debian-trixie,
 #  rpi-misc-utils,
@@ -11,6 +11,8 @@
 #  rpi-user-credentials,
 #  systemd-net-min,
 #  openssh-server,
-#  systemd-timesyncd
+#  systemd-timesyncd,
+#  wireless-regulatory,
+#  iwd
 # METAEND
 ---


### PR DESCRIPTION
All downstream consumers of trixie-minbase will gain wireless LAN support. This includes the default build configuration targets and OTA example.