### PR TITLE
Refactor user credential layers and harden sudo group membership

### DIFF
--- a/docs/layer/bookworm-minbase.html
+++ b/docs/layer/bookworm-minbase.html
@@ -135,7 +135,6 @@
             <a href="rpi-misc-utils.html" class="dep-badge">rpi-misc-utils</a>
             <a href="rpi-essential-base.html" class="dep-badge">rpi-essential-base</a>
             <a href="rpi-misc-skel.html" class="dep-badge">rpi-misc-skel</a>
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             <a href="fake-hwclock.html" class="dep-badge">fake-hwclock</a>
             <a href="openssh-server.html" class="dep-badge">openssh-server</a>

--- a/docs/layer/device-user-admin.html
+++ b/docs/layer/device-user-admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>rpi-user-credentials - Layer Documentation</title>
+    <title>device-user-admin - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,19 +121,22 @@
     </div>
 
     <div class="header">
-        <h1>rpi-user-credentials</h1>
-        <span class="badge">general</span>
-        <span class="badge">v3.0.1</span>
-        <p>Raspberry Pi base layer for local user admin.
- Creates a local account for user IGconf_device_user1, a home directory and
- adds the user to the standard Raspberry Pi groups. Sudo access is configurable.</p>
+        <h1>device-user-admin</h1>
+        <span class="badge">device</span>
+        <span class="badge">v1.0.0</span>
+        <p>Base layer for local user account provisioning.
+ Creates user accounts, sets credentials, group membership and sudo access.</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
+        <p><strong>Depends on:</strong></p>
+        <div class="deps">
+            <a href="device-user-credentials.html" class="dep-badge">device-user-credentials</a>
+        </div>
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
-            <a href="bookworm-minbase.html" class="dep-badge">bookworm-minbase</a>
+            <a href="device-base.html" class="dep-badge">device-base</a>
             
             <a href="docker-debian-bookworm.html" class="dep-badge">docker-debian-bookworm</a>
             
@@ -145,16 +148,7 @@
             
             <a href="rpi-connect-lite.html" class="dep-badge">rpi-connect-lite</a>
             
-            <a href="trixie-minbase.html" class="dep-badge">trixie-minbase</a>
-            
         </div>
-    </div>
-    <div class="section">
-        <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>, 
-        <code>RPI_TEMPLATES</code>
-        </p>
     </div>
     <div class="section">
         <h2>mmdebstrap</h2>
