### PR TITLE
wireless-regulatory: Add country code support

### DIFF
--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -1311,6 +1311,11 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
+            <a href="interactive-essential.html">interactive-essential</a><span class="layer-desc">- Essential packages for interactive systems. Provides
+ baseline tools expected on any interactive Debian-based system.</span>
+        </div>
+        
+        <div class="layer-item">
             <a href="locale-config.html">locale-config</a><span class="layer-desc">- Localisation and Internationalisation config settings</span>
         </div>
         

--- a/docs/layer/iwd.html
+++ b/docs/layer/iwd.html
@@ -127,6 +127,77 @@
         <p>iNet wireless daemon for wifi management</p>
     </div>
     <div class="section">
+        <h2>Additional Documentation</h2>
+        <div class="companion-content">
+            <div class="sect1">
+<h2 id="_build_time_wireless_profile">Build-time Wireless Profile</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><code>IGconf_iwd_profile</code> accepts a path to an iwd network profile file. The file is installed into <code>/var/lib/iwd/</code> preserving its filename and contents exactly. The filename must be identical to the network SSID. See <a href="https://manpages.debian.org/testing/iwd/iwd.network.5.en.html" target="_blank" rel="noopener">iwd.network(5)</a>.</p>
+</div>
+<div class="paragraph">
+<p>For example, a profile for a WPA2 network named <code>Pi Towers Guest</code>:</p>
+</div>
+<div class="listingblock">
+<div class="title">Pi Towers Guest.psk</div>
+<div class="content">
+<pre class="highlight"><code class="language-ini" data-lang="ini">[Security]
+Passphrase=&lt;passphrase&gt;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The profile file can be supplied via different mechanisms.</p>
+</div>
+<div class="sect2">
+<h3 id="_config_yaml_absolute_path">Config YAML (absolute path)</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">iwd:
+  profile: /path/to/Pi Towers Guest.psk</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_config_yaml_source_relative_path">Config YAML (source-relative path)</h3>
+<div class="paragraph">
+<p>Use the <code>${@SRCROOT}</code> <a href="https://raspberrypi.github.io/rpi-image-gen/config/index.html#_anchors" target="_blank" rel="noopener">anchor</a> to express the path relative to the source root (the directory passed via <code>rpi-image-gen -S</code>):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">iwd:
+  profile: ${@SRCROOT}/Pi Towers Guest.psk</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_command_line">Command line</h3>
+<div class="paragraph">
+<p>Pass the profile path as a build variable. Quote the value if the filename contains spaces:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ rpi-image-gen build -S ./examples/ota/ -c ota.yaml -- IGconf_iwd_profile='Pi Towers Guest.psk'</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+A bare filename is resolved relative to the source directory determined by <code>rpi-image-gen</code>. Use an absolute path or the <code>${@SRCROOT}</code> anchor to be explicit.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</div>
+
+        </div>
+    </div>
+    <div class="section">
         <h2>Relationships</h2>
         <p><strong>Required by:</strong></p>
         <div class="deps">

--- a/docs/layer/wireless-regulatory.html
+++ b/docs/layer/wireless-regulatory.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>wireless-regulatory</h1>
         <span class="badge">connectivity</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Wireless regulatory database</p>
     </div>
     <div class="section">
@@ -135,6 +135,37 @@
             
         </div>
         <p><strong>Provides:</strong> wireless-regdb</p>
+    </div>
+    <div class="section">
+        <h2>Configuration Variables</h2>
+        <p><strong>Declares</strong> (prefix: <code>ieee80211</code>):</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>Variable</th>
+                    <th>Description</th>
+                    <th>Default</th>
+                    <th>Validation</th>
+                    <th>Policy</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>IGconf_ieee80211_regdom</code></td>
+                    <td>ISO 3166-1 alpha-2 wireless country code definition
+ to set the Regulatory Domain global default. This will be written to
+ /etc/modprobe.d/cfg80211_regdomain.conf. Additional phy settings may be
+ required.</td>
+                    <td>
+                           <code>GB</code>
+                    </td>
+                    <td>Non-empty string value</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>

--- a/layer/net-wireless/iwd-systemd.adoc
+++ b/layer/net-wireless/iwd-systemd.adoc
@@ -1,0 +1,45 @@
+= iwd (iNet wireless daemon)
+
+== Build-time Wireless Profile
+
+`IGconf_iwd_profile` accepts a path to an iwd network profile file. The file is installed into `/var/lib/iwd/` preserving its filename and contents exactly. The filename must be identical to the network SSID. See https://manpages.debian.org/testing/iwd/iwd.network.5.en.html[iwd.network(5),window=_blank].
+
+For example, a profile for a WPA2 network named `Pi Towers Guest`:
+
+.Pi Towers Guest.psk
+[source,ini]
+----
+[Security]
+Passphrase=<passphrase>
+----
+
+The profile file can be supplied via different mechanisms.
+
+=== Config YAML (absolute path)
+
+[source,yaml]
+----
+iwd:
+  profile: /path/to/Pi Towers Guest.psk
+----
+
+=== Config YAML (source-relative path)
+
+Use the `${@SRCROOT}` https://raspberrypi.github.io/rpi-image-gen/config/index.html#_anchors[anchor,window=_blank] to express the path relative to the source root (the directory passed via `rpi-image-gen -S`):
+
+[source,yaml]
+----
+iwd:
+  profile: ${@SRCROOT}/Pi Towers Guest.psk
+----
+
+=== Command line
+
+Pass the profile path as a build variable. Quote the value if the filename contains spaces:
+
+[source,bash]
+----
+$ rpi-image-gen build -S ./examples/ota/ -c ota.yaml -- IGconf_iwd_profile='Pi Towers Guest.psk'
+----
+
+NOTE: A bare filename is resolved relative to the source directory determined by `rpi-image-gen`. Use an absolute path or the `${@SRCROOT}` anchor to be explicit.

--- a/layer/net-wireless/regulatory.yaml
+++ b/layer/net-wireless/regulatory.yaml
@@ -2,10 +2,24 @@
 # X-Env-Layer-Name: wireless-regulatory
 # X-Env-Layer-Category: connectivity
 # X-Env-Layer-Desc: Wireless regulatory database
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Provides: wireless-regdb
+#
+# X-Env-VarPrefix: ieee80211
+#
+# X-Env-Var-regdom: GB
+# X-Env-Var-regdom-Desc: ISO 3166-1 alpha-2 wireless country code definition
+#  to set the Regulatory Domain global default. This will be written to
+#  /etc/modprobe.d/cfg80211_regdomain.conf. Additional phy settings may be
+#  required.
+# X-Env-Var-regdom-Required: n
+# X-Env-Var-regdom-Valid: string
+# X-Env-Var-regdom-Set: y
+#
 # METAEND
 ---
 mmdebstrap:
   packages:
     - wireless-regdb
+  customize-hooks:
+    - echo "options cfg80211 ieee80211_regdom=${IGconf_ieee80211_regdom}" > $1/etc/modprobe.d/cfg80211_regdomain.conf


### PR DESCRIPTION
Add a config var for setting Regulatory Domain global default via the linux 80211 stack.
Refs #212