### PR TITLE
Widen scope for providers and requires, add new validators

### DIFF
--- a/device/cm4/device.yaml
+++ b/device/cm4/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm4
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM4 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: rpi-device
 #
@@ -32,7 +32,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/device/cm5/device.yaml
+++ b/device/cm5/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi-cm5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM5 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-device-base,rpi-linux-2712
 # X-Env-Layer-Provides: rpi-device
 #
@@ -32,7 +32,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/device/pi3/device.yaml
+++ b/device/pi3/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi3
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 3 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: rpi-device
 #
@@ -23,7 +23,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/device/pi4/device.yaml
+++ b/device/pi4/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi4
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 4 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: rpi-device
 #
@@ -24,7 +24,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/device/pi5/device.yaml
+++ b/device/pi5/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpi5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 5 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-device-base,rpi-linux-2712
 # X-Env-Layer-Provides: rpi-device
 #
@@ -24,7 +24,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/device/zero2w/device.yaml
+++ b/device/zero2w/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: rpizero2w
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi Zero 2 W specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
 # X-Env-Layer-Provides: rpi-device
 #
@@ -24,7 +24,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/examples/custom_kernel/device/device.yaml
+++ b/examples/custom_kernel/device/device.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: custom-rpi5
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Custom Raspberry Pi 5 specific device layer
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: device-base
 # X-Env-Layer-Provides: device,rpi-device
 #
@@ -23,7 +23,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 # METAEND
 ---

--- a/examples/custom_kernel/image/image.yaml
+++ b/examples/custom_kernel/image/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Raspberry Pi OS style image layout with MBR, vfat
 #  boot partition, and an ext4 root partition.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
 # X-Env-Layer-Requires: image-base
 # X-Env-Layer-Provides: image
 #
@@ -30,7 +30,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 #
 # METAEND

--- a/examples/nested_image/image/embedded_squashfs/myimage.yaml
+++ b/examples/nested_image/image/embedded_squashfs/myimage.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Example image layer. This declares the asset dir so that
 #  hooks in there will be run.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
 # X-Env-Layer-Requires: image-base
 # X-Env-Layer-Provides: image
 #
@@ -12,7 +12,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 #
 # METAEND

--- a/examples/slim/device/mypi5/myboard.yaml
+++ b/examples/slim/device/mypi5/myboard.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc: Example device layer that performs some fine tuning using
 #  dpkg to trim files so we boot a v8 kernel on pi5 / cm5 only. Declares the
 #  asset dir so that overlays and hooks will be found.
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: device-base
 # X-Env-Layer-Provides: device,rpi-device
 #
@@ -15,7 +15,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Directory for device assets
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 
 # METAEND

--- a/examples/slim/image/compact/myimage-layout.yaml
+++ b/examples/slim/image/compact/myimage-layout.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Example image layer. This declares the asset dir so that
 #  hooks in there will be run.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
 # X-Env-Layer-Requires: image-base
 # X-Env-Layer-Provides: image
 #
@@ -12,7 +12,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 #
 # METAEND

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
 #  boot/system redundancy, and a shared persistent data partition.
-# X-Env-Layer-Version: 5.5.0
+# X-Env-Layer-Version: 5.5.1
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
@@ -43,7 +43,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 #
 # X-Env-Var-pmap: clear

--- a/image/mbr/simple_dual/image.yaml
+++ b/image/mbr/simple_dual/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Raspberry Pi OS style image layout with MBR, vfat
 #  boot partition, and a root partition that can be ext4 or btrfs.
-# X-Env-Layer-Version: 2.2.0
+# X-Env-Layer-Version: 2.2.1
 # X-Env-Layer-Requires: image-base,rpi-storage-binder
 # X-Env-Layer-Provides: image
 #
@@ -33,7 +33,7 @@
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Image specific asset directory
 # X-Env-Var-assetdir-Required: n
-# X-Env-Var-assetdir-Valid: string
+# X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
 #
 # X-Env-Var-pmap: clear

--- a/layer/sbom/gen.sh
+++ b/layer/sbom/gen.sh
@@ -9,7 +9,7 @@ igconf isy sbom_enable || exit 0
 
 [[ $(igconf getval sbom_provider) == syft ]] || exit 0
 
-SYFTCFG=$(realpath -e $(igconf getval sbom_syft_config)) || die "Invalid syft config"
+SYFTCFG=$(igconf getval sbom_syft_config)
 
 SYFT_VER=v1.44.0  # leave empty to install latest
 