@@ -170,7 +164,7 @@
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>rpi/user-credentials.yaml</code></p>
+        <p><strong>File:</strong> <code>base/device-user-admin.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/device-user-credentials.html
+++ b/docs/layer/device-user-credentials.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>device-base - Layer Documentation</title>
+    <title>device-user-credentials - Layer Documentation</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; line-height: 1.6; }
         .header { border-bottom: 2px solid #eee; padding-bottom: 20px; margin-bottom: 30px; }
@@ -121,26 +121,21 @@
     </div>
 
     <div class="header">
-        <h1>device-base</h1>
+        <h1>device-user-credentials</h1>
         <span class="badge">device</span>
-        <span class="badge">v3.1.0</span>
-        <p>Device base layer and defaults</p>
+        <span class="badge">v1.0.0</span>
+        <p>Variable definitions for device user account configuration.
+ Declares user account settings: username, password, UID, GID, sudo access,
+ and supplementary group membership.</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
-        <p><strong>Depends on:</strong></p>
-        <div class="deps">
-            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
-        </div>
         <p><strong>Required by:</strong></p>
         <div class="deps">
             
-            <a href="image-rota.html" class="dep-badge">image-rota</a>
-            
-            <a href="rpi-device-base.html" class="dep-badge">rpi-device-base</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
             
         </div>
-        <p><strong>Requires Provider:</strong> device</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>
@@ -157,87 +152,97 @@
             </thead>
             <tbody>
                 <tr>
-                    <td><code>IGconf_device_vendor</code></td>
-                    <td>Device vendor</td>
+                    <td><code>IGconf_device_user1</code></td>
+                    <td>A user account with this name will be created on the
+ device.</td>
                     <td>
-                           <code>vendor</code>
+                           <code>pi</code>
                     </td>
                     <td>Non-empty string value</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><code>IGconf_device_class</code></td>
-                    <td>Device classification</td>
+                    <td><code>IGconf_device_user1pass</code></td>
+                    <td>Password required to log into the user1 account.
+ If neither user1pass nor user1passhash is set, the account will be locked.
+ Password requirements are as follows.
+ At least 8 characters.
+ At least one lowercase letter.
+ At least one uppercase letter.
+ At least one digit.
+ At least one special character from @$!%*?&</td>
                     <td>
-                           <code>generic</code>
+                           <code>&lt;disabled&gt;</code>
+                    </td>
+                    <td>Must match regex pattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_device_user1passhash</code></td>
+                    <td>A pre-hashed password for the user1 account.
+ Generate using the provided genpasswd utility, or supply a hash created with
+ the same algorithm used by the chroot.
+ If neither user1pass nor user1passhash is set, the account will be locked.</td>
+                    <td>
+                           <code>&lt;disabled&gt;</code>
                     </td>
                     <td>Non-empty string value</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><code>IGconf_device_variant</code></td>
-                    <td>Device variant</td>
+                    <td><code>IGconf_device_user1sudo</code></td>
+                    <td>Controls sudo access for the user1 account. 'none' disables
+ sudo access entirely. 'passwd' requires a password for sudo. 'nopasswd' grants
+ passwordless sudo. If user1pass or user1passhash is set, defaults to 'passwd'.
+ Note: setting 'nopasswd' without a password is permitted but inadvisable.</td>
                     <td>
                            <code>none</code>
                     </td>
-                    <td>Non-empty string value</td>
+                    <td>Must be one of: none, passwd, nopasswd</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><code>IGconf_device_hostname</code></td>
-                    <td>Sets the network hostname for the device</td>
+                    <td><code>IGconf_device_user1uid</code></td>
+                    <td>The UID assigned to the user1 account. If unset,
+ one will be assigned automatically.</td>
                     <td>
-                           <code class="long-default">${IGconf_device_class}-$(tr -dc 'a-z' < /dev/urandom | head -c 6)</code>
+                           <code>&lt;disabled&gt;</code>
                     </td>
-                    <td>Non-empty string value</td>
+                    <td>Integer value in range 1000 to 65533</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td><code>IGconf_device_storage_type</code></td>
-                    <td>Declares the storage media the image is intended
- for, as seen by the OS. For example, an NVMe backed disk connected via USB
- would be usb, not nvme. Whether this restricts where the image can be written
- to or booted from depends on downstream layers. This may seed the configuration
- and behaviour of run-time boot media detection, device provisioning, etc.</td>
-                    <td>
-                           <code>sd</code>
-                    </td>
-                    <td>Must be one of: sd, emmc, nvme, usb</td>
-                    <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><code>IGconf_device_sector_size</code></td>
-                    <td>Logical sector size (in bytes) of the target storage
- device. Used to guide image layout decisions (e.g. alignment, padding, and
- sector-based structure placement) so the image matches the intended media.
- Common values: 512 (for 512n/512e) or 4096 (for 4Kn).</td>
+                    <td><code>IGconf_device_user1gid</code></td>
+                    <td>The GID assigned to the user1 account. If unset,
+ one will be assigned automatically.</td>
                     <td>
-                           <code>512</code>
+                           <code>&lt;disabled&gt;</code>
                     </td>
-                    <td>Integer value in range 512 to 512</td>
+                    <td>Integer value in range 1000 to 65533</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-skip" title="Click for policy and validation help">skip</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><code>IGconf_device_assetdir</code></td>
-                    <td>Device specific asset location. Use this directory
- to hold configuration files, scripts, certificates, Device Tree source, wifi
- regulatory domains, firmware blobs, overlays, etc particular to the device.</td>
+                    <td><code>IGconf_device_user1groups</code></td>
+                    <td>Comma-separated list of supplementary groups that the user1 account
+ will be added to. Groups that do not exist on the system are created as system groups. Group
+ names must follow Linux naming conventions: start with a letter or underscore, followed by
+ letters, digits, underscores, or hyphens.</td>
                     <td>
-                           <code>/dev/null</code>
+                           <code class="long-default">adm,dialout,cdrom,audio,users,video,games,plugdev,input,spi,i2c,gpio,render</code>
                     </td>
-                    <td>Non-empty string value</td>
+                    <td>Must match regex pattern: ^[a-zA-Z_][a-zA-Z0-9_-]*(,[a-zA-Z_][a-zA-Z0-9_-]*)*$</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
@@ -248,7 +253,7 @@
 
     <div class="section">
         <h2>Attributes</h2>
-        <p><strong>File:</strong> <code>base/device-base.yaml</code></p>
+        <p><strong>File:</strong> <code>base/device-user-credentials.yaml</code></p>
         <p><strong>Type:</strong> <code>static</code></p>
     </div>
 </body>

--- a/docs/layer/docker-debian-bookworm.html
+++ b/docs/layer/docker-debian-bookworm.html
@@ -123,14 +123,14 @@
     <div class="header">
         <h1>docker-debian-bookworm</h1>
         <span class="badge">container</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v2.1.0</span>
         <p>Docker engine and framework for Debian Bookworm</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
         <p><strong>Depends on:</strong></p>
         <div class="deps">
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
             <a href="sys-build-base.html" class="dep-badge">sys-build-base</a>
         </div>
         <p><strong>Provides:</strong> docker</p>
@@ -138,7 +138,6 @@
     <div class="section">
         <h2>Configuration Variables</h2>
         <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>, 
         <code>IGconf_sys_apt_keydir</code>
         </p>
         <p><strong>Declares</strong> (prefix: <code>docker</code>):</p>

--- a/docs/layer/docker-debian-trixie.html
+++ b/docs/layer/docker-debian-trixie.html
@@ -123,14 +123,14 @@
     <div class="header">
         <h1>docker-debian-trixie</h1>
         <span class="badge">container</span>
-        <span class="badge">v2.0.0</span>
+        <span class="badge">v2.1.0</span>
         <p>Docker engine and framework for Debian Trixie</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
         <p><strong>Depends on:</strong></p>
         <div class="deps">
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
             <a href="sys-build-base.html" class="dep-badge">sys-build-base</a>
         </div>
         <p><strong>Provides:</strong> docker</p>
@@ -138,7 +138,6 @@
     <div class="section">
         <h2>Configuration Variables</h2>
         <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>, 
         <code>IGconf_sys_apt_keydir</code>
         </p>
         <p><strong>Declares</strong> (prefix: <code>docker</code>):</p>

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -1195,6 +1195,16 @@ IGconf_layer_app=my-app</code></pre>
         </div>
         
         <div class="layer-item">
+            <a href="device-user-admin.html">device-user-admin</a><span class="layer-desc">- Base layer for local user account provisioning.
+ Creates user accounts, sets credentials, group membership and sudo access.</span>
+        </div>
+        
+        <div class="layer-item">
+            <a href="device-user-credentials.html">device-user-credentials</a><span class="layer-desc">- Variable definitions for device user account configuration.
+ Declares user account settings: username, password, UID,...</span>
+        </div>
+        
+        <div class="layer-item">
             <a href="rpi-ab-slot-mapper.html">rpi-ab-slot-mapper</a><span class="layer-desc">- Dynamic slot device management for A/B boot: udev rules and
  helpers that create stable by-slot symlinks from GPT PAR...</span>
         </div>
@@ -1377,11 +1387,6 @@ IGconf_layer_app=my-app</code></pre>
         
         <div class="layer-item">
             <a href="rpi-misc-utils.html">rpi-misc-utils</a><span class="layer-desc">- Raspberry Pi system utilities</span>
-        </div>
-        
-        <div class="layer-item">
-            <a href="rpi-user-credentials.html">rpi-user-credentials</a><span class="layer-desc">- Raspberry Pi base layer for local user admin.
- Creates a local account for user IGconf_device_user1, a home directory...</span>
         </div>
         
         <div class="layer-item">

--- a/docs/layer/openssh-server.html
+++ b/docs/layer/openssh-server.html
@@ -123,14 +123,14 @@
     <div class="header">
         <h1>openssh-server</h1>
         <span class="badge">general</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>OpenSSH server daemon and local user SSH key setup.</p>
     </div>
     <div class="section">
         <h2>Relationships</h2>
         <p><strong>Depends on:</strong></p>
         <div class="deps">
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
         </div>
         <p><strong>Required by:</strong></p>
         <div class="deps">
@@ -143,9 +143,6 @@
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>
-        </p>
         <p><strong>Declares</strong> (prefix: <code>ssh</code>):</p>
         <table>
             <thead>

--- a/docs/layer/rpi-connect-lite.html
+++ b/docs/layer/rpi-connect-lite.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-connect-lite</h1>
         <span class="badge">service</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi Connect client with remote shell access</p>
     </div>
     <div class="section">
@@ -241,15 +241,12 @@
         <p><strong>Depends on:</strong></p>
         <div class="deps">
             <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
         </div>
         <p><strong>Provides:</strong> rpi-connect-client</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>
-        </p>
         <p><strong>Declares</strong> (prefix: <code>connect</code>):</p>
         <table>
             <thead>

--- a/docs/layer/rpi-connect.html
+++ b/docs/layer/rpi-connect.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>rpi-connect</h1>
         <span class="badge">service</span>
-        <span class="badge">v1.0.0</span>
+        <span class="badge">v1.1.0</span>
         <p>Raspberry Pi Connect client with screen-sharing support and
  remote shell access</p>
     </div>
@@ -242,15 +242,12 @@
         <p><strong>Depends on:</strong></p>
         <div class="deps">
             <a href="systemd-min.html" class="dep-badge">systemd-min</a>
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
+            <a href="device-user-admin.html" class="dep-badge">device-user-admin</a>
         </div>
         <p><strong>Provides:</strong> rpi-connect-client</p>
     </div>
     <div class="section">
         <h2>Configuration Variables</h2>
-        <p><strong>References:</strong>
-        <code>IGconf_device_user1</code>
-        </p>
         <p><strong>Declares</strong> (prefix: <code>connect</code>):</p>
         <table>
             <thead>

--- a/docs/layer/trixie-minbase.html
+++ b/docs/layer/trixie-minbase.html
@@ -135,7 +135,6 @@
             <a href="rpi-misc-utils.html" class="dep-badge">rpi-misc-utils</a>
             <a href="rpi-essential-base.html" class="dep-badge">rpi-essential-base</a>
             <a href="rpi-misc-skel.html" class="dep-badge">rpi-misc-skel</a>
-            <a href="rpi-user-credentials.html" class="dep-badge">rpi-user-credentials</a>
             <a href="systemd-net-min.html" class="dep-badge">systemd-net-min</a>
             <a href="openssh-server.html" class="dep-badge">openssh-server</a>
             <a href="systemd-timesyncd.html" class="dep-badge">systemd-timesyncd</a>

--- a/examples/custom_layers/layer/acme-developer.yaml
+++ b/examples/custom_layers/layer/acme-developer.yaml
@@ -3,13 +3,12 @@
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer that demonstrates simply pulling several
 #  other layers that are agnostic to device.
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Requires: debian-bookworm-arm64-multi,
 #  rpi-debian-bookworm,
 #  rpi-misc-utils,
 #  rpi-essential-base,
 #  rpi-misc-skel,
-#  rpi-user-credentials,
 #  systemd-net-min,
 #  systemd-timesyncd,
 #  fake-hwclock,

--- a/examples/custom_layers/layer/acme-sdk-v1.yaml
+++ b/examples/custom_layers/layer/acme-sdk-v1.yaml
@@ -4,12 +4,10 @@
 # X-Env-Layer-Desc: Example layer with dependencies, variables and
 #  demonstrating usage of the uchroot helper to install assets for the local
 #  user.
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: example-essential-base,rpi-user-credentials
+# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Requires: example-essential-base,device-user-admin
 #
 # X-Env-VarPrefix: acme
-#
-# X-Env-VarRequires: IGconf_device_user
 #
 # X-Env-Var-subdomain: development
 # X-Env-Var-subdomain-Desc: Deployment subdomain

--- a/examples/slim/layer/slim-customisations.yaml
+++ b/examples/slim/layer/slim-customisations.yaml
@@ -1,26 +1,15 @@
 # METABEGIN
 # X-Env-Layer-Name: example-slim-customisation
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example layer with dependency plus some customisation
 #  hooks.
 # X-Env-Layer-Requires: v8-svelte
-#
-# X-Env-VarRequires: IGconf_device_user1
-# X-Env-VarRequires-Valid: string
-#
-# X-Env-VarOptional: IGconf_device_user1pass
 # METAEND
 ---
-mmdebstrap:
-  packages:
-    - passwd
-    - libpam-runtime
-    - login
-  customize-hooks:
-    - chroot $1 sh -c "useradd -m -s /bin/bash -u 4000 $IGconf_device_user1"
-    - |-
-      if [ -n "$IGconf_device_user1pass" ] ; then
-         chroot $1 sh -c "printf '%s:%s\n' '${IGconf_device_user1}' '${IGconf_device_user1pass}' | chpasswd"
-      fi
-    - chroot $1 usermod --pass='*' root
+#mmdebstrap:
+#  packages:
+#   - pkg1
+#   - pkg2
+#  customize-hooks:
+#    - chroot $1 sh -c "echo run cmd in chroot"

--- a/examples/webkiosk/layer/mykiosk.yaml
+++ b/examples/webkiosk/layer/mykiosk.yaml
@@ -1,12 +1,12 @@
 # METABEGIN
 # X-Env-Layer-Name: example-kiosk
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.1.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example webkiosk layer showing how to define configuration
 #  variables, declare packages and create a start up script. We depend on the
-#  RPi user creds layer as we want to run the kiosk as the user it creates, and
+#  device-user-admin layer as we want to run the kiosk as the user it creates, and
 #  we depend on systemd because we install a systemd service to start the kiosk.
-# X-Env-Layer-Requires: rpi-user-credentials,systemd-net-min,systemd-timesyncd
+# X-Env-Layer-Requires: device-user-admin,systemd-net-min,systemd-timesyncd
 #
 # X-Env-VarPrefix: kiosk
 #

--- a/layer/app-container/docker/engine-bookworm.yaml
+++ b/layer/app-container/docker/engine-bookworm.yaml
@@ -2,12 +2,12 @@
 # X-Env-Layer-Name: docker-debian-bookworm
 # X-Env-Layer-Category: container
 # X-Env-Layer-Desc: Docker engine and framework for Debian Bookworm
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Provides: docker
-# X-Env-Layer-Requires: rpi-user-credentials,sys-build-base
+# X-Env-Layer-Requires: device-user-admin,sys-build-base
 #
-# X-Env-VarRequires: IGconf_device_user1,IGconf_sys_apt_keydir
-# X-Env-VarRequires-Valid: string,string
+# X-Env-VarRequires: IGconf_sys_apt_keydir
+# X-Env-VarRequires-Valid: string
 #
 # X-Env-VarPrefix: docker
 #

--- a/layer/app-container/docker/engine-trixie.yaml
+++ b/layer/app-container/docker/engine-trixie.yaml
@@ -2,12 +2,12 @@
 # X-Env-Layer-Name: docker-debian-trixie
 # X-Env-Layer-Category: container
 # X-Env-Layer-Desc: Docker engine and framework for Debian Trixie
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Provides: docker
-# X-Env-Layer-Requires: rpi-user-credentials,sys-build-base
+# X-Env-Layer-Requires: device-user-admin,sys-build-base
 #
-# X-Env-VarRequires: IGconf_device_user1,IGconf_sys_apt_keydir
-# X-Env-VarRequires-Valid: string,string
+# X-Env-VarRequires: IGconf_sys_apt_keydir
+# X-Env-VarRequires-Valid: string
 #
 # X-Env-VarPrefix: docker
 #

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -2,8 +2,8 @@
 # X-Env-Layer-Name: device-base
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Device base layer and defaults
-# X-Env-Layer-Version: 3.0.0
-# X-Env-Layer-Requires:
+# X-Env-Layer-Version: 3.1.0
+# X-Env-Layer-Requires: device-user-admin
 # X-Env-Layer-RequiresProvider: device
 #
 # X-Env-VarPrefix: device
@@ -31,72 +31,6 @@
 # X-Env-Var-hostname-Required: false
 # X-Env-Var-hostname-Valid: string
 # X-Env-Var-hostname-Set: y
-#
-# X-Env-Var-user1: pi
-# X-Env-Var-user1-Desc: A user account with this name will be created on the
-#  device.
-# X-Env-Var-user1-Required: n
-# X-Env-Var-user1-Valid: string
-# X-Env-Var-user1-Set: y
-#
-# X-Env-Var-user1pass:
-# X-Env-Var-user1pass-Desc: Password required to log into the user1 account.
-#  If neither user1pass nor user1passhash is set, the account will be locked.
-#  Password requirements are as follows.
-#  At least 8 characters.
-#  At least one lowercase letter.
-#  At least one uppercase letter.
-#  At least one digit.
-#  At least one special character from @$!%*?&
-# X-Env-Var-user1pass-Required: n
-# X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
-# X-Env-Var-user1pass-Set: n
-# X-Env-Var-user1pass-Conflicts: IGconf_device_user1pass != '' and IGconf_device_user1passhash != ''
-# X-Env-Var-user1pass-Triggers: when=IGconf_device_user1pass != '' set IGconf_device_user1sudo=passwd policy=lazy
-#
-# X-Env-Var-user1passhash:
-# X-Env-Var-user1passhash-Desc: A pre-hashed password for the user1 account.
-#  Generate using the provided genpasswd utility, or supply a hash created with
-#  the same algorithm used by the chroot.
-#  If neither user1pass nor user1passhash is set, the account will be locked.
-# X-Env-Var-user1passhash-Required: n
-# X-Env-Var-user1passhash-Valid: string
-# X-Env-Var-user1passhash-Set: n
-# X-Env-Var-user1passhash-Conflicts: IGconf_device_user1passhash != '' and IGconf_device_user1pass != ''
-# X-Env-Var-user1passhash-Triggers: when=IGconf_device_user1passhash != '' set IGconf_device_user1sudo=passwd policy=lazy
-#
-# X-Env-Var-user1sudo: none
-# X-Env-Var-user1sudo-Desc: Controls sudo access for the user1 account. 'none' disables
-#  sudo access entirely. 'passwd' requires a password for sudo. 'nopasswd' grants
-#  passwordless sudo. If user1pass or user1passhash is set, defaults to 'passwd'.
-#  Note: setting 'nopasswd' without a password is permitted but inadvisable.
-# X-Env-Var-user1sudo-Required: n
-# X-Env-Var-user1sudo-Valid: none,passwd,nopasswd
-# X-Env-Var-user1sudo-Set: lazy
-#
-# X-Env-Var-user1uid:
-# X-Env-Var-user1uid-Desc: The UID assigned to the user1 account. If unset,
-#  one will be assigned automatically.
-# X-Env-Var-user1uid-Required: n
-# X-Env-Var-user1uid-Valid: int:1000-65533
-# X-Env-Var-user1uid-Set: n
-#
-# X-Env-Var-user1gid:
-# X-Env-Var-user1gid-Desc: The GID assigned to the user1 account. If unset,
-#  one will be assigned automatically.
-# X-Env-Var-user1gid-Required: n
-# X-Env-Var-user1gid-Valid: int:1000-65533
-# X-Env-Var-user1gid-Set: n
-#
-# X-Env-Var-user1groups: adm,dialout,cdrom,audio,users,video,games,plugdev,input,spi,i2c,gpio,render
-# X-Env-Var-user1groups-Desc: Comma-separated list of supplementary groups that the user1 account
-#  will be added to. Groups that do not exist on the system are created as system groups. Group
-#  names must follow Linux naming conventions: start with a letter or underscore, followed by
-#  letters, digits, underscores, or hyphens.
-# X-Env-Var-user1groups-Required: n
-# X-Env-Var-user1groups-Valid: regex:^[a-zA-Z_][a-zA-Z0-9_-]*(,[a-zA-Z_][a-zA-Z0-9_-]*)*$
-# X-Env-Var-user1groups-Conflicts: 'sudo' in IGconf_device_user1groups
-# X-Env-Var-user1groups-Set: lazy
 #
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Desc: Declares the storage media the image is intended

--- a/layer/base/device-base.yaml
+++ b/layer/base/device-base.yaml
@@ -88,6 +88,16 @@
 # X-Env-Var-user1gid-Valid: int:1000-65533
 # X-Env-Var-user1gid-Set: n
 #
+# X-Env-Var-user1groups: adm,dialout,cdrom,audio,users,video,games,plugdev,input,spi,i2c,gpio,render
+# X-Env-Var-user1groups-Desc: Comma-separated list of supplementary groups that the user1 account
+#  will be added to. Groups that do not exist on the system are created as system groups. Group
+#  names must follow Linux naming conventions: start with a letter or underscore, followed by
+#  letters, digits, underscores, or hyphens.
+# X-Env-Var-user1groups-Required: n
+# X-Env-Var-user1groups-Valid: regex:^[a-zA-Z_][a-zA-Z0-9_-]*(,[a-zA-Z_][a-zA-Z0-9_-]*)*$
+# X-Env-Var-user1groups-Conflicts: 'sudo' in IGconf_device_user1groups
+# X-Env-Var-user1groups-Set: lazy
+#
 # X-Env-Var-storage_type: sd
 # X-Env-Var-storage_type-Desc: Declares the storage media the image is intended
 #  for, as seen by the OS. For example, an NVMe backed disk connected via USB

--- a/layer/base/device-user-admin.yaml
+++ b/layer/base/device-user-admin.yaml
@@ -1,14 +1,10 @@
 # METABEGIN
-# X-Env-Layer-Name: rpi-user-credentials
-# X-Env-Layer-Desc: Raspberry Pi base layer for local user admin.
-#  Creates a local account for user IGconf_device_user1, a home directory and
-#  adds the user to the standard Raspberry Pi groups. Sudo access is configurable.
-# X-Env-Layer-Version: 3.0.1
-#
-# X-Env-VarRequires: IGconf_device_user1
-# X-Env-VarRequires-Valid: string
-#
-# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid,IGconf_device_user1sudo,IGconf_device_user1groups
+# X-Env-Layer-Name: device-user-admin
+# X-Env-Layer-Category: device
+# X-Env-Layer-Desc: Base layer for local user account provisioning.
+#  Creates user accounts, sets credentials, group membership and sudo access.
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: device-user-credentials
 # METAEND
 ---
 mmdebstrap:
@@ -18,6 +14,7 @@ mmdebstrap:
     - adduser
   customize-hooks:
     - |-
+      #
       # Account creation
       set -eu
       uid_arg=""
@@ -33,7 +30,8 @@ mmdebstrap:
           chroot $1 adduser --disabled-password --gecos "" $uid_arg $gid_arg "$IGconf_device_user1"
       fi
     - |-
-      # Password and group
+      #
+      # Password
       set -eu
       if [ -n "${IGconf_device_user1passhash:-}" ] ; then
          printf '%s:%s\n' "$IGconf_device_user1" "$IGconf_device_user1passhash" | chroot $1 chpasswd -e
@@ -42,6 +40,7 @@ mmdebstrap:
       fi
     - chroot $1 usermod --pass='*' root
     - |-
+      #
       # Group membership
       set -eu
       GRP_LIST=$(printf '%s' "${IGconf_device_user1groups:-}" | tr ',' ' ')
@@ -50,7 +49,8 @@ mmdebstrap:
         adduser $IGconf_device_user1 \$GRP;
       done"
     - |-
-      # Sudo
+      #
+      # sudo
       set -eu
       if [ "$IGconf_device_user1sudo" = "nopasswd" ] &&
          [ -z "${IGconf_device_user1pass:-}" ] &&
@@ -59,22 +59,28 @@ mmdebstrap:
       fi
       case "$IGconf_device_user1sudo" in
         nopasswd)
