### PR TITLE
Refactor locale layers and introduce dedicated i18n configurations

### DIFF
--- a/docs/layer/debian-bookworm-arm64-multi.html
+++ b/docs/layer/debian-bookworm-arm64-multi.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-bookworm-arm64-multi</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Debian Bookworm apt base for arm64 and armhf.</p>
     </div>
     <div class="section">
@@ -138,15 +138,7 @@
             <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
             
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/debian-bookworm-arm64-slim.html
+++ b/docs/layer/debian-bookworm-arm64-slim.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-bookworm-arm64-slim</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.1.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Debian Bookworm custom layer for arm64 providing
  a usable and practical base.</p>
     </div>
@@ -133,15 +133,7 @@
         <div class="deps">
             <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/debian-bookworm-buildd.html
+++ b/docs/layer/debian-bookworm-buildd.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-bookworm-buildd</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Architecture agnostic Debian Bookworm buildd base.
  This provides a base layer specifically designed for automated package
  building and software compilation.</p>
@@ -132,17 +132,9 @@
         <h2>Relationships</h2>
         <p><strong>Depends on:</strong></p>
         <div class="deps">
-            <a href="locale-base.html" class="dep-badge">locale-base</a>
+            <a href="locale-gen.html" class="dep-badge">locale-gen</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/debian-trixie-arm64-multi.html
+++ b/docs/layer/debian-trixie-arm64-multi.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-trixie-arm64-multi</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Debian Trixie apt base for arm64 and armhf.</p>
     </div>
     <div class="section">
@@ -138,15 +138,7 @@
             <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
             
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/debian-trixie-arm64-slim.html
+++ b/docs/layer/debian-trixie-arm64-slim.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-trixie-arm64-slim</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.1.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Debian Trixie custom layer for arm64 providing
  a usable and practical base.</p>
     </div>
@@ -133,15 +133,7 @@
         <div class="deps">
             <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -182,6 +174,7 @@
             <li><code>e2fsprogs</code></li>
             <li><code>linux-sysctl-defaults</code></li>
             <li><code>debian-archive-keyring</code></li>
+            <li><code>coreutils</code></li>
         </ul>
         
         <h3>Mirrors</h3>

--- a/docs/layer/debian-trixie-arm64.html
+++ b/docs/layer/debian-trixie-arm64.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-trixie-arm64</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Debian Trixie apt base for arm64.</p>
     </div>
     <div class="section">
@@ -132,15 +132,7 @@
         <div class="deps">
             <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/debian-trixie-buildd.html
+++ b/docs/layer/debian-trixie-buildd.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>debian-trixie-buildd</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Architecture agnostic Debian Trixie buildd base.
  This provides a base layer specifically designed for automated package
  building and software compilation.</p>
@@ -132,17 +132,9 @@
         <h2>Relationships</h2>
         <p><strong>Depends on:</strong></p>
         <div class="deps">
-            <a href="locale-base.html" class="dep-badge">locale-base</a>
+            <a href="locale-gen.html" class="dep-badge">locale-gen</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/essential.html
+++ b/docs/layer/essential.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>essential</h1>
         <span class="badge">foundation</span>
-        <span class="badge">v1.1.0</span>
+        <span class="badge">v2.0.0</span>
         <p>Serves as the mandatory foundation for all rpi-image-gen
  builds, and is automatically included in every configuration to provide
  essential build infrastructure.</p>
@@ -212,7 +212,6 @@
             <a href="artefact-base.html" class="dep-badge">artefact-base</a>
             <a href="sys-build-base.html" class="dep-badge">sys-build-base</a>
             <a href="target-config.html" class="dep-badge">target-config</a>
-            <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
     </div>
 

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -1069,7 +1069,7 @@ IGconf_layer_app=my-app</code></pre>
     <h2>Available Layers</h2>
     
     
