### PR TITLE
Initial groundwork for multi-version layer support

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -192,10 +192,11 @@ apply_layer_overlays() {
    local plan=${PLAN:-}
    [[ -n $plan && -f $plan ]] || return 0
 
-   local layer version static resolved overlay
+   local layer version static resolved overlay major minor patch
    while IFS=: read -r layer version static resolved; do
       [[ -n $layer && -n $static ]] || continue
       [[ $layer == \#* ]] && continue
+      IFS='.' read -r major minor patch <<< "$version"
       overlay="${static%.yaml}.rootfs-overlay"
       if [[ -d $overlay ]]; then
          msg "runner: layer overlay ($layer) [$overlay -> $dest]"

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -104,8 +104,8 @@ def main():
             msgs = "\n".join(f"{k}: {v}" for k, v in manager.load_errors.items())
             raise SystemExit(f"Aborting docs generation due to layer load errors:\n{msgs}")
 
-        # All layer names
-        layer_names = sorted(manager.layers.keys())
+        # All layer names - resolves to latest version per name
+        layer_names = sorted(manager._name_to_versions.keys())
 
         # Do it
         layer_template = env.get_template('layer.html')

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -109,7 +109,7 @@ Generators that use `argparse` or `getopt` should parse from `argv[3:]`, as `arg
 
 `X-Env-Layer-Category`: Categorisation (device, image, etc.)
 
-`X-Env-Layer-Version`: Version identifier for the layer
+`X-Env-Layer-Version`: Layer version in `major.minor.patch` format (all components must be non-negative integers with no leading zeros)
 
 `X-Env-Layer-Requires`: Comma-separated list of required layers
 

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -398,7 +398,7 @@ mmdebstrap:
 <p><code>X-Env-Layer-Category</code>: Categorisation (device, image, etc.)</p>
 </div>
 <div class="paragraph">
-<p><code>X-Env-Layer-Version</code>: Version identifier for the layer</p>
+<p><code>X-Env-Layer-Version</code>: Layer version in <code>major.minor.patch</code> format (all components must be non-negative integers with no leading zeros)</p>
 </div>
 <div class="paragraph">
 <p><code>X-Env-Layer-Requires</code>: Comma-separated list of required layers</p>

--- a/examples/container_chroot/layer/build-tools.yaml
+++ b/examples/container_chroot/layer/build-tools.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: build-tools
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Native development tools to support pkg download and build
 #  using autotools in a bash shell.

--- a/examples/debstore/layer/debstore-installer.yaml
+++ b/examples/debstore/layer/debstore-installer.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: example-debstore
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer showing how to install local Debian
 #  packages into the chroot.

--- a/examples/ota/layer/ota.yaml
+++ b/examples/ota/layer/ota.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: example-ota
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer that can be remotely deployed and updated by
 #  Raspberry Pi Connect.

--- a/examples/slim/layer/slim-customisations.yaml
+++ b/examples/slim/layer/slim-customisations.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: example-slim-customisation
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer with dependency plus some customisation
 #  hooks.

--- a/examples/slim/layer/slim.yaml
+++ b/examples/slim/layer/slim.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: v8-svelte
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer that provides a thin base using
 #  other layers.

--- a/examples/webkiosk/layer/mykiosk.yaml
+++ b/examples/webkiosk/layer/mykiosk.yaml
@@ -1,5 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: example-kiosk
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example webkiosk layer showing how to define configuration
 #  variables, declare packages and create a start up script. We depend on the

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -43,11 +43,12 @@ class LayerManager:
         self.search_roots = self._build_search_roots(search_paths)
         self.search_paths = [root.path for root in self.search_roots]
         self.file_patterns = file_patterns
-        self.layers: Dict[str, Metadata] = {}  # layer_name -> Metadata object
-        self.layer_files: Dict[str, str] = {}  # layer_name -> file_path (resolved; may be tmpfs for dynamic)
-        self.layer_source_files: Dict[str, str] = {}  # layer_name -> original source file path (never updated)
-        self.layer_tags: Dict[str, str] = {}  # layer_name -> search path tag
-        self.layer_relpaths: Dict[str, str] = {}  # layer_name -> relative path under tagged root
+        self.layers: Dict[Tuple[str, str], Metadata] = {}  # (layer_name, version) -> Metadata object
+        self.layer_files: Dict[Tuple[str, str], str] = {}  # (layer_name, version) -> file_path (resolved; may be tmpfs for dynamic)
+        self.layer_source_files: Dict[Tuple[str, str], str] = {}  # (layer_name, version) -> original source file path (never updated)
+        self.layer_tags: Dict[Tuple[str, str], str] = {}  # (layer_name, version) -> search path tag
+        self.layer_relpaths: Dict[Tuple[str, str], str] = {}  # (layer_name, version) -> relative path under tagged root
+        self._name_to_versions: Dict[str, List[str]] = {}  # layer_name -> list of loaded version strings
         self.tag_to_path: Dict[str, Path] = {root.tag: root.path for root in self.search_roots}
         self.show_loaded = show_loaded
         self.doc_mode = doc_mode  # Relaxed loader, eg does not run generators for dynamic layers
@@ -57,7 +58,7 @@ class LayerManager:
         self.provider_conflicts: Dict[str, Set[str]] = {}
         self.generated_root: Optional[Path] = None
         self.load_errors: Dict[str, str] = {}
-        self.pending_generators: Dict[str, tuple] = {}  # layer_name -> (cmd, input, output)
+        self.pending_generators: Dict[Tuple[str, str], tuple] = {}  # (layer_name, version) -> (cmd, input, output)
 
         for path in self.search_paths:
             if not path.exists():
@@ -124,9 +125,21 @@ class LayerManager:
         return roots
 
 
+    def _latest_version(self, name: str) -> Optional[str]:
+        """Return the latest loaded version string for a layer name, or None if not loaded."""
+        versions = self._name_to_versions.get(name)
+        if not versions:
+            return None
+        return max(versions, key=lambda v: tuple(int(x) for x in v.split('.')))
+
+    def _resolve_key(self, name: str) -> Optional[Tuple[str, str]]:
+        """Resolve a layer name to its (name, version) registry key using the latest version."""
+        v = self._latest_version(name)
+        return (name, v) if v is not None else None
+
     def _build_provider_index(self):
         """Index providers to unique layer names"""
-        for lname, layer in self.layers.items():
+        for (lname, _version), layer in self.layers.items():
             info = layer.get_layer_info()
             if not info:
                 continue
@@ -201,6 +214,8 @@ class LayerManager:
                 generator_cmd = (layer_info.get('generator') or '').strip()
 
                 layer_name = layer_info['name']
+                version = layer_info.get('version', '1.0.0')
+                key = (layer_name, version)
 
                 # lint on load
                 lint_results = meta.lint_metadata_syntax()
@@ -218,11 +233,11 @@ class LayerManager:
                     )
                     continue
 
-                # Duplicate detection
-                if layer_name in self.layers:
-                    prev_path = self.layer_files[layer_name]
+                # Duplicate detection: same name AND same version is a clash
+                if key in self.layers:
+                    prev_path = self.layer_files[key]
                     raise ValueError(
-                        f"Duplicate layer name '{layer_name}' found in:\n  {prev_path}\n  {abs_file}"
+                        f"Duplicate layer '{layer_name}' version {version} found in:\n  {prev_path}\n  {abs_file}"
                     )
 
                 if layer_type == 'dynamic':
@@ -241,7 +256,7 @@ class LayerManager:
                         output_file = generated_root / rel_path
                         output_file.parent.mkdir(parents=True, exist_ok=True)
                         # Generators are deferred so they only run for layers in the build stack
-                        self.pending_generators[layer_name] = (generator_cmd, abs_file, output_file)
+                        self.pending_generators[key] = (generator_cmd, abs_file, output_file)
                         tag = 'DYNlayer' # implicitly hard wired
                 else:
                     tag = root.tag
@@ -250,16 +265,17 @@ class LayerManager:
                     except ValueError:
                         rel_path = abs_file
 
-                self.layers[layer_name] = meta
-                self.layer_files[layer_name] = str(abs_file)
-                self.layer_source_files[layer_name] = str(abs_file)
-                self.layer_tags[layer_name] = tag
-                self.layer_relpaths[layer_name] = str(rel_path)
+                self.layers[key] = meta
+                self.layer_files[key] = str(abs_file)
+                self.layer_source_files[key] = str(abs_file)
+                self.layer_tags[key] = tag
+                self.layer_relpaths[key] = str(rel_path)
+                self._name_to_versions.setdefault(layer_name, []).append(version)
                 loaded_layers.add(layer_name)
 
                 if self.show_loaded:
                     relative_path = rel_path
-                    log_info(f"Loaded layer: {layer_name} from {relative_path}")
+                    log_info(f"Loaded layer: {layer_name} ({version}) from {relative_path}")
 
     def _ensure_generated_root(self) -> Path:
         if self.generated_root is not None:
@@ -275,12 +291,18 @@ class LayerManager:
 
     def run_generators_for_layers(self, layer_names: List[str]) -> None:
         """Run deferred generators for layers in the given build order."""
+        # NOTE: _resolve_key returns the *latest* loaded version of a layer.
+        # pending_generators is keyed by the exact (name, version) from load time.
+        # Once the build order carries explicit version information (planned), this
+        # should use that version directly rather than resolving to latest, otherwise
+        # a non-latest dynamic layer in the build order would silently skip its generator.
         for layer_name in layer_names:
-            if layer_name not in self.pending_generators:
+            key = self._resolve_key(layer_name)
+            if key is None or key not in self.pending_generators:
                 continue
-            generator_cmd, input_path, output_path = self.pending_generators.pop(layer_name)
+            generator_cmd, input_path, output_path = self.pending_generators.pop(key)
             self._run_layer_generator(layer_name, generator_cmd, input_path, output_path)
-            self.layer_files[layer_name] = str(output_path.resolve())
+            self.layer_files[key] = str(output_path.resolve())
 
     def _run_layer_generator(self, layer_name: str, generator_cmd: str, input_path: Path, output_path: Path) -> None:
         cmd = shlex.split(generator_cmd) # supports positional args
@@ -301,13 +323,17 @@ class LayerManager:
             raise ValueError(f"Generator '{generator_cmd}' for layer '{layer_name}' failed with exit code {exc.returncode}") from exc
 
     def get_layer_info(self, layer_name: str) -> Optional[dict]:
-        if layer_name not in self.layers:
+        key = self._resolve_key(layer_name)
+        if key is None:
             return None
-        return self.layers[layer_name].get_layer_info()
+        return self.layers[key].get_layer_info()
 
     def get_layer_relative_spec(self, layer_name: str) -> Optional[str]:
-        tag = self.layer_tags.get(layer_name)
-        rel_path = self.layer_relpaths.get(layer_name)
+        key = self._resolve_key(layer_name)
+        if key is None:
+            return None
+        tag = self.layer_tags.get(key)
+        rel_path = self.layer_relpaths.get(key)
         if tag and rel_path is not None:
             return f"{tag}:{rel_path}"
         return None
@@ -329,14 +355,14 @@ class LayerManager:
             return []
 
         # Search through all loaded layers
-        for layer_name, layer_obj in self.layers.items():
+        for (lname, _version), layer_obj in self.layers.items():
             layer_info = layer_obj.get_layer_info()
             if layer_info and layer_info.get('depends'):
                 # Check if target layer is in this layer's dependencies
                 if resolved_target in layer_info['depends']:
-                    reverse_deps.append(layer_name)
+                    reverse_deps.append(lname)
 
-        return sorted(reverse_deps)
+        return sorted(set(reverse_deps))
 
     def get_optional_dependencies(self, layer_name: str) -> List[str]:
         """Get optional deps"""
@@ -348,7 +374,7 @@ class LayerManager:
         if visited is None:
             visited = set()
 
-        if layer_name in visited or layer_name not in self.layers:
+        if layer_name in visited or layer_name not in self._name_to_versions:
             return []
 
         visited.add(layer_name)
@@ -366,7 +392,7 @@ class LayerManager:
         # Add optional dependencies if requested and they exist
         if include_optional:
             for opt_dep in self.get_optional_dependencies(layer_name):
-                if opt_dep in self.layers and opt_dep not in all_deps:
+                if opt_dep in self._name_to_versions and opt_dep not in all_deps:
                     all_deps.append(opt_dep)
                     # Add transitive dependencies of optional dependencies
                     for trans_dep in self.get_all_dependencies(opt_dep, visited.copy(), include_optional):
@@ -377,7 +403,7 @@ class LayerManager:
 
     def check_dependencies(self, layer_name: str) -> Tuple[bool, List[str]]:
         """Check if all dependencies for a layer are available"""
-        if layer_name not in self.layers:
+        if layer_name not in self._name_to_versions:
             return False, [f"Layer '{layer_name}' not found in search paths"]
 
         missing_deps = []
@@ -386,13 +412,13 @@ class LayerManager:
         # Check required dependencies
         required_deps = self.get_all_dependencies(layer_name, include_optional=False)
         for dep in required_deps:
-            if dep not in self.layers:
+            if dep not in self._name_to_versions:
                 missing_deps.append(f"Layer '{layer_name}' missing required dependency: {dep}")
 
         # Check optional dependencies separately - these generate warnings only
         optional_deps = self.get_optional_dependencies(layer_name)
         for opt_dep in optional_deps:
-            if opt_dep not in self.layers:
+            if opt_dep not in self._name_to_versions:
                 warnings.append(f"Optional dependency not available: {opt_dep}")
 
         # Check for circular dependencies
@@ -423,7 +449,7 @@ class LayerManager:
         if layer_name in path:
             return path + [layer_name]  # Found cycle
 
-        if layer_name not in self.layers:
+        if layer_name not in self._name_to_versions:
             return []
 
         path = path + [layer_name]
@@ -449,7 +475,7 @@ class LayerManager:
                 return
             checked.add(layer_name)
 
-            if layer_name not in self.layers:
+            if layer_name not in self._name_to_versions:
                 if layer_name in self.load_errors:
                     raise ValueError(f"Layer '{layer_name}' unavailable: {self.load_errors[layer_name]}")
                 raise ValueError(f"Missing required dependency: {layer_name}")
@@ -468,7 +494,7 @@ class LayerManager:
 
             # Add optional dependencies if they exist and are available
             for opt_dep in self.get_optional_dependencies(layer_name):
-                if opt_dep in self.layers:
+                if opt_dep in self._name_to_versions:
                     add_layer_and_deps(opt_dep)
 
             if layer_name not in processed:
@@ -529,9 +555,9 @@ class LayerManager:
         except (FileNotFoundError, yaml.YAMLError, UnicodeDecodeError):
             return None
 
-    def _get_mmdebstrap_config(self, layer_name: str) -> Optional[dict]:
+    def _get_mmdebstrap_config(self, layer_name: str, key=None) -> Optional[dict]:
         """Get mmdebstrap configuration if present """
-        layer_path = self.layer_files.get(layer_name)
+        layer_path = self.layer_files.get(key if key is not None else self._resolve_key(layer_name))
         if not layer_path:
             return None
 
@@ -547,7 +573,7 @@ class LayerManager:
 
     def _get_env_config(self, layer_name: str) -> Optional[dict]:
         """Get env configuration if present """
-        layer_path = self.layer_files.get(layer_name)
+        layer_path = self.layer_files.get(self._resolve_key(layer_name))
         if not layer_path:
             return None
 
@@ -563,12 +589,13 @@ class LayerManager:
 
     def validate_layer(self, layer_name: str, silent: bool = False) -> bool:
         """Validate one layer schema (independent of env/value resolution)."""
-        if layer_name not in self.layers:
+        key = self._resolve_key(layer_name)
+        if key is None:
             if not silent:
                 log_error(f"Layer '{layer_name}' not found")
             return False
 
-        layer = self.layers[layer_name]
+        layer = self.layers[key]
         layer_valid = True
 
         # Validate layer schema first (independent of env/value resolution).
@@ -586,49 +613,55 @@ class LayerManager:
 
         BOLD = "\033[1m"
         RESET = "\033[0m"
-        MAX_DESC = 60
+        LABEL_W = 20  # max width of widest attr desc + 2
 
-        # Build category -> [layer_names]
+        # Build category -> [layer_name]
         categories: Dict[str, List[str]] = {}
-        for lname in self.layers.keys():
+        for (lname, _version) in self.layers.keys():
             info = self.get_layer_info(lname)
             if not info:
                 continue
             cat = info.get('category', 'general')
-            categories.setdefault(cat, []).append(lname)
-
-        # Compute widest layer name for column alignment
-        all_layer_names = [n for lst in categories.values() for n in lst]
-        name_width = max(len(n) for n in all_layer_names) if all_layer_names else 0
+            if lname not in categories.get(cat, []):
+                categories.setdefault(cat, []).append(lname)
 
         print("Available layers:")
 
         for cat in sorted(categories.keys()):
-            print(f"{BOLD}Category: {cat}{RESET}")
+            print(f"\n{BOLD}Category: {cat}{RESET}")
 
             for layer_name in sorted(categories[cat]):
                 layer_info = self.get_layer_info(layer_name)
                 if not layer_info:
                     continue
 
-                # Description trimming
-                raw_desc = (layer_info.get('description') or '')
-                desc = ' '.join(raw_desc.split())
-                if len(desc) > MAX_DESC:
-                    desc = desc[: MAX_DESC - 3] + '...'
+                print(f"\n  {BOLD}{layer_name}{RESET}")
 
-                # Bold layer name column
-                print(f"  {BOLD}{layer_name:<{name_width}}{RESET}  {desc}")
+                ver_str = self._fmt_versions(layer_name)
+                print(f"    {'Available versions:':<{LABEL_W}}{ver_str}")
 
-                # Dependencies line
+                raw_desc = ' '.join((layer_info.get('description') or '').split())
+                print(f"    {'Description:':<{LABEL_W}}{raw_desc}")
+
                 deps = ', '.join(layer_info['depends']) if layer_info['depends'] else 'none'
-                print(f"    deps: {deps}")
+                print(f"    {'Deps:':<{LABEL_W}}{deps}")
 
-                # Capability info
                 provides = ', '.join(layer_info.get('provides', [])) or 'none'
+                print(f"    {'Provides:':<{LABEL_W}}{provides}")
+
                 reqprov = ', '.join(layer_info.get('provider_requires', [])) or 'none'
-                print(f"    provides: {provides}")
-                print(f"    requires-provider: {reqprov}")
+                print(f"    {'Requires-provider:':<{LABEL_W}}{reqprov}")
+
+    def _fmt_versions(self, name: str) -> str:
+        """Format the version list for a layer name: single version plain, multiple as '1.0.0  2.0.0*'."""
+        versions = self._name_to_versions.get(name, [])
+        if not versions:
+            return ""
+        latest = self._latest_version(name)
+        sorted_versions = sorted(versions, key=lambda v: tuple(int(x) for x in v.split('.')))
+        if len(sorted_versions) == 1:
+            return sorted_versions[0]
+        return "  ".join(v + ("*" if v == latest else "") for v in sorted_versions)
 
     def show_search_paths(self):
         print("Layer search paths:")
@@ -639,7 +672,7 @@ class LayerManager:
 
     def resolve_layer_name(self, layer_identifier: str) -> Optional[str]:
         # Direct layer name lookup
-        if layer_identifier in self.layers:
+        if layer_identifier in self._name_to_versions:
             return layer_identifier
 
         # Known load error for this identifier
@@ -647,9 +680,9 @@ class LayerManager:
             raise ValueError(self.load_errors[layer_identifier])
 
         # File path lookup for already loaded layers
-        for layer_name, file_path in self.layer_files.items():
+        for (lname, _version), file_path in self.layer_files.items():
             if Path(file_path).resolve() == Path(layer_identifier).resolve():
-                return layer_name
+                return lname
 
         # Load error recorded by path
         rel_id = Path(layer_identifier).name
@@ -658,8 +691,8 @@ class LayerManager:
 
         return None
 
-    def _get_overlays(self, layer_name: str) -> list:
-        layer_path = self.layer_files.get(layer_name)
+    def _get_overlays(self, layer_name: str, key=None) -> list:
+        layer_path = self.layer_files.get(key if key is not None else self._resolve_key(layer_name))
         if not layer_path:
             return []
         layer_dir = Path(layer_path).parent
@@ -675,10 +708,11 @@ class LayerManager:
 
     def get_layer_documentation_data(self, layer_name: str):
         """Extract structured layer data for documentation generation"""
-        if layer_name not in self.layers:
+        key = self._resolve_key(layer_name)
+        if key is None:
             return None
 
-        layer = self.layers[layer_name]
+        layer = self.layers[key]
 
         # Get detailed variable information from validators
         variables = {}
@@ -726,7 +760,7 @@ class LayerManager:
         env_config = self._get_env_config(layer_name) or {}
 
         # Make file path relative to search paths
-        file_path = self.layer_files.get(layer_name)
+        file_path = self.layer_files.get(key)
         relative_path = file_path
         if file_path:
             for search_path in self.search_paths:
@@ -775,10 +809,11 @@ class LayerManager:
         }
 
     def _get_companion_doc(self, layer_name: str, format: str = 'markdown') -> str:
-        if layer_name not in self.layer_files:
+        key = self._resolve_key(layer_name)
+        if key is None or key not in self.layer_files:
             return ""
 
-        yaml_file_path = self.layer_files[layer_name]
+        yaml_file_path = self.layer_files[key]
 
         # Convert .yaml/.yml extension to appropriate format extension
         from pathlib import Path
@@ -806,10 +841,11 @@ class LayerManager:
 
     def _get_raw_metadata_fields(self, layer_name: str) -> dict:
         """Get all raw (unexpanded) metadata field values from the layer file."""
-        if layer_name not in self.layer_files:
+        key = self._resolve_key(layer_name)
+        if key is None or key not in self.layer_files:
             return {}
 
-        file_path = self.layer_files[layer_name]
+        file_path = self.layer_files[key]
         raw_fields = {}
 
         try:
@@ -950,8 +986,8 @@ def LayerManager_register_parser(subparsers, root=None):
                        help='File patterns to search (default: *.yaml *.yml)')
     parser.add_argument('--list', '-l', action='store_true',
                        help='List all available layers')
-    parser.add_argument('--describe', metavar='LAYER',
-                       help='Show detailed information for a layer (use layer name)')
+    parser.add_argument('--describe', metavar='LAYER[=VERSION]',
+                       help='Show detailed information for a layer, append =VERSION to pin a specific version')
     parser.add_argument('--rdep', '--reverse-deps', metavar='LAYER',
                        help='Show layers that depend on the specified layer')
     parser.add_argument('--show-paths', action='store_true',
@@ -1017,12 +1053,29 @@ def _layer_main(args):
             print(f"{len(reverse_deps)} layer(s) depend on '{layer_name}'")
 
     if args.describe:
-        layer_name = manager.resolve_layer_name(args.describe)
+        describe_arg = args.describe
+        pinned_version = None
+        if '=' in describe_arg:
+            describe_arg, pinned_version = describe_arg.split('=', 1)
+
+        layer_name = manager.resolve_layer_name(describe_arg)
         if not layer_name:
-            print(f"✗ Layer '{args.describe}' not found")
+            print(f"✗ Layer '{describe_arg}' not found")
             exit(1)
 
-        layer_info = manager.get_layer_info(layer_name)
+        if pinned_version is not None:
+            lkey = (layer_name, pinned_version)
+            if lkey not in manager.layers:
+                available = ', '.join(
+                    sorted(manager._name_to_versions.get(layer_name, []),
+                           key=lambda v: tuple(int(x) for x in v.split('.')))
+                )
+                print(f"✗ Layer '{layer_name}' version '{pinned_version}' not found (available: {available})")
+                exit(1)
+        else:
+            lkey = manager._resolve_key(layer_name)
+
+        layer_info = manager.layers[lkey].get_layer_info() if lkey else None
         if layer_info:
             print(f"Layer: {layer_info['name']}")
             print(f"Version: {layer_info['version']}")
@@ -1040,14 +1093,14 @@ def _layer_main(args):
                 requires_list = ', '.join(layer_info['provider_requires'])
                 print(f"Requires Provider: {requires_list}")
 
-            layer_path = manager.layer_files.get(layer_name, "<unknown>")
-            rel_layer_path = manager.layer_relpaths.get(layer_name, layer_path)
+            layer_path = manager.layer_files.get(lkey, "<unknown>")
+            rel_layer_path = manager.layer_relpaths.get(lkey, layer_path)
             print(f"Path: {rel_layer_path}")
-            overlays = manager._get_overlays(layer_name)
+            overlays = manager._get_overlays(layer_name, key=lkey)
             if overlays:
                 print(f"Overlay: {', '.join(overlays)}")
 
-            mmdebstrap = manager._get_mmdebstrap_config(layer_name)
+            mmdebstrap = manager._get_mmdebstrap_config(layer_name, key=lkey)
             if mmdebstrap:
                 for field in ('suite', 'variant', 'mode'):
                     if field in mmdebstrap:
@@ -1056,31 +1109,28 @@ def _layer_main(args):
             if layer_info['depends']:
                 print("Depends:")
 
-                def _show_deps(dep_layer: str, seen: set[str], indent: int = 1):
+                def _show_deps(deps: List[str], seen: set, indent: int = 1):
                     pad = "  " * indent
-                    for dep in manager.get_dependencies(dep_layer):
-                        # guard against cycles / duplicates
+                    for dep in deps:
                         if dep in seen:
                             print(f"{pad}- {dep} (already shown)")
                             continue
                         seen.add(dep)
-
-                        dep_path = manager.layer_files.get(dep, "<unknown>")
-                        rel_path = manager.layer_relpaths.get(dep, dep_path)
+                        _dkey = manager._resolve_key(dep)
+                        dep_path = manager.layer_files.get(_dkey, "<unknown>")
+                        rel_path = manager.layer_relpaths.get(_dkey, dep_path)
                         print(f"{pad}- {dep}: {rel_path}")
+                        _show_deps(manager.get_dependencies(dep), seen, indent + 1)
 
-                        # recurse into dependencies of this dependency
-                        _show_deps(dep, seen, indent + 1)
+                _show_deps(layer_info['depends'], set())
 
-                _show_deps(layer_name, set())
             if layer_info['optional_depends']:
                 print(f"Optional-Depends: {', '.join(layer_info['optional_depends'])}")
+
             if layer_info['conflicts']:
                 print(f"Conflicts: {', '.join(layer_info['conflicts'])}")
 
-            # Show mmdebstrap configuration if any
-            # TODO can extend for other maps
-            mmdebstrap_config = manager._get_mmdebstrap_config(layer_name)
+            mmdebstrap_config = manager._get_mmdebstrap_config(layer_name, key=lkey)
             if mmdebstrap_config:
                 print()
 
@@ -1095,10 +1145,7 @@ def _layer_main(args):
                     for package in packages:
                         print(f"  - {package}")
 
-            # Print environment variables for this layer
-            meta_obj = manager.layers.get(layer_name)
+            meta_obj = manager.layers.get(lkey)
             if meta_obj and meta_obj.get_all_env_vars():
                 print()
                 print_env_var_descriptions(meta_obj, indent=2)
-
-    # build-order CLI removed; layer commands are read-only.

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import argparse
 import yaml
@@ -782,7 +783,7 @@ class Metadata:
         """Lint metadata using schema-only checks (no environment dependence)."""
         results = {}
 
-        # 0) Require at least some X-Env-* fields; otherwise treat as lint error
+        # Require at least some X-Env-* fields; otherwise treat as lint error
         raw_meta = getattr(self._container, "raw_metadata", {}) if hasattr(self, "_container") else {}
         if not raw_meta:
             results["NO_METADATA_FIELDS"] = self._result_builder.build_result(
@@ -803,10 +804,10 @@ class Metadata:
             )
             return results
 
-        # 1) Schema errors (unsupported fields, etc.)
+        # Schema errors (unsupported fields, etc.)
         results.update(self._collect_schema_errors())
 
-        # 2) Missing layer name if any X-Env-Layer-* is present
+        # Missing layer name / version if any X-Env-Layer-* is present
         has_layer_fields = any(k.startswith("X-Env-Layer-") for k in raw_meta.keys())
         if has_layer_fields and not raw_meta.get(XEnv.layer_name()):
             results["MISSING_LAYER_NAME"] = {
@@ -815,17 +816,35 @@ class Metadata:
                 "required": True,
                 "message": f"{self.filepath}: X-Env-Layer-* fields present but {XEnv.layer_name()} is missing",
             }
+        if has_layer_fields and not raw_meta.get(XEnv.layer_version()):
+            results["MISSING_LAYER_VERSION"] = self._result_builder.build_result(
+                status="missing_layer_version",
+                valid=False,
+                required=True,
+                message=f"{self.filepath}: X-Env-Layer-* fields present but {XEnv.layer_version()} is missing",
+            )
 
-        # 3) Var prefix + orphaned attribute checks (schema-only)
+        # Layer version must be major.minor.patch if present
+        version_val = raw_meta.get(XEnv.layer_version())
+        if version_val is not None and not re.fullmatch(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)", version_val.strip()):
+            results["INVALID_LAYER_VERSION"] = self._result_builder.build_result(
+                status="invalid_layer_version",
+                value=version_val,
+                valid=False,
+                required=False,
+                message=f"{self.filepath}: {XEnv.layer_version()} '{version_val}' is not major.minor.patch",
+            )
+
+        # Var prefix + orphaned attribute checks (schema-only)
         results.update(self._validate_prefix_and_orphans())
 
-        # 4) Validation rule sanity checks (schema-only)
+        # Validation rule sanity checks (schema-only)
         results.update(self._lint_validation_rules(raw_meta))
 
-        # 5) Trigger rule syntax (condition expressions and action keywords)
+        # Trigger rule syntax (condition expressions and action keywords)
         results.update(self._lint_trigger_rules(raw_meta))
 
-        # 6) Conflict expression syntax
+        # Conflict expression syntax
         results.update(self._lint_conflict_rules(raw_meta))
 
         return results
@@ -1383,6 +1402,8 @@ def _main(args):
                 "orphaned_attributes",
                 "invalid_validation_rule",
                 "missing_layer_name",
+                "missing_layer_version",
+                "invalid_layer_version",
                 "no_metadata_fields",
             ]:
                 print(f"[ERROR] {result['message']}")

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -153,8 +153,8 @@ def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) 
             for layer in build_order:
                 info = manager.get_layer_info(layer) or {}
                 version = info.get("version", "")
-                static = manager.layer_source_files.get(layer, "")
-                resolved = manager.layer_files.get(layer, "")
+                static = manager.layer_source_files.get(manager._resolve_key(layer), "")
+                resolved = manager.layer_files.get(manager._resolve_key(layer), "")
                 handle.write(f'{layer}:{version}:{static}:{resolved}\n')
         print(f"Layer plan written to: {path}")
     except Exception as exc:
@@ -165,7 +165,7 @@ def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) 
 def _build_anchor_map_from_layers(manager: LayerManager, layers: List[str]) -> Dict[str, Dict[str, Optional[str]]]:
     anchor_bindings: Dict[str, str] = {}
     for layer in layers:
-        meta = manager.layers.get(layer)
+        meta = manager.layers.get(manager._resolve_key(layer))
         if not meta:
             continue
         for env_var in meta._container.variables.values():
@@ -179,7 +179,7 @@ def _collect_layer_sets(manager: LayerManager, build_order: List[str]) -> Ordere
     Later layers override earlier ones for the same key. """
     collected: OrderedDict[str, Tuple[str, str]] = OrderedDict()
     for layer_name in build_order:
-        meta = manager.layers.get(layer_name)
+        meta = manager.layers.get(manager._resolve_key(layer_name))
         if not meta:
             continue
         layer = meta._container.layer
@@ -192,7 +192,7 @@ def _collect_layer_sets(manager: LayerManager, build_order: List[str]) -> Ordere
 def _collect_variable_definitions(manager: LayerManager, build_order: List[str]) -> Dict[str, List[EnvVariable]]:
     variable_definitions: Dict[str, List[EnvVariable]] = {}
     for position, layer_name in enumerate(build_order):
-        meta = manager.layers.get(layer_name)
+        meta = manager.layers.get(manager._resolve_key(layer_name))
         if not meta:
             continue
         for var_name, env_var in meta._container.variables.items():
@@ -261,7 +261,7 @@ def _apply_layers(
 
 def _validate_layers(manager: LayerManager, layer_names: List[str]) -> bool:
     for layer_name in layer_names:
-        if layer_name not in manager.layers:
+        if layer_name not in manager._name_to_versions:
             print(f"Layer '{layer_name}' not found")
             return False
         if not hasattr(manager, "validate_layer"):
@@ -294,7 +294,7 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
 
     # Validate layer-required external vars (X-Env-VarRequires) in pipeline mode.
     for layer_name in build_order:
-        meta = manager.layers.get(layer_name)
+        meta = manager.layers.get(manager._resolve_key(layer_name))
         if not meta:
             continue
         required_vars = list(getattr(meta._container, "required_vars", []) or [])

--- a/test/layer/test_dynamic_layer_manager.py
+++ b/test/layer/test_dynamic_layer_manager.py
@@ -22,7 +22,7 @@ def main() -> None:
         if "dynamic-test" not in order:
             raise SystemExit("dynamic-test not in build order")
         manager.run_generators_for_layers(order)
-        generated = Path(manager.layer_files["dynamic-test"])
+        generated = Path(manager.layer_files[manager._resolve_key("dynamic-test")])
         if tmpdir not in str(generated):
             raise SystemExit("generated file not in dynamic layer directory")
         data = generated.read_text().strip()

--- a/test/meta/layer-duplicate-name.yaml
+++ b/test/meta/layer-duplicate-name.yaml
@@ -1,7 +1,7 @@
 # METABEGIN
 # X-Env-Layer-Name: test-basic
 # X-Env-Layer-Desc: Duplicate layer name test
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Category: test
 # X-Env-VarPrefix: dup
 # X-Env-Var-value: duplicate

--- a/test/meta/lint-invalid-version-alpha.yaml
+++ b/test/meta/lint-invalid-version-alpha.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-invalid-version-alpha
+# X-Env-Layer-Desc: Layer with non-numeric version components
+# X-Env-Layer-Version: a.b.c
+# X-Env-Layer-Category: test
+# METAEND

--- a/test/meta/lint-invalid-version-leading-zero.yaml
+++ b/test/meta/lint-invalid-version-leading-zero.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-invalid-version-leading-zero
+# X-Env-Layer-Desc: Layer with a leading zero in version component
+# X-Env-Layer-Version: 1.0.01
+# X-Env-Layer-Category: test
+# METAEND

--- a/test/meta/lint-invalid-version-long.yaml
+++ b/test/meta/lint-invalid-version-long.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-invalid-version-long
+# X-Env-Layer-Desc: Layer with a four-part version (a.b.c.d)
+# X-Env-Layer-Version: 1.0.0.0
+# X-Env-Layer-Category: test
+# METAEND

--- a/test/meta/lint-invalid-version-short.yaml
+++ b/test/meta/lint-invalid-version-short.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-invalid-version-short
+# X-Env-Layer-Desc: Layer with a two-part version (major.minor only)
+# X-Env-Layer-Version: 1.0
+# X-Env-Layer-Category: test
+# METAEND

--- a/test/meta/lint-missing-version.yaml
+++ b/test/meta/lint-missing-version.yaml
@@ -1,0 +1,5 @@
+# METABEGIN
+# X-Env-Layer-Name: lint-missing-version
+# X-Env-Layer-Desc: Layer with no version field
+# X-Env-Layer-Category: test
+# METAEND

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -712,5 +712,30 @@ run_test "lint-unknown-xenv-field" \
     1 \
     "Lint should fail on unknown top-level X-Env-* field names"
 
+run_test "lint-missing-version" \
+    "ig metadata --lint ${META}/lint-missing-version.yaml" \
+    1 \
+    "Lint should fail when layer fields exist but Version is missing"
+
+run_test "lint-invalid-version-short" \
+    "ig metadata --lint ${META}/lint-invalid-version-short.yaml" \
+    1 \
+    "Lint should fail when version is major.minor only"
+
+run_test "lint-invalid-version-long" \
+    "ig metadata --lint ${META}/lint-invalid-version-long.yaml" \
+    1 \
+    "Lint should fail when version has more than three components"
+
+run_test "lint-invalid-version-alpha" \
+    "ig metadata --lint ${META}/lint-invalid-version-alpha.yaml" \
+    1 \
+    "Lint should fail when version contains non-numeric components"
+
+run_test "lint-invalid-version-leading-zero" \
+    "ig metadata --lint ${META}/lint-invalid-version-leading-zero.yaml" \
+    1 \
+    "Lint should fail when version contains a leading zero"
+
 cleanup_env
 print_summary

--- a/test/meta/run-tests.sh
+++ b/test/meta/run-tests.sh
@@ -461,7 +461,12 @@ run_test "layer-build-order-circular" \
 run_test "layer-duplicate-name-handling" \
     "ig layer --path ${META} --list" \
     1 \
-    "Duplicate layer name should raise an error"
+    "Duplicate layer name and version should raise an error"
+
+run_test "layer-same-name-different-version" \
+    "ig layer --path ${PIPELINE_DIR} --list" \
+    0 \
+    "Same layer name at different versions should both load without error"
 
 # ---------------------------------------------------------------------------
 print_header "OTHER TESTS"

--- a/test/meta/valid-basic-v2.yaml
+++ b/test/meta/valid-basic-v2.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: test-basic
+# X-Env-Layer-Desc: Basic test layer with simple variables
+# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Category: test
+# X-Env-VarPrefix: basic
+# X-Env-Var-hostname: localhost
+# X-Env-Var-hostname-Desc: Server hostname
+# X-Env-Var-hostname-Valid: string
+# X-Env-Var-port: 8080
+# METAEND


### PR DESCRIPTION
This change-set adds initial support of multiple versions of the same layer. By default, the latest version of a layer will always be used. Future functionality will include being able to take version into account when resolving inter-layer dependencies, therefore opening the door to versioned layer build configurations.