--- a/layer/sbom/sbom.yaml
+++ b/layer/sbom/sbom.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: sbom-base
 # X-Env-Layer-Category: audit
 # X-Env-Layer-Desc: SBOM provider and settings.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
 # X-Env-Layer-Requires: artefact-base
 #
 # X-Env-VarRequires: IGconf_artefact_target_name,IGconf_artefact_version
@@ -57,7 +57,7 @@
 #  For further information, refer to
 #  https://github.com/anchore/syft/wiki/Configuration
 # X-Env-Var-syft_config-Required: n
-# X-Env-Var-syft_config-Valid: string
+# X-Env-Var-syft_config-Valid: file-nzero
 # X-Env-Var-syft_config-Set: lazy
 #
 # X-Env-Var-syft_source:

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -596,10 +596,10 @@ class EnvLayer:
                     raise ValueError(
                         f"Invalid dependency token '{dep_name}' - dependencies must be comma-separated without spaces/newlines inside a token")
                 # In doc_mode, allow environment variable placeholders like ${VAR}-suffix
-                if doc_mode and not re.match(r'^[A-Za-z0-9_${}-]+$', dep_name):
-                    raise ValueError(f"Invalid dependency name '{dep_name}' - only alphanum, dash, underscore, and environment variable placeholders allowed")
-                elif not doc_mode and not re.match(r'^[A-Za-z0-9_-]+$', dep_name):
-                    raise ValueError(f"Invalid dependency name '{dep_name}' - only alphanum, dash, underscore allowed")
+                if doc_mode and not re.match(r'^[A-Za-z0-9_:${}\-]+$', dep_name):
+                    raise ValueError(f"Invalid dependency name '{dep_name}' - only alphanum, dash, underscore, colon, and environment variable placeholders allowed")
+                elif not doc_mode and not re.match(r'^[A-Za-z0-9_:\-]+$', dep_name):
+                    raise ValueError(f"Invalid dependency name '{dep_name}' - only alphanum, dash, underscore, colon allowed")
                 deps.append(dep_name)
         return deps
 

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -325,7 +325,8 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
 
             errors = validator.validate(current)
             if errors:
-                log_error(f"[FAIL] {req_var}={current} (invalid, layer: {layer_name})")
+                reason = "; ".join(errors)
+                log_error(f"[FAIL] {req_var}={current} (invalid value, reason: {reason}, layer: {layer_name})")
                 ok = False
 
     for var_name in sorted(variable_definitions.keys()):
@@ -352,8 +353,9 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
         elif current is not None and env_var.validator:
             errors = env_var.validate_value(current)
             if errors:
+                reason = "; ".join(errors)
                 log_error(
-                    f"[FAIL] {env_var.name}={current} (invalid value, layer: {env_var.source_layer})"
+                    f"[FAIL] {env_var.name}={current} (invalid value, reason: {reason}, layer: {env_var.source_layer})"
                 )
                 ok = False
 

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -104,10 +104,6 @@ def _pipeline_main(args):
     for var_name, value in applied_values.items():
         assignments[var_name] = value
 
-    if not _validate_resolved(manager, build_order):
-        log_error("Error: Validation failed for target layers")
-        raise SystemExit(1)
-
     if args.plan_out:
         _write_layer_plan(args.plan_out, build_order, manager)
 
@@ -135,6 +131,12 @@ def _pipeline_main(args):
         raise SystemExit(f"Undefined variable: {e}")
     except CircularReferenceError as e:
         raise SystemExit(f"Circular reference: {e}")
+
+    # Validate after anchor expansion so path validators see fully resolved values
+    os.environ.update(final_values)
+    if not _validate_resolved(manager, build_order):
+        log_error("Error: Validation failed for target layers")
+        raise SystemExit(1)
 
     # Write out
     write_env_file(args.env_out, assignments, final_values)

