### PR TITLE
layer: Add new Trixe base layer for interactive systems

### DIFF
--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -1274,6 +1274,11 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
+            <a href="debian-trixie-arm64-multi-minbase.html">debian-trixie-arm64-multi-minbase</a><span class="layer-desc">- Debian Trixie multi-arch base for interactive systems.
+ No apt or dpkg restrictions - recommended packages are preser...</span>
+        </div>
+        
+        <div class="layer-item">
             <a href="debian-trixie-arm64-slim.html">debian-trixie-arm64-slim</a><span class="layer-desc">- Debian Trixie custom layer for arm64 providing
  a usable and practical base.</span>
         </div>
@@ -1308,11 +1313,6 @@ IGconf_layer_app=my-app</code></pre>
         <div class="layer-item">
             <a href="essential.html">essential</a><span class="layer-desc">- Serves as the mandatory foundation for all rpi-image-gen
  builds, and is automatically included in every configuratio...</span>
-        </div>
-        
-        <div class="layer-item">
-            <a href="interactive-essential.html">interactive-essential</a><span class="layer-desc">- Essential packages for interactive systems. Provides
- baseline tools expected on any interactive Debian-based system.</span>
         </div>
         
         <div class="layer-item">

--- a/docs/layer/locale-base.html
+++ b/docs/layer/locale-base.html
@@ -145,6 +145,8 @@
             
             <a href="debian-trixie-arm64-multi.html" class="dep-badge">debian-trixie-arm64-multi</a>
             
+            <a href="debian-trixie-arm64-multi-minbase.html" class="dep-badge">debian-trixie-arm64-multi-minbase</a>
+            
             <a href="debian-trixie-arm64-slim.html" class="dep-badge">debian-trixie-arm64-slim</a>
             
             <a href="raspbian-bookworm-armhf.html" class="dep-badge">raspbian-bookworm-armhf</a>

--- a/docs/layer/locale-gen.html
+++ b/docs/layer/locale-gen.html
@@ -133,6 +133,8 @@
             
             <a href="debian-bookworm-buildd.html" class="dep-badge">debian-bookworm-buildd</a>
             
+            <a href="debian-trixie-arm64-multi-minbase.html" class="dep-badge">debian-trixie-arm64-multi-minbase</a>
+            
             <a href="debian-trixie-buildd.html" class="dep-badge">debian-trixie-buildd</a>
             
         </div>

--- a/layer/debian/trixie/arm64/base-minbase-multi.yaml
+++ b/layer/debian/trixie/arm64/base-minbase-multi.yaml
@@ -1,0 +1,19 @@
+# METABEGIN
+# X-Env-Layer-Name: debian-trixie-arm64-multi-minbase
+# X-Env-Layer-Category: distribution
+# X-Env-Layer-Desc: Debian Trixie multi-arch base for interactive systems.
+#  No apt or dpkg restrictions - recommended packages are preserved, locale
+#  generated.
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: locale-base,locale-gen
+# X-Env-Layer-Provides: debian-base
+# METAEND
+---
+mmdebstrap:
+  architectures:
+    - arm64 armhf
+  mode: auto
+  variant: minbase
+  suite: trixie
+  mirrors:
+    - ${IGTOP}/templates/debian/apt/trixie.sources


### PR DESCRIPTION
debian-trixie-arm64-multi-minbase provides a base system composed of minbase plus generated locale data and no dpkg or apt opts. Recommended packages will be installed by default.