-    <h3>Audit</h3>
+    <h3>audit</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1078,7 +1078,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Base</h3>
+    <h3>base</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1102,7 +1102,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Build</h3>
+    <h3>build</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1125,7 +1125,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Ci</h3>
+    <h3>ci</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1136,7 +1136,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Connectivity</h3>
+    <h3>connectivity</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1157,7 +1157,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Container</h3>
+    <h3>container</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1170,7 +1170,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Device</h3>
+    <h3>device</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1236,7 +1236,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Distribution</h3>
+    <h3>distribution</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1293,7 +1293,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Firmware</h3>
+    <h3>firmware</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1302,7 +1302,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Foundation</h3>
+    <h3>foundation</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1311,12 +1311,12 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
-            <a href="locale-base.html">locale-base</a><span class="layer-desc">- Default locale settings</span>
+            <a href="locale-config.html">locale-config</a><span class="layer-desc">- Localisation and Internationalisation config settings</span>
         </div>
         
     </div>
     
-    <h3>General</h3>
+    <h3>general</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1381,7 +1381,20 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Image</h3>
+    <h3>i18n</h3>
+    <div class="layer-list">
+        
+        <div class="layer-item">
+            <a href="locale-base.html">locale-base</a><span class="layer-desc">- Pre-seeded locale and internationalisation settings</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="locale-gen.html">locale-gen</a><span class="layer-desc">- Installs and generates locales at build time</span>
+        </div>
+        
+    </div>
+    
+    <h3>image</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1400,7 +1413,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Kernel</h3>
+    <h3>kernel</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1421,7 +1434,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Security</h3>
+    <h3>security</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1430,7 +1443,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Service</h3>
+    <h3>service</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1448,7 +1461,7 @@ IGconf_layer_app=my-app</code></pre>
         
     </div>
     
-    <h3>Suite</h3>
+    <h3>suite</h3>
     <div class="layer-list">
         
         <div class="layer-item">
@@ -1456,12 +1469,12 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
-            <a href="trixie-minbase.html">trixie-minbase</a><span class="layer-desc">- Debian Trixie with apt, utils, wired networking, ssh.</span>
+            <a href="trixie-minbase.html">trixie-minbase</a><span class="layer-desc">- Debian Trixie with apt, utils, wired and wifi networking, ssh.</span>
         </div>
         
     </div>
     
-    <h3>Toolchain</h3>
+    <h3>toolchain</h3>
     <div class="layer-list">
         
         <div class="layer-item">

--- a/docs/layer/iwd.html
+++ b/docs/layer/iwd.html
@@ -128,6 +128,12 @@
     </div>
     <div class="section">
         <h2>Relationships</h2>
+        <p><strong>Required by:</strong></p>
+        <div class="deps">
+            
+            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
+            
+        </div>
         <p><strong>Provides:</strong> wifi-supplicant</p>
         <p><strong>Requires Provider:</strong> wireless-regdb, systemd, network-activator</p>
     </div>

--- a/docs/layer/locale-base.html
+++ b/docs/layer/locale-base.html
@@ -122,12 +122,16 @@
 
     <div class="header">
         <h1>locale-base</h1>
-        <span class="badge">foundation</span>
-        <span class="badge">v1.0.0</span>
-        <p>Default locale settings</p>
+        <span class="badge">i18n</span>
+        <span class="badge">v2.0.0</span>
+        <p>Pre-seeded locale and internationalisation settings</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
+        <p><strong>Depends on:</strong></p>
+        <div class="deps">
+            <a href="locale-config.html" class="dep-badge">locale-config</a>
+        </div>
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
@@ -137,90 +141,41 @@
             
             <a href="debian-bookworm-arm64-slim.html" class="dep-badge">debian-bookworm-arm64-slim</a>
             
-            <a href="debian-bookworm-buildd.html" class="dep-badge">debian-bookworm-buildd</a>
-            
             <a href="debian-trixie-arm64.html" class="dep-badge">debian-trixie-arm64</a>
             
             <a href="debian-trixie-arm64-multi.html" class="dep-badge">debian-trixie-arm64-multi</a>
             
             <a href="debian-trixie-arm64-slim.html" class="dep-badge">debian-trixie-arm64-slim</a>
             