-          echo "$IGconf_device_user1 ALL=(ALL) NOPASSWD: ALL" > $1/etc/sudoers.d/010_pi-nopasswd
+          echo "$IGconf_device_user1 ALL=(ALL) NOPASSWD: ALL" > $1/etc/sudoers.d/010_rpi-nopasswd
           chroot $1 adduser "$IGconf_device_user1" sudo
           ;;
         passwd)
-          echo "$IGconf_device_user1 ALL=(ALL:ALL) ALL" > $1/etc/sudoers.d/010_pi-nopasswd
+          echo "$IGconf_device_user1 ALL=(ALL:ALL) ALL" > $1/etc/sudoers.d/010_rpi-passwd
           chroot $1 adduser "$IGconf_device_user1" sudo
           ;;
         none)
           ;;
       esac
-    - mkdir -p $1/etc/profile.d
     - |-
+      #
       # Profile
+      set -eu
+      mkdir -p $1/etc/profile.d
       cat <<- 'EOCHROOT' > $1/etc/profile.d/01local.sh
       #!/bin/sh
       if [ "$(id -u)" -ne 0 ]; then
         PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games
       fi
       EOCHROOT
+  cleanup-hooks:
+    - |-
+      set -eu
+      [ "$IGconf_device_user1sudo" = "none" ] && chroot $1 dpkg --purge sudo || true