--- a/site/validators.py
+++ b/site/validators.py
@@ -190,6 +190,41 @@ SIZES:
     50%          (percentage; any positive integer)"""
 
 
+class PathValidator(BaseValidator):
+    def __init__(self, kind: str, nonzero: bool = False):
+        # kind: file or dir
+        self.kind = kind
+        self.nonzero = nonzero
+
+    def validate(self, value: Optional[str]) -> list[str]:
+        import os
+        if value is None:
+            return []
+        path = os.path.expandvars(os.path.expanduser(value))
+        if self.kind == 'file':
+            if not os.path.isfile(path):
+                return [f"Path '{path}' is not a regular file or does not exist"]
+            if self.nonzero and os.path.getsize(path) == 0:
+                return [f"File '{path}' exists but is empty"]
+        elif self.kind == 'dir':
+            if not os.path.isdir(path):
+                return [f"Path '{path}' is not a directory or does not exist"]
+        return []
+
+    def describe(self) -> str:
+        if self.kind == 'dir':
+            return "Path to an existing directory"
+        if self.nonzero:
+            return "Path to an existing non-empty regular file"
+        return "Path to an existing regular file (may be empty)"
+
+    @classmethod
+    def get_help_text(cls) -> str:
+        return ("file                  - Must be a path to an existing regular file (may be empty)\n"
+                "file-nzero            - Must be a path to an existing non-empty regular file\n"
+                "dir                   - Must be a path to an existing directory")
+
+
 class CapacityValidator(BaseValidator):
     def __init__(self):
         # Accept: K, M, G, T, (1024-based) and KiB, MiB, GiB, TiB
@@ -298,6 +333,12 @@ def parse_validator(rule_str: str) -> BaseValidator:
     elif rule_str.startswith("keywords:"):
         options = [x.strip() for x in rule_str.split(":", 1)[1].split(",")]
         return EnumValidator(options)
+    elif rule_str == "file":
+        return PathValidator('file')
+    elif rule_str == "file-nzero":
+        return PathValidator('file', nonzero=True)
+    elif rule_str == "dir":
+        return PathValidator('dir')
     elif rule_str == "size":
         return SizeValidator()
     elif rule_str == "capacity":
@@ -308,7 +349,7 @@ def parse_validator(rule_str: str) -> BaseValidator:
         return EnumValidator(options)
     else:
         # Single value without comma - reject unless it's a known type
-        if rule_str in ["string", "string-or-empty", "string-or-unset", "bool", "int", "size", "capacity"]:
+        if rule_str in ["string", "string-or-empty", "string-or-unset", "bool", "int", "size", "capacity", "file", "file-nzero", "dir"]:
             raise ValueError(f"Unknown validation rule: {rule_str}")
         else:
             raise ValueError(f"Single value '{rule_str}' must use trailing comma ('{rule_str},') or keywords: prefix ('keywords:{rule_str}')")

--- a/test/layer/invalid-provides-capability-fmt.yaml
+++ b/test/layer/invalid-provides-capability-fmt.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: test-invalid-cap-fmt
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Provides: cap:hw:bluetooth!!
+# METAEND

--- a/test/layer/run-tests.sh
+++ b/test/layer/run-tests.sh
@@ -306,6 +306,16 @@ run_test "meta-parse-rejects-invalid-dependency-declaration" \
     1 \
     "Meta parse should perform validation of dependency declaration"
 
+run_test "meta-validate-accepts-capability-provides-tokens" \
+    "ig metadata --validate ${LAYERS}/valid-provides-capability.yaml" \
+    0 \
+    "Capability provides tokens (cap:hw:*) should be accepted"
+
+run_test "meta-validate-rejects-invalid-capability-provides-fmt" \
+    "ig metadata --validate ${LAYERS}/invalid-provides-capability-fmt.yaml" \
+    1 \
+    "Provides tokens with invalid characters should be rejected"
+
 run_test "layer-with-deps-info" \
     "ig layer --path ${LAYERS} --describe test-with-deps" \
     0 \

--- a/test/layer/valid-provides-capability.yaml
+++ b/test/layer/valid-provides-capability.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provides-capability
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# X-Env-Layer-Provides: base-os,cap:hw:bluetooth,cap:hw:wlan,cap:hw:crypto:aes-accel
+# METAEND


### PR DESCRIPTION
Update the regex that gates what can be set in `X-Env-Layer-{Provides,Requires,RequiresProvider}` so that colon separated values can be used.

Add new path checking validators (`file`, `file-nzero` and `dir`) and use them where appropriate, simplifying scripts that previously checked that a directory (or file) declared by a variable existed.  The engine now catches this early, and performs validation after all variables are resolved, meaning that placeholders like `${DIRECTORY}` are taken into account.

Improved layer validation error reporting by including the reason for the validation failure.