-            <a href="debian-trixie-buildd.html" class="dep-badge">debian-trixie-buildd</a>
-            
-            <a href="essential.html" class="dep-badge">essential</a>
-            
             <a href="raspbian-bookworm-armhf.html" class="dep-badge">raspbian-bookworm-armhf</a>
             
             <a href="raspbian-trixie-armhf.html" class="dep-badge">raspbian-trixie-armhf</a>
             
         </div>
+        <p><strong>Provides:</strong> locale-configured</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>
-        <p><strong>Declares</strong> (prefix: <code>locale</code>):</p>
-        <table>
-            <thead>
-                <tr>
-                    <th>Variable</th>
-                    <th>Description</th>
-                    <th>Default</th>
-                    <th>Validation</th>
-                    <th>Policy</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><code>IGconf_locale_default</code></td>
-                    <td>The default system locale.</td>
-                    <td>
-                           <code>en_GB.UTF-8</code>
-                    </td>
-                    <td>Non-empty string value</td>
-                    <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td><code>IGconf_locale_keyboard_keymap</code></td>
-                    <td>The default system keyboard map.</td>
-                    <td>
-                           <code>gb</code>
-                    </td>
-                    <td>Non-empty string value</td>
-                    <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td><code>IGconf_locale_keyboard_layout</code></td>
-                    <td>The default system keyboard layout. See
- debconf-show keyboard-configuration keyboard-configuration/xkb-keymap</td>
-                    <td>
-                           <code>English (UK)</code>
-                    </td>
-                    <td>Non-empty string value</td>
-                    <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td><code>IGconf_locale_timezone</code></td>
-                    <td>The default system timezone defined by IANA.</td>
-                    <td>
-                           <code>Europe/London</code>
-                    </td>
-                    <td>Non-empty string value</td>
-                    <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <p><strong>References:</strong>
+        <code>IGconf_locale_timezone</code>, 
+        <code>IGconf_locale_default</code>, 
+        <code>IGconf_locale_keyboard_layout</code>, 
+        <code>IGconf_locale_keyboard_keymap</code>
+        </p>
+    </div>
+    <div class="section">
+        <h2>mmdebstrap</h2>
+        
+        <h3>Packages</h3>
+        <p>Installs:</p>
+        <ul>
+            <li><code>console-setup</code></li>
+        </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>base/locale-base.yaml</code></p>
+        <p><strong>File:</strong> <code>app-i18n/locale-base.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/locale-config.html
+++ b/docs/layer/locale-config.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>debian-bookworm-arm64 - Layer Documentation</title>
+    <title>locale-config - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,66 +121,86 @@
     </div>
 
     <div class="header">
-        <h1>debian-bookworm-arm64</h1>
-        <span class="badge">distribution</span>
-        <span class="badge">v3.0.0</span>
-        <p>Debian Bookworm apt base for arm64</p>
+        <h1>locale-config</h1>
+        <span class="badge">foundation</span>
+        <span class="badge">v1.0.0</span>
+        <p>Localisation and Internationalisation config settings</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
+        <p><strong>Required by:</strong></p>
         <div class="deps">
+            
             <a href="locale-base.html" class="dep-badge">locale-base</a>
+            
         </div>