--- a/layer/base/device-user-credentials.yaml
+++ b/layer/base/device-user-credentials.yaml
@@ -1,0 +1,80 @@
+# METABEGIN
+# X-Env-Layer-Name: device-user-credentials
+# X-Env-Layer-Category: device
+# X-Env-Layer-Desc: Variable definitions for device user account configuration.
+#  Declares user account settings: username, password, UID, GID, sudo access,
+#  and supplementary group membership.
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires:
+# X-Env-Layer-RequiresProvider:
+#
+# X-Env-VarPrefix: device
+#
+# X-Env-Var-user1: pi
+# X-Env-Var-user1-Desc: A user account with this name will be created on the
+#  device.
+# X-Env-Var-user1-Required: n
+# X-Env-Var-user1-Valid: string
+# X-Env-Var-user1-Set: y
+#
+# X-Env-Var-user1pass:
+# X-Env-Var-user1pass-Desc: Password required to log into the user1 account.
+#  If neither user1pass nor user1passhash is set, the account will be locked.
+#  Password requirements are as follows.
+#  At least 8 characters.
+#  At least one lowercase letter.
+#  At least one uppercase letter.
+#  At least one digit.
+#  At least one special character from @$!%*?&
+# X-Env-Var-user1pass-Required: n
+# X-Env-Var-user1pass-Valid: regex:^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
+# X-Env-Var-user1pass-Set: n
+# X-Env-Var-user1pass-Conflicts: IGconf_device_user1pass != '' and IGconf_device_user1passhash != ''
+# X-Env-Var-user1pass-Triggers: when=IGconf_device_user1pass != '' set IGconf_device_user1sudo=passwd policy=lazy
+#
+# X-Env-Var-user1passhash:
+# X-Env-Var-user1passhash-Desc: A pre-hashed password for the user1 account.
+#  Generate using the provided genpasswd utility, or supply a hash created with
+#  the same algorithm used by the chroot.
+#  If neither user1pass nor user1passhash is set, the account will be locked.
+# X-Env-Var-user1passhash-Required: n
+# X-Env-Var-user1passhash-Valid: string
+# X-Env-Var-user1passhash-Set: n
+# X-Env-Var-user1passhash-Conflicts: IGconf_device_user1passhash != '' and IGconf_device_user1pass != ''
+# X-Env-Var-user1passhash-Triggers: when=IGconf_device_user1passhash != '' set IGconf_device_user1sudo=passwd policy=lazy
+#
+# X-Env-Var-user1sudo: none
+# X-Env-Var-user1sudo-Desc: Controls sudo access for the user1 account. 'none' disables
+#  sudo access entirely. 'passwd' requires a password for sudo. 'nopasswd' grants
+#  passwordless sudo. If user1pass or user1passhash is set, defaults to 'passwd'.
+#  Note: setting 'nopasswd' without a password is permitted but inadvisable.
+# X-Env-Var-user1sudo-Required: n
+# X-Env-Var-user1sudo-Valid: none,passwd,nopasswd
+# X-Env-Var-user1sudo-Set: lazy
+#
+# X-Env-Var-user1uid:
+# X-Env-Var-user1uid-Desc: The UID assigned to the user1 account. If unset,
+#  one will be assigned automatically.
+# X-Env-Var-user1uid-Required: n
+# X-Env-Var-user1uid-Valid: int:1000-65533
+# X-Env-Var-user1uid-Set: n
+#
+# X-Env-Var-user1gid:
+# X-Env-Var-user1gid-Desc: The GID assigned to the user1 account. If unset,
+#  one will be assigned automatically.
+# X-Env-Var-user1gid-Required: n
+# X-Env-Var-user1gid-Valid: int:1000-65533
+# X-Env-Var-user1gid-Set: n
+#
+# X-Env-Var-user1groups: adm,dialout,cdrom,audio,users,video,games,plugdev,input,spi,i2c,gpio,render
+# X-Env-Var-user1groups-Desc: Comma-separated list of supplementary groups that the user1 account
+#  will be added to. Groups that do not exist on the system are created as system groups. Group
+#  names must follow Linux naming conventions: start with a letter or underscore, followed by
+#  letters, digits, underscores, or hyphens.
+# X-Env-Var-user1groups-Required: n
+# X-Env-Var-user1groups-Valid: regex:^[a-zA-Z_][a-zA-Z0-9_-]*(,[a-zA-Z_][a-zA-Z0-9_-]*)*$
+# X-Env-Var-user1groups-Conflicts: 'sudo' in IGconf_device_user1groups
+# X-Env-Var-user1groups-Set: lazy
+#
+# METAEND
+---

