### PR TITLE
Add X-Env-Layer-AfterProvider field to enforce provider-based build ordering

### DIFF
--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -115,7 +115,9 @@ Generators that use `argparse` or `getopt` should parse from `argv[3:]`, as `arg
 
 `X-Env-Layer-Provides`: Services or capabilities this layer provides
 
-`X-Env-Layer-RequiresProvider`: Services or capabilities this layer requires
+`X-Env-Layer-RequiresProvider`: Capabilities that must exist in the build (validation only, no ordering)
+
+`X-Env-Layer-AfterProvider`: Capabilities that must exist and must precede this layer in the build
 
 `X-Env-Layer-Conflicts`: Layers that cannot be used together with this one
 
@@ -156,13 +158,25 @@ This enables dynamic layer dependency resolution based on build-time variables s
 Only variables present in the environment can be used in dependencies.
 ====
 
-==== X-Env-Layer-Provides / X-Env-Layer-RequiresProvider
+==== X-Env-Layer-Provides / X-Env-Layer-RequiresProvider / X-Env-Layer-AfterProvider
+
+`X-Env-Layer-Provides` declares one or more capability tokens that this layer makes available to the rest of the build. Other layers reference these tokens rather than a specific layer name, which keeps the dependency abstract and substitutable.
+
+All fields share the same capability contract model:
 
 - **Abstract capability requirements**: "I need something that provides X"
 - **Service/capability contracts**: Multiple layers could satisfy the requirement
-- **Flexible implementation**: Any layer providing the capability can fulfill it
+- **Flexible implementation**: Any layer providing the capability can fulfil it
 - **Relationships**: If a provider is required, only one can exist in the overall configuration
 - **Example**: A layer requires a device provider, which could be satisfied by different device layers
+
+`X-Env-Layer-RequiresProvider` declares capabilities that must be present somewhere in the build. The engine validates their existence but imposes no ordering constraint - use this when a layer is semantically tied to a capability but its position in the build plan is already determined by its `Requires` relationships, when variable resolution handles the dependency lazily, or when position in the build plan is not important.
+
+`X-Env-Layer-AfterProvider` declares capabilities that must be present AND must precede this layer in the build plan. Use this when the provider's position has a structural effect on the build - for example, APT mirror ordering where a Debian distribution foundation layer must appear first in the build order so that mmdebstrap derives the correct native architecture when bdebstrap merges the YAML, or when hooks provided by one layer must execute before hooks from another.
+
+Both fields enforce uniqueness: only one layer in the build may provide a given capability token.
+
+The engine raises an error on impossible relationships, e.g. B `Requires` A but A uses `AfterProvider` to require a capability that B provides.
 
 [IMPORTANT]
 ====

--- a/docs/layer/index.html
+++ b/docs/layer/index.html
@@ -150,7 +150,7 @@
 <li><a href="#_dependencies_and_providers">Dependencies and Providers</a>
 <ul class="sectlevel3">
 <li><a href="#_x_env_layer_requires">X-Env-Layer-Requires</a></li>
-<li><a href="#_x_env_layer_provides_x_env_layer_requiresprovider">X-Env-Layer-Provides / X-Env-Layer-RequiresProvider</a></li>
+<li><a href="#_x_env_layer_provides_x_env_layer_requiresprovider_x_env_layer_afterprovider">X-Env-Layer-Provides / X-Env-Layer-RequiresProvider / X-Env-Layer-AfterProvider</a></li>
 <li><a href="#_x_env_layer_sets">X-Env-Layer-Sets</a></li>
 </ul>
 </li>
@@ -407,7 +407,10 @@ mmdebstrap:
 <p><code>X-Env-Layer-Provides</code>: Services or capabilities this layer provides</p>
 </div>
 <div class="paragraph">
-<p><code>X-Env-Layer-RequiresProvider</code>: Services or capabilities this layer requires</p>
+<p><code>X-Env-Layer-RequiresProvider</code>: Capabilities that must exist in the build (validation only, no ordering)</p>
+</div>
+<div class="paragraph">
+<p><code>X-Env-Layer-AfterProvider</code>: Capabilities that must exist and must precede this layer in the build</p>
 </div>
 <div class="paragraph">
 <p><code>X-Env-Layer-Conflicts</code>: Layers that cannot be used together with this one</p>
@@ -488,7 +491,13 @@ mmdebstrap:
 </div>
 </div>
 <div class="sect3">
-<h4 id="_x_env_layer_provides_x_env_layer_requiresprovider"><a class="anchor" href="#_x_env_layer_provides_x_env_layer_requiresprovider"></a><a class="link" href="#_x_env_layer_provides_x_env_layer_requiresprovider">X-Env-Layer-Provides / X-Env-Layer-RequiresProvider</a></h4>
+<h4 id="_x_env_layer_provides_x_env_layer_requiresprovider_x_env_layer_afterprovider"><a class="anchor" href="#_x_env_layer_provides_x_env_layer_requiresprovider_x_env_layer_afterprovider"></a><a class="link" href="#_x_env_layer_provides_x_env_layer_requiresprovider_x_env_layer_afterprovider">X-Env-Layer-Provides / X-Env-Layer-RequiresProvider / X-Env-Layer-AfterProvider</a></h4>
+<div class="paragraph">
+<p><code>X-Env-Layer-Provides</code> declares one or more capability tokens that this layer makes available to the rest of the build. Other layers reference these tokens rather than a specific layer name, which keeps the dependency abstract and substitutable.</p>
+</div>
+<div class="paragraph">
+<p>All fields share the same capability contract model:</p>
+</div>
 <div class="ulist">
 <ul>
 <li>
@@ -498,7 +507,7 @@ mmdebstrap:
 <p><strong>Service/capability contracts</strong>: Multiple layers could satisfy the requirement</p>
 </li>
 <li>
-<p><strong>Flexible implementation</strong>: Any layer providing the capability can fulfill it</p>
+<p><strong>Flexible implementation</strong>: Any layer providing the capability can fulfil it</p>
 </li>
 <li>
 <p><strong>Relationships</strong>: If a provider is required, only one can exist in the overall configuration</p>
@@ -507,6 +516,18 @@ mmdebstrap:
 <p><strong>Example</strong>: A layer requires a device provider, which could be satisfied by different device layers</p>
 </li>
 </ul>
+</div>
+<div class="paragraph">
+<p><code>X-Env-Layer-RequiresProvider</code> declares capabilities that must be present somewhere in the build. The engine validates their existence but imposes no ordering constraint - use this when a layer is semantically tied to a capability but its position in the build plan is already determined by its <code>Requires</code> relationships, when variable resolution handles the dependency lazily, or when position in the build plan is not important.</p>
+</div>
+<div class="paragraph">
+<p><code>X-Env-Layer-AfterProvider</code> declares capabilities that must be present AND must precede this layer in the build plan. Use this when the provider&#8217;s position has a structural effect on the build - for example, APT mirror ordering where a Debian distribution foundation layer must appear first in the build order so that mmdebstrap derives the correct native architecture when bdebstrap merges the YAML, or when hooks provided by one layer must execute before hooks from another.</p>
+</div>
+<div class="paragraph">
+<p>Both fields enforce uniqueness: only one layer in the build may provide a given capability token.</p>
+</div>
+<div class="paragraph">
+<p>The engine raises an error on impossible relationships, e.g. B <code>Requires</code> A but A uses <code>AfterProvider</code> to require a capability that B provides.</p>
 </div>
 <div class="admonitionblock important">
 <table>

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -214,6 +214,11 @@ class XEnv:
         return f"{cls.LAYER_PREFIX}RequiresProvider"
 
     @classmethod
+    def layer_after_provider(cls) -> str:
+        """Build layer after-provider field: X-Env-Layer-AfterProvider"""
+        return f"{cls.LAYER_PREFIX}AfterProvider"
+
+    @classmethod
     def layer_conflicts(cls) -> str:
         """Build layer conflicts field: X-Env-Layer-Conflicts"""
         return f"{cls.LAYER_PREFIX}Conflicts"
@@ -503,6 +508,7 @@ class EnvLayer:
     def __init__(self, name: str, description: str = "", version: str = "1.0.0",
                  category: str = "general", deps: List[str] = None,
                  provides: List[str] = None, requires_provider: List[str] = None,
+                 after_provider: List[str] = None,
                  conflicts: List[str] = None, layer_type: str = "static",
                  generator: str = "", config_file: str = "",
                  sets: Dict[str, str] = None):
@@ -513,6 +519,7 @@ class EnvLayer:
         self.deps = deps or []
         self.provides = provides or []
         self.requires_provider = requires_provider or []
+        self.after_provider = after_provider or []
         self.conflicts = conflicts or []
         self.layer_type = layer_type
         self.generator = generator
@@ -551,6 +558,9 @@ class EnvLayer:
         requires_provider_str = metadata_dict.get(XEnv.layer_requires_provider(), "")
         requires_provider = cls._parse_dependency_list(requires_provider_str, doc_mode)
 
+        after_provider_str = metadata_dict.get(XEnv.layer_after_provider(), "")
+        after_provider = cls._parse_dependency_list(after_provider_str, doc_mode)
+
         conflicts_str = metadata_dict.get(XEnv.layer_conflicts(), "")
         conflicts = cls._parse_dependency_list(conflicts_str, doc_mode)
 
@@ -569,6 +579,7 @@ class EnvLayer:
             deps=requires,
             provides=provides,
             requires_provider=requires_provider,
+            after_provider=after_provider,
             conflicts=conflicts,
             layer_type=layer_type,
             generator=generator,
@@ -697,6 +708,7 @@ class EnvLayer:
             "config_file": self.config_file,
             "provides": self.provides,
             "provider_requires": self.requires_provider,
+            "after_provider": self.after_provider,
             "sets": self.sets,
         }
 

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -1,6 +1,7 @@
 import os
 import re
 import glob
+import heapq
 import shutil
 import argparse
 import shlex
@@ -509,6 +510,12 @@ class LayerManager:
         for layer in target_layers:
             add_layer_and_deps(layer)
 
+        # Fail if any capability is claimed by more than one layer
+        self._check_provider_conflicts_in_scope(build_order)
+
+        # Apply AfterProvider ordering constraints
+        build_order = self._apply_provider_ordering(build_order)
+
         # Validate that all required providers are satisfied by the build order
         self._validate_provider_requirements(build_order)
 
@@ -516,9 +523,6 @@ class LayerManager:
 
     def _validate_provider_requirements(self, build_order: List[str]) -> None:
         """Validate that all required providers are satisfied by layers in the build order"""
-        # Check for provider conflicts within the build order scope
-        self._check_provider_conflicts_in_scope(build_order)
-
         # Collect all providers available in the build order
         available_providers = set()
         for layer_name in build_order:
@@ -526,13 +530,95 @@ class LayerManager:
             if layer_info:
                 available_providers.update(layer_info.get('provides', []))
 
-        # Check each layer's provider requirements
+        # Check both RequiresProvider (validation-only) and AfterProvider (validation + ordering)
         for layer_name in build_order:
             layer_info = self.get_layer_info(layer_name)
             if layer_info:
-                for required_provider in layer_info.get('provider_requires', []):
+                for required_provider in (layer_info.get('provider_requires', []) +
+                                          layer_info.get('after_provider', [])):
                     if required_provider not in available_providers:
                         raise ValueError(f"Layer '{layer_name}' requires provider '{required_provider}' but no layer in the dependency chain provides it")
+
+    def _apply_provider_ordering(self, build_order: List[str]) -> List[str]:
+        """Stable-sort build_order so each AfterProvider consumer follows its provider."""
+        # Raw provides only - ordering is relative to the declaring layer only
+        # @TODO include capability token checking
+        cap_to_layer = {}
+        for layer_name in build_order:
+            layer_info = self.get_layer_info(layer_name)
+            if layer_info:
+                for cap in layer_info.get('provides', []):
+                    cap_to_layer[cap] = layer_name
+
+        # Collect AfterProvider ordering, store the capability token for diagnostics.
+        # Missing providers are skipped - _validate_provider_requirements already checked
+        rp_edges: Dict[Tuple[str, str], str] = {}  # (provider, consumer) -> cap
+        for layer_name in build_order:
+            layer_info = self.get_layer_info(layer_name)
+            if layer_info:
+                for cap in layer_info.get('after_provider', []):
+                    if cap in cap_to_layer:
+                        provider = cap_to_layer[cap]
+                        if provider != layer_name:
+                            rp_edges[(provider, layer_name)] = cap
+
+        if not rp_edges:
+            return build_order
+
+        # Build the combined constraint graph (Requires + AfterProvider edges) so that
+        # the algo detects impossible relationships, eg B Requires A while A
+        # uses AfterProvider on a capability that B provides.
+        must_precede: Dict[str, Set[str]] = {layer: set() for layer in build_order}
+        for layer_name in build_order:
+            layer_info = self.get_layer_info(layer_name)
+            if layer_info:
+                for dep in layer_info.get('depends', []):
+                    if dep in must_precede:
+                        must_precede[dep].add(layer_name)
+        for provider, consumer in rp_edges:
+            must_precede[provider].add(consumer)
+
+        # Perform a topological sort with original_pos as tiebreaker - preserves order
+        # for layers with no ordering constraint between them.
+        predecessor_count = {layer: 0 for layer in build_order}
+        for layer in build_order:
+            for consumer in must_precede[layer]:
+                if consumer in predecessor_count:
+                    predecessor_count[consumer] += 1
+
+        original_pos = {layer: i for i, layer in enumerate(build_order)}
+        ready = [(original_pos[l], l) for l in build_order if predecessor_count[l] == 0]
+        heapq.heapify(ready)
+
+        result = []
+        while ready:
+            _, layer = heapq.heappop(ready)
+            result.append(layer)
+            for consumer in must_precede[layer]:
+                predecessor_count[consumer] -= 1
+                if predecessor_count[consumer] == 0:
+                    heapq.heappush(ready, (original_pos[consumer], consumer))
+
+        if len(result) != len(build_order):
+            stuck = [l for l in build_order if predecessor_count[l] > 0]
+
+            def _describe_cycle(stuck_layers):
+                stuck_set = set(stuck_layers)
+                lines = []
+                for layer in stuck_layers:
+                    for follower in sorted(must_precede[layer]):
+                        if follower in stuck_set:
+                            cap = rp_edges.get((layer, follower))
+                            label = f'X-Env-Layer-AfterProvider: {cap}' if cap else 'X-Env-Layer-Requires'
+                            lines.append(f'  {layer} must precede {follower}  [{label}]')
+                return lines
+
+            detail = '\n'.join(_describe_cycle(stuck))
+            raise ValueError(
+                f"Loop detected in AfterProvider ordering constraints involving: {', '.join(stuck)}\n{detail}"
+            )
+
+        return result
 
     def _check_provider_conflicts_in_scope(self, layer_names: List[str]) -> None:
         """Validate that no provider conflicts exist within the given scope of layers."""
@@ -651,6 +737,8 @@ class LayerManager:
 
                 reqprov = ', '.join(layer_info.get('provider_requires', [])) or 'none'
                 print(f"    {'Requires-provider:':<{LABEL_W}}{reqprov}")
+                afterprov = ', '.join(layer_info.get('after_provider', [])) or 'none'
+                print(f"    {'After-provider:':<{LABEL_W}}{afterprov}")
 
     def _fmt_versions(self, name: str) -> str:
         """Format the version list for a layer name: single version plain, multiple as '1.0.0  2.0.0*'."""
@@ -908,6 +996,7 @@ def _generate_layer_boilerplate():
 # X-Env-Layer-Version: 1.0.0
 # X-Env-Layer-Provides: debian-base
 # X-Env-Layer-RequiresProvider:
+# X-Env-Layer-AfterProvider:
 # X-Env-Layer-Requires: base-layer,common-tools
 
 # X-Env-VarRequires: SITE
@@ -1092,6 +1181,10 @@ def _layer_main(args):
             if layer_info.get('provider_requires'):
                 requires_list = ', '.join(layer_info['provider_requires'])
                 print(f"Requires Provider: {requires_list}")
+
+            if layer_info.get('after_provider'):
+                after_list = ', '.join(layer_info['after_provider'])
+                print(f"After Provider: {after_list}")
 
             layer_path = manager.layer_files.get(lkey, "<unknown>")
             rel_layer_path = manager.layer_relpaths.get(lkey, layer_path)

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -126,7 +126,8 @@ SUPPORTED_FIELD_PATTERNS = {
     XEnv.layer_type(): {"type": "single", "description": "Layer type (static or dynamic)"},
     XEnv.layer_generator(): {"type": "single", "description": "Generator executable for dynamic layers"},
     XEnv.layer_provides(): {"type": "single", "description": "Capabilities provided by this layer"},
-    XEnv.layer_requires_provider(): {"type": "single", "description": "Capabilities required (virtual)"},
+    XEnv.layer_requires_provider(): {"type": "single", "description": "Capabilities that must exist in the build (validation only)"},
+    XEnv.layer_after_provider(): {"type": "single", "description": "Capabilities that must exist and precede this layer in the build"},
     XEnv.layer_sets(): {"type": "single", "description": "Internal variables set when this layer is present (KEY=VALUE)"},
 
     # Variable definition patterns (these match multiple fields)

--- a/templates/docs/html/layer.html
+++ b/templates/docs/html/layer.html
@@ -136,7 +136,7 @@
     </div>
     {%- endif %}
 
-    {%- if layer.dependencies.static_dep or layer.dependencies.dyn_dep or layer.reverse_dependencies or layer.layer_info.provides or layer.layer_info.provider_requires %}
+    {%- if layer.dependencies.static_dep or layer.dependencies.dyn_dep or layer.reverse_dependencies or layer.layer_info.provides or layer.layer_info.provider_requires or layer.layer_info.after_provider %}
     <div class="section">
         <h2>Relationships</h2>
         {%- if layer.dependencies.static_dep or layer.dependencies.dyn_dep %}
@@ -163,6 +163,9 @@
         {%- endif %}
         {%- if layer.layer_info.provider_requires %}
         <p><strong>Requires Provider:</strong> {{ layer.layer_info.provider_requires|join(', ') }}</p>
+        {%- endif %}
+        {%- if layer.layer_info.after_provider %}
+        <p><strong>After Provider:</strong> {{ layer.layer_info.after_provider|join(', ') }}</p>
         {%- endif %}
     </div>
     {%- endif %}

--- a/test/layer/provider-ordering-consumer.yaml
+++ b/test/layer/provider-ordering-consumer.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-ordering-consumer
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-AfterProvider: base-os
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/provider-ordering-cycle-a.yaml
+++ b/test/layer/provider-ordering-cycle-a.yaml
@@ -1,0 +1,8 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-ordering-cycle-a
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: test-provider-ordering-cycle-b
+# X-Env-Layer-Provides: cap-cycle-a
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/provider-ordering-cycle-b.yaml
+++ b/test/layer/provider-ordering-cycle-b.yaml
@@ -1,0 +1,8 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-ordering-cycle-b
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-AfterProvider: cap-cycle-a
+# X-Env-Layer-Provides: cap-cycle-b
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/run-tests.sh
+++ b/test/layer/run-tests.sh
@@ -705,6 +705,34 @@ EOF
     "Check should fail when multiple layers provide the same capability"
 
 cleanup_env
+run_test "provider-ordering" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-base.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/provider-ordering-consumer.yaml "$TMP_DIR"/ && \
+     make_pipeline_env "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" \
+        --layers test-provider-ordering-consumer test-provider-base \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     awk '"'"'/^test-provider-base:/{base=NR} /^test-provider-ordering-consumer:/{con=NR} END{exit !(base < con)}'"'"' "$TMP_ORDER" && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_ORDER" "$TMP_DIR"' \
+    0 \
+    "RequiresProvider should enforce provider before consumer in build order"
+
+cleanup_env
+run_test "provider-ordering-cycle" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-ordering-cycle-a.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/provider-ordering-cycle-b.yaml "$TMP_DIR"/ && \
+     make_pipeline_env "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" \
+        --layers test-provider-ordering-cycle-a \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" >/dev/null; RESULT=$?; \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_DIR"; \
+     exit $RESULT' \
+    1 \
+    "Cycle between Requires and RequiresProvider should be detected"
+
+cleanup_env
 
 run_test "pipeline-build-order" \
     'TMP_ENV=$(mktemp) && TMP_ENV_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && \


### PR DESCRIPTION
`X-Env-Layer-RequiresProvider` is validation-only. `X-Env-Layer-AfterProvider` validates and positions the provider before the declaring layer in the build plan, which may be useful to constrain layer order based on abstract tokens.
Ref #168 