-        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
-        <h2>mmdebstrap</h2>
-        
-        <h3>Suite</h3>
-        <ul>
-            <li><code>bookworm</code></li>
-        </ul>
-        
-        <h3>Variant</h3>
-        <p>Installs package set:</p>
-        <ul>
-            <li><code>apt</code></li>
-        </ul>
-        
-        <h3>Architectures</h3>
-        <ul>
-            <li><code>arm64</code></li>
-        </ul>
-        
-        <h3>Mirrors</h3>
-        <ul>
-            <li><code>${IGTOP}/templates/debian/apt/bookworm.sources</code></li>
-        </ul>
-        
-        <h3>dpkgopts</h3>
-        <ul>
-            <li><code>path-exclude=/usr/share/man/*</code></li>
-            <li><code>path-include=/usr/share/man/man[1-9]/*</code></li>
-            <li><code>path-exclude=/usr/share/locale/*</code></li>
-            <li><code>path-include=/usr/share/locale/locale.alias</code></li>
-            <li><code>path-exclude=/usr/share/doc/*</code></li>
-            <li><code>path-include=/usr/share/doc/*/copyright</code></li>
-            <li><code>path-include=/usr/share/doc/*/changelog.Debian.*</code></li>
-            <li><code>path-exclude=/usr/share/{doc,info,man,omf,help,gnome/help}/*</code></li>
-            <li><code>path-exclude=/usr/share/lintian/*</code></li>
-        </ul>
-        
-        <h3>aptopts</h3>
-        <ul>
-            <li><code>APT::Install-Suggests "false"</code></li>
-            <li><code>APT::Install-Recommends "false"</code></li>
-        </ul>
+        <h2>Configuration Variables</h2>
+        <p><strong>Declares</strong> (prefix: <code>locale</code>):</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>Variable</th>
+                    <th>Description</th>
+                    <th>Default</th>
+                    <th>Validation</th>
+                    <th>Policy</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>IGconf_locale_default</code></td>
+                    <td>The default system locale.</td>
+                    <td>
+                           <code>en_GB.UTF-8</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_locale_keyboard_keymap</code></td>
+                    <td>The default system keyboard map.</td>
+                    <td>
+                           <code>gb</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_locale_keyboard_layout</code></td>
+                    <td>The default system keyboard layout. See
+ debconf-show keyboard-configuration keyboard-configuration/xkb-keymap</td>
+                    <td>
+                           <code>English (UK)</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_locale_timezone</code></td>
+                    <td>The default system timezone defined by IANA.</td>
+                    <td>
+                           <code>Europe/London</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>debian/bookworm/arm64/base-apt.yaml</code></p>
+        <p><strong>File:</strong> <code>base/locale-config.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/locale-gen.html
+++ b/docs/layer/locale-gen.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>debian-bookworm-arm64 - Layer Documentation</title>
+    <title>locale-gen - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,66 +121,37 @@
     </div>
 
     <div class="header">
-        <h1>debian-bookworm-arm64</h1>
-        <span class="badge">distribution</span>
-        <span class="badge">v3.0.0</span>
-        <p>Debian Bookworm apt base for arm64</p>
+        <h1>locale-gen</h1>
+        <span class="badge">i18n</span>
+        <span class="badge">v1.0.0</span>
+        <p>Installs and generates locales at build time</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
+        <p><strong>Required by:</strong></p>
         <div class="deps">
-            <a href="locale-base.html" class="dep-badge">locale-base</a>
+            
+            <a href="debian-bookworm-buildd.html" class="dep-badge">debian-bookworm-buildd</a>
+            
+            <a href="debian-trixie-buildd.html" class="dep-badge">debian-trixie-buildd</a>
+            
         </div>
-        <p><strong>Provides:</strong> debian-base</p>
+        <p><strong>Provides:</strong> locale-generated</p>
+        <p><strong>Requires Provider:</strong> locale-configured</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
         
-        <h3>Suite</h3>
+        <h3>Packages</h3>
+        <p>Installs:</p>
         <ul>
-            <li><code>bookworm</code></li>
-        </ul>
-        
-        <h3>Variant</h3>
-        <p>Installs package set:</p>
-        <ul>
-            <li><code>apt</code></li>
-        </ul>
-        
-        <h3>Architectures</h3>
-        <ul>
-            <li><code>arm64</code></li>
-        </ul>
-        
-        <h3>Mirrors</h3>
-        <ul>
-            <li><code>${IGTOP}/templates/debian/apt/bookworm.sources</code></li>
-        </ul>
-        
-        <h3>dpkgopts</h3>
-        <ul>
-            <li><code>path-exclude=/usr/share/man/*</code></li>
-            <li><code>path-include=/usr/share/man/man[1-9]/*</code></li>
-            <li><code>path-exclude=/usr/share/locale/*</code></li>
-            <li><code>path-include=/usr/share/locale/locale.alias</code></li>
-            <li><code>path-exclude=/usr/share/doc/*</code></li>
-            <li><code>path-include=/usr/share/doc/*/copyright</code></li>
-            <li><code>path-include=/usr/share/doc/*/changelog.Debian.*</code></li>
-            <li><code>path-exclude=/usr/share/{doc,info,man,omf,help,gnome/help}/*</code></li>
-            <li><code>path-exclude=/usr/share/lintian/*</code></li>
-        </ul>
-        
-        <h3>aptopts</h3>
-        <ul>
-            <li><code>APT::Install-Suggests "false"</code></li>
-            <li><code>APT::Install-Recommends "false"</code></li>
+            <li><code>locales</code></li>
         </ul>
     </div>
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>debian/bookworm/arm64/base-apt.yaml</code></p>
+        <p><strong>File:</strong> <code>app-i18n/locale-gen.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/raspbian-bookworm-armhf.html
+++ b/docs/layer/raspbian-bookworm-armhf.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>raspbian-bookworm-armhf</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Raspbian Bookworm apt base for armhf.</p>
     </div>
     <div class="section">
@@ -157,15 +157,7 @@
         <div class="deps">
             <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/raspbian-trixie-armhf.html
+++ b/docs/layer/raspbian-trixie-armhf.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>raspbian-trixie-armhf</h1>
         <span class="badge">distribution</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v3.0.0</span>
         <p>Raspbian Trixie apt base for armhf.</p>
     </div>
     <div class="section">
@@ -157,15 +157,7 @@
         <div class="deps">
             <a href="locale-base.html" class="dep-badge">locale-base</a>
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_locale_timezone</code>, 
-        <code>IGconf_locale_default</code>, 
-        <code>IGconf_locale_keyboard_layout</code>, 
-        <code>IGconf_locale_keyboard_keymap</code>
-        </p>
+        <p><strong>Provides:</strong> debian-base</p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/docs/layer/trixie-minbase.html
+++ b/docs/layer/trixie-minbase.html
@@ -123,8 +123,8 @@
     <div class="header">
         <h1>trixie-minbase</h1>
         <span class="badge">suite</span>
-        <span class="badge">v1.1.0</span>
-        <p>Debian Trixie with apt, utils, wired networking, ssh.</p>
+        <span class="badge">v2.0.0</span>
+        <p>Debian Trixie with apt, utils, wired and wifi networking, ssh.</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
@@ -139,6 +139,8 @@
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             <a href="openssh-server.html" class="dep-badge">openssh-server</a>
             <a href="systemd-timesyncd.html" class="dep-badge">systemd-timesyncd</a>
+            <a href="wireless-regulatory.html" class="dep-badge">wireless-regulatory</a>
+            <a href="iwd.html" class="dep-badge">iwd</a>
         </div>
     </div>
 

--- a/docs/layer/wireless-regulatory.html
+++ b/docs/layer/wireless-regulatory.html
@@ -128,6 +128,12 @@
     </div>
     <div class="section">
         <h2>Relationships</h2>
+        <p><strong>Required by:</strong></p>
+        <div class="deps">
+            
+            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
+            
+        </div>
         <p><strong>Provides:</strong> wireless-regdb</p>
     </div>
     <div class="section">

--- a/examples/custom_kernel/README.adoc
+++ b/examples/custom_kernel/README.adoc
@@ -35,7 +35,7 @@ Using podman, import the tarball to use as the container image.
 
 [source,bash]
 ----
-$ podman import ./work/build-vehicles/deb12-kbuild.tgz chroot:deb12-kbuild
+$ podman import ./work/build-vehicles/deb13-kbuild.tgz chroot:deb13-kbuild
 ----
 
 NOTE: It's possible to use other container managers instead of podman, e.g. docker.
@@ -46,7 +46,7 @@ Start the container, making the kernel source available to it.
 
 [source,bash]
 ----
-$ podman run -it --userns=keep-id -e HOME=/home/build -w /home/build --user build -v ./work/:/home/build/work chroot:deb12-kbuild /bin/bash -l
+$ podman run -it --userns=keep-id -e HOME=/home/build -w /home/build --user build -v ./work/:/home/build/work chroot:deb13-kbuild /bin/bash -l
 ----
 
 `--userns=keep-id`
@@ -107,7 +107,7 @@ logout
 ----
 $ podman ps -a
 CONTAINER ID  IMAGE                          COMMAND       CREATED         STATUS                         PORTS       NAMES
-b2de4ac17059  localhost/chroot:deb12-kbuild  /bin/bash -l  22 minutes ago  Exited (0) About a minute ago              infallible_leavitt
+b2de4ac17059  localhost/chroot:deb13-kbuild  /bin/bash -l  22 minutes ago  Exited (0) About a minute ago              infallible_leavitt
 
 $ podman start b2de4ac17059
 b2de4ac17059

--- a/examples/custom_kernel/config/kbuild.yaml
+++ b/examples/custom_kernel/config/kbuild.yaml
@@ -3,9 +3,10 @@ env:
 
 artefact:
   context: build-vehicles
-  target_name: deb12-kbuild.tgz
+  target_name: deb13-kbuild.tgz
 
 layer:
-  base: debian-bookworm-buildd
+  base: debian-trixie-buildd
+  lang: locale-base
   tools: kbuild-base
 

--- a/layer/app-i18n/locale-base.yaml
+++ b/layer/app-i18n/locale-base.yaml
@@ -1,0 +1,38 @@
+# METABEGIN
+# X-Env-Layer-Name: locale-base
+# X-Env-Layer-Category: i18n
+# X-Env-Layer-Desc: Pre-seeded locale and internationalisation settings
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Requires: locale-config
+# X-Env-Layer-Provides: locale-configured
+#
+# X-Env-VarRequires:
+#  IGconf_locale_timezone,
+#  IGconf_locale_default,
+#  IGconf_locale_keyboard_layout,
+#  IGconf_locale_keyboard_keymap
+#
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - console-setup
+  essential-hooks:
+    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
+        | chroot $1 debconf-set-selections
+    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
+        | chroot $1 debconf-set-selections
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
+        | chroot $1 debconf-set-selections
+    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
+        | chroot $1 debconf-set-selections
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
+        | chroot $1 debconf-set-selections
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
+        | chroot $1 debconf-set-selections
+    - |-
+      if grep -q 'VERSION_CODENAME=bookworm' "$1/etc/os-release" 2>/dev/null; then
+        printf "LANG=C.UTF-8\nLANGUAGE=C\n" > "$1/etc/default/locale"
+      else
+        printf "LANG=C.UTF-8\nLANGUAGE=C\n" > "$1/etc/locale.conf"
+      fi

--- a/layer/app-i18n/locale-gen.yaml
+++ b/layer/app-i18n/locale-gen.yaml
@@ -1,0 +1,12 @@
+# METABEGIN
+# X-Env-Layer-Name: locale-gen
+# X-Env-Layer-Category: i18n
+# X-Env-Layer-Desc: Installs and generates locales at build time
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-RequiresProvider: locale-configured
+# X-Env-Layer-Provides: locale-generated
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - locales

--- a/layer/base/core-essential.yaml
+++ b/layer/base/core-essential.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc:  Serves as the mandatory foundation for all rpi-image-gen
 #  builds, and is automatically included in every configuration to provide
 #  essential build infrastructure.
-# X-Env-Layer-Version: 1.1.0
-# X-Env-Layer-Requires: artefact-base,sys-build-base,target-config,locale-base
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Requires: artefact-base,sys-build-base,target-config
 # METAEND
 ---

--- a/layer/base/locale-config.yaml
+++ b/layer/base/locale-config.yaml
@@ -1,7 +1,7 @@
 # METABEGIN
-# X-Env-Layer-Name: locale-base
+# X-Env-Layer-Name: locale-config
 # X-Env-Layer-Category: foundation
-# X-Env-Layer-Desc: Default locale settings
+# X-Env-Layer-Desc: Localisation and Internationalisation config settings
 # X-Env-Layer-Version: 1.0.0
 #
 # X-Env-VarPrefix: locale

--- a/layer/debian/bookworm/arm64/base-apt-multi.yaml
+++ b/layer/debian/bookworm/arm64/base-apt-multi.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: debian-bookworm-arm64-multi
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Bookworm apt base for arm64 and armhf.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -19,20 +15,6 @@ mmdebstrap:
   suite: bookworm
   mirrors:
     - ${IGTOP}/templates/debian/apt/bookworm.sources
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/bookworm/arm64/base-apt.yaml
+++ b/layer/debian/bookworm/arm64/base-apt.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: debian-bookworm-arm64
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Bookworm apt base for arm64
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -19,20 +15,6 @@ mmdebstrap:
   suite: bookworm
   mirrors:
     - ${IGTOP}/templates/debian/apt/bookworm.sources
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/bookworm/arm64/base-slim.yaml
+++ b/layer/debian/bookworm/arm64/base-slim.yaml
@@ -3,13 +3,9 @@
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Bookworm custom layer for arm64 providing
 #  a usable and practical base.
-# X-Env-Layer-Version: 2.1.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -40,20 +36,6 @@ mmdebstrap:
   setup-hooks:
     - mkdir -p $1/bin
     - ln -s bash $1/bin/sh
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/bookworm/base-buildd.yaml
+++ b/layer/debian/bookworm/base-buildd.yaml
@@ -4,13 +4,9 @@
 # X-Env-Layer-Desc: Architecture agnostic Debian Bookworm buildd base.
 #  This provides a base layer specifically designed for automated package
 #  building and software compilation.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -19,17 +15,3 @@ mmdebstrap:
   suite: bookworm
   mirrors:
     - ${IGTOP}/templates/debian/apt/bookworm.sources
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale

--- a/layer/debian/bookworm/base-buildd.yaml
+++ b/layer/debian/bookworm/base-buildd.yaml
@@ -5,7 +5,7 @@
 #  This provides a base layer specifically designed for automated package
 #  building and software compilation.
 # X-Env-Layer-Version: 3.0.0
-# X-Env-Layer-Requires: locale-base
+# X-Env-Layer-Requires: locale-gen
 # X-Env-Layer-Provides: debian-base
 # METAEND
 ---

--- a/layer/debian/trixie/arm64/base-apt-multi.yaml
+++ b/layer/debian/trixie/arm64/base-apt-multi.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: debian-trixie-arm64-multi
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Trixie apt base for arm64 and armhf.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -21,20 +17,6 @@ mmdebstrap:
     - ${IGTOP}/templates/debian/apt/trixie.sources
   packages:
     - linux-sysctl-defaults
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/locale.conf
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/trixie/arm64/base-apt.yaml
+++ b/layer/debian/trixie/arm64/base-apt.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: debian-trixie-arm64
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Trixie apt base for arm64.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -21,20 +17,6 @@ mmdebstrap:
     - ${IGTOP}/templates/debian/apt/trixie.sources
   packages:
     - linux-sysctl-defaults
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/locale.conf
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/trixie/arm64/base-slim.yaml
+++ b/layer/debian/trixie/arm64/base-slim.yaml
@@ -3,13 +3,9 @@
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Debian Trixie custom layer for arm64 providing
 #  a usable and practical base.
-# X-Env-Layer-Version: 2.1.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -42,20 +38,6 @@ mmdebstrap:
   setup-hooks:
     - mkdir -p $1/usr/bin
     - ln -s bash $1/usr/bin/sh
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/locale.conf
   aptopts:
     - APT::Install-Suggests "false"
     - APT::Install-Recommends "false"

--- a/layer/debian/trixie/base-buildd.yaml
+++ b/layer/debian/trixie/base-buildd.yaml
@@ -4,13 +4,9 @@
 # X-Env-Layer-Desc: Architecture agnostic Debian Trixie buildd base.
 #  This provides a base layer specifically designed for automated package
 #  building and software compilation.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -19,17 +15,3 @@ mmdebstrap:
   suite: trixie
   mirrors:
     - ${IGTOP}/templates/debian/apt/trixie.sources
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale

--- a/layer/debian/trixie/base-buildd.yaml
+++ b/layer/debian/trixie/base-buildd.yaml
@@ -5,7 +5,7 @@
 #  This provides a base layer specifically designed for automated package
 #  building and software compilation.
 # X-Env-Layer-Version: 3.0.0
-# X-Env-Layer-Requires: locale-base
+# X-Env-Layer-Requires: locale-gen
 # X-Env-Layer-Provides: debian-base
 # METAEND
 ---

--- a/layer/raspbian/bookworm/base-apt.yaml
+++ b/layer/raspbian/bookworm/base-apt.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: raspbian-bookworm-armhf
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Raspbian Bookworm apt base for armhf.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -33,17 +29,3 @@ mmdebstrap:
     - path-exclude=/usr/share/lintian/*
   packages:
     - raspbian-archive-keyring
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/default/locale

--- a/layer/raspbian/trixie/base-apt.yaml
+++ b/layer/raspbian/trixie/base-apt.yaml
@@ -2,13 +2,9 @@
 # X-Env-Layer-Name: raspbian-trixie-armhf
 # X-Env-Layer-Category: distribution
 # X-Env-Layer-Desc: Raspbian Trixie apt base for armhf.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: locale-base
-#
-# X-Env-VarRequires: IGconf_locale_timezone,
-#  IGconf_locale_default,
-#  IGconf_locale_keyboard_layout,
-#  IGconf_locale_keyboard_keymap
+# X-Env-Layer-Provides: debian-base
 # METAEND
 ---
 mmdebstrap:
@@ -33,17 +29,3 @@ mmdebstrap:
     - path-exclude=/usr/share/lintian/*
   packages:
     - raspbian-archive-keyring
-  essential-hooks:
-    - echo tzdata tzdata/Areas select "${IGconf_locale_timezone%%/*}"
-        | chroot $1 debconf-set-selections
-    - echo tzdata tzdata/Zones/"${IGconf_locale_timezone%%/*}" select "${IGconf_locale_timezone#*/}"
-        | chroot $1 debconf-set-selections
-    - echo locales locales/locales_to_be_generated multiselect "$IGconf_locale_default" UTF-8
-        | chroot $1 debconf-set-selections
-    - echo locales locales/default_environment_locale select "$IGconf_locale_default"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_locale_keyboard_layout"
-        | chroot $1 debconf-set-selections
-    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_locale_keyboard_keymap"
-        | chroot $1 debconf-set-selections
-    - printf "LANG=C.UTF-8\nLANGUAGE=C\n" > $1/etc/locale.conf

