### PR TITLE
image-rota: slot-shared-generator must create symlinks

### DIFF
--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
@@ -55,3 +55,7 @@ WantedBy=local-fs.target
 EOF
     done
 done
+
+   # Create .wants symlinks for local-fs.target
+   mkdir -p "${OUT_DIR}/local-fs.target.wants"
+   ln -sf "${OUT_DIR}/${unit_name}" "${OUT_DIR}/local-fs.target.wants/${unit_name}"


### PR DESCRIPTION
The [Install] WantedBy= in generator output isn't processed by systemd automatically. Generators must write their own .wants symlinks otherwise the unit file exists (written by the generator) but never started.

Resolves #257