--- a/layer/net-misc/openssh-server.yaml
+++ b/layer/net-misc/openssh-server.yaml
@@ -1,11 +1,8 @@
 # METABEGIN
 # X-Env-Layer-Name: openssh-server
 # X-Env-Layer-Desc: OpenSSH server daemon and local user SSH key setup.
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: rpi-user-credentials
-#
-# X-Env-VarRequires: IGconf_device_user1
-# X-Env-VarRequires-Valid: string
+# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Requires: device-user-admin
 #
 # X-Env-VarPrefix: ssh
 #

--- a/layer/rpi/device/services/rpi-connect-lite.yaml
+++ b/layer/rpi/device/services/rpi-connect-lite.yaml
@@ -2,12 +2,9 @@
 # X-Env-Layer-Name: rpi-connect-lite
 # X-Env-Layer-Category: service
 # X-Env-Layer-Desc: Raspberry Pi Connect client with remote shell access
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: systemd-min,rpi-user-credentials
+# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Requires: systemd-min,device-user-admin
 # X-Env-Layer-Provides: rpi-connect-client
-#
-# X-Env-VarRequires: IGconf_device_user1
-# X-Env-VarRequires-Valid: string
 #
 # X-Env-VarPrefix: connect
 #

--- a/layer/rpi/device/services/rpi-connect.yaml
+++ b/layer/rpi/device/services/rpi-connect.yaml
@@ -3,12 +3,9 @@
 # X-Env-Layer-Category: service
 # X-Env-Layer-Desc: Raspberry Pi Connect client with screen-sharing support and
 #  remote shell access