--- a/templates/docs/html/index.html
+++ b/templates/docs/html/index.html
@@ -132,7 +132,7 @@
     <h2>Available Layers</h2>
     {% set categories = layers|groupby('category') %}
     {% for category, category_layers in categories %}
-    <h3>{{ category|title }}</h3>
+    <h3>{{ category }}</h3>
     <div class="layer-list">
         {% for layer in category_layers %}
         <div class="layer-item">

--- a/templates/docs/html/layer-index.html
+++ b/templates/docs/html/layer-index.html
@@ -141,7 +141,7 @@
     <h2>Available Layers</h2>
     {% set categories = layers|groupby('category') %}
     {% for category, category_layers in categories %}
-    <h3>{{ category|title }}</h3>
+    <h3>{{ category }}</h3>
     <div class="layer-list">
         {% for layer in category_layers %}
         <div class="layer-item">


### PR DESCRIPTION
- Rename layer/base/locale-base to locale-config (config defs only)
- New layers under `layer/app-i18n` - `locale-base` (debconf pre-seeding), `locale-gen` (installs and generates locales at build time for environments that require full locale support)
- Formalise the `debian-base` provider contract on all distribution base layers via `X-Env-Layer-Provides: debian-base`.
- Drop `locale-base` from `core-essential` (it's not a build infrastructure concern)
- Switch both buildd bases to use `locale-gen` - build environments run locale-sensitive tooling (so generated locales are safer).
- Doc updates
- examples - kbuild container updated to Trixie and with generated locales installed