### PR TITLE
examples: kiosk needs to depend on network-online.target

### DIFF
--- a/examples/webkiosk/kiosk.service.tpl
+++ b/examples/webkiosk/kiosk.service.tpl
@@ -1,5 +1,6 @@
 [Unit]
 Description=Kiosk Wayland Session
+After=network-online.target
 After=systemd-time-wait-sync.service
 Requires=systemd-time-wait-sync.service
 After=multi-user.target


### PR DESCRIPTION
systemd-time-wait-sync.service in Debian has no network dependency. It starts early and waits forever for the clock to sync, but if NTP sync hasn't been achieved that wait could be very long.

Defer starting the kiosk service until networking is also up, by which time the NTP sync process can start and then complete.

In terms of kiosk boot, the flow is:

network-online.target -> time sync can reach NTP
systemd-time-wait-sync completes
time-sync.target -> kiosk starts