-# X-Env-Layer-Version: 1.0.0
-# X-Env-Layer-Requires: systemd-min,rpi-user-credentials
+# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Requires: systemd-min,device-user-admin
 # X-Env-Layer-Provides: rpi-connect-client
-#
-# X-Env-VarRequires: IGconf_device_user1
-# X-Env-VarRequires-Valid: string
 #
 # X-Env-VarPrefix: connect
 #

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -8,7 +8,7 @@
 # X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
 # X-Env-VarRequires-Valid: string,string
 #
-# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid,IGconf_device_user1sudo
+# X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid,IGconf_device_user1sudo,IGconf_device_user1groups
 # METAEND
 ---
 mmdebstrap:
@@ -41,11 +41,13 @@ mmdebstrap:
          printf '%s:%s\n' "$IGconf_device_user1" "$IGconf_device_user1pass" | chroot $1 chpasswd
       fi
     - chroot $1 usermod --pass='*' root
-    - chroot $1 sh -c "for GRP in input spi i2c gpio; do
-         groupadd -f -r \$GRP;
-      done"
-    - chroot $1 sh -c "for GRP in adm dialout cdrom audio users sudo video games plugdev input spi i2c gpio render ; do
-         getent group \$GRP > /dev/null && adduser $IGconf_device_user1 \$GRP || true;
+    - |-
+      # Group membership
+      set -eu
+      GRP_LIST=$(printf '%s' "${IGconf_device_user1groups:-}" | tr ',' ' ')
+      chroot $1 sh -c "for GRP in $GRP_LIST ; do
+        groupadd -f -r \$GRP;
+        adduser $IGconf_device_user1 \$GRP;
       done"
     - |-
       # Sudo
