### PR TITLE
layer: add bluez and bluez-obex to net-wireless

### DIFF
--- a/layer/net-wireless/bluez-obex.yaml
+++ b/layer/net-wireless/bluez-obex.yaml
@@ -1,0 +1,11 @@
+# METABEGIN
+# X-Env-Layer-Name: bluez-obex
+# X-Env-Layer-Desc: BlueZ OBEX daemon for Bluetooth file transfer
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-Requires: bluez
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - bluez-obexd

--- a/layer/net-wireless/bluez.rootfs-overlay/etc/rpi-image-gen/slot-shared.d/bluez.conf
+++ b/layer/net-wireless/bluez.rootfs-overlay/etc/rpi-image-gen/slot-shared.d/bluez.conf
@@ -1,0 +1,2 @@
+Version=1
+Path=/var/lib/bluetooth

--- a/layer/net-wireless/bluez.yaml
+++ b/layer/net-wireless/bluez.yaml
@@ -1,0 +1,28 @@
+# METABEGIN
+# X-Env-Layer-Name: bluez
+# X-Env-Layer-Desc: BlueZ Bluetooth stack
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: connectivity
+# X-Env-Layer-RequiresProvider: systemd
+#
+# X-Env-VarPrefix: bluez
+#
+# X-Env-Var-name:
+# X-Env-Var-name-Desc: Bluetooth adapter name advertised to remote devices.
+#  Defaults to the system hostname if not set.
+# X-Env-Var-name-Valid: string-or-empty
+# X-Env-Var-name-Set: y
+#
+# METAEND
+---
+mmdebstrap:
+  packages:
+    - bluez
+  customize-hooks:
+    - $BDEBSTRAP_HOOKS/enable-units "$1" bluetooth
+    - |-
+      set -eu
+      printf '\n[Policy]\nAutoEnable=true\n' >> "$1/etc/bluetooth/main.conf"
+      if [ -n "${IGconf_bluez_name:-}" ]; then
+        printf '\n[General]\nName=%s\n' "${IGconf_bluez_name}" >> "$1/etc/bluetooth/main.conf"
+      fi

--- a/layer/rpi/device/family-base.yaml
+++ b/layer/rpi/device/family-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi device base layer and defaults
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: device-base,rpi-boot-firmware,rpi-idp,rpi-device-secpolicy
 # X-Env-Layer-Provides: device
 # X-Env-Layer-RequiresProvider: rpi-device,systemd,network-activator
@@ -33,6 +33,7 @@ mmdebstrap:
   packages:
     - udev
     - firmware-brcm80211
+    - bluez-firmware
   customize-hooks:
     - mkdir -p $1/etc/systemd/network
     - $LAYER_HOOKS/systemd/netgen eth0 > $1/etc/systemd/network/01-eth0.network


### PR DESCRIPTION
Add net-wireless/bluez providing the BlueZ stack with bluetooth service enabled, AutoEnable=true, slot.shared persistence for /var/lib/bluetooth, and an optional config variable to set the advertised BlueZ name.

Add net-wireless/bluez-obex providing bluez-obexd for OBEX file transfer.

Add bluez-firmware to family-base.yaml so it's installed unconditionally for all devices. Future enhancements will enable device capabilities to dictate what gets installed.