@@ -58,9 +60,11 @@ mmdebstrap:
       case "$IGconf_device_user1sudo" in
         nopasswd)
           sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+          chroot $1 adduser "$IGconf_device_user1" sudo
           ;;
         passwd)
           echo "$IGconf_device_user1 ALL=(ALL:ALL) ALL" > $1/etc/sudoers.d/010_pi-nopasswd
+          chroot $1 adduser "$IGconf_device_user1" sudo
           ;;
         none)
           ;;

--- a/layer/rpi/user-credentials.yaml
+++ b/layer/rpi/user-credentials.yaml
@@ -5,8 +5,8 @@
 #  adds the user to the standard Raspberry Pi groups. Sudo access is configurable.
 # X-Env-Layer-Version: 3.0.1
 #
-# X-Env-VarRequires: IGconf_device_user1,RPI_TEMPLATES
-# X-Env-VarRequires-Valid: string,string
+# X-Env-VarRequires: IGconf_device_user1
+# X-Env-VarRequires-Valid: string
 #
 # X-Env-VarOptional: IGconf_device_user1pass,IGconf_device_user1passhash,IGconf_device_user1uid,IGconf_device_user1gid,IGconf_device_user1sudo,IGconf_device_user1groups
 # METAEND
@@ -59,7 +59,7 @@ mmdebstrap:
       fi
       case "$IGconf_device_user1sudo" in
         nopasswd)
-          sed "s/^pi /$IGconf_device_user1 /" $RPI_TEMPLATES/sudo/010_pi-nopasswd > $1/etc/sudoers.d/010_pi-nopasswd
+          echo "$IGconf_device_user1 ALL=(ALL) NOPASSWD: ALL" > $1/etc/sudoers.d/010_pi-nopasswd
           chroot $1 adduser "$IGconf_device_user1" sudo
           ;;
         passwd)

--- a/layer/suite/debian/bookworm-minbase.yaml
+++ b/layer/suite/debian/bookworm-minbase.yaml
@@ -8,7 +8,6 @@
 #  rpi-misc-utils,
 #  rpi-essential-base,
 #  rpi-misc-skel,
-#  rpi-user-credentials,
 #  systemd-net-min,
 #  fake-hwclock,
 #  openssh-server,

--- a/layer/suite/debian/trixie-minbase.yaml
+++ b/layer/suite/debian/trixie-minbase.yaml
@@ -8,7 +8,6 @@
 #  rpi-misc-utils,
 #  rpi-essential-base,
 #  rpi-misc-skel,
-#  rpi-user-credentials,
 #  systemd-net-min,
 #  openssh-server,
 #  systemd-timesyncd,

--- a/templates/rpi/sudo/010_pi-nopasswd
+++ b/templates/rpi/sudo/010_pi-nopasswd
@@ -1,1 +1,0 @@
-pi ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
This series introduces two new base layers for user account management, makes user account provisioning generic, and hardens sudo group membership controls.

### New layers

User account variables were previously defined in `device-base` and provisioning performed by `rpi-user-credentials`. This series splits those concerns into a clean three-layer chain:

device-base -> device-user-admin -> device-user-credentials

- `device-user-credentials` declares all `IGconf_device_user1*` variables (extracted from `device-base`)
- `device-user-admin` performs all user account provisioning (renamed and relocated from `layer/rpi/user-credentials.yaml`)

`device-base` requires `device-user-admin`, so user account provisioning is automatic for all device builds.

### Configurable group membership

`IGconf_device_user1groups` replaces the hardcoded supplementary group list. Groups not present on the system are created as system groups before the user is added.

After group definition was moved to a variable, there was nothing RPi specific about the user account creation beyond a template, so drop that and use echo to install the `nopasswd` setting instead.

### Hardened sudo group membership

`sudo` is removed from the default group list, with group membership now added exclusively by the sudo hook when `user1sudo` is `passwd` or `nopasswd`. Declare a conflict on user1groups if sudo is present, avoiding sudo being introduced via that path.

### Breaking change

Layers requiring `rpi-user-credentials` must be updated to require `device-user-admin`. 