### PR TITLE
Add reusable apt download cache support

### DIFF
--- a/bin/ns
+++ b/bin/ns
@@ -3,11 +3,18 @@
 # Used to run a command inside a linux user namespace, remapping uid/gid
 # so that permissions may be elevated (eg like inside a container).
 # May be needed for execution of certain commands / tools.
+#
+# NS_SETUP carries the definition of _ns_setup() across the podman unshare
+# boundary. _ns_setup is called inside the namespace before running the cmd.
 
 set -eu
 uid=$(id -u)
+: "${NS_SETUP:=_ns_setup() { :; }}"
+
 if [ "$uid" -eq 0 ]; then
-   exec "$@"
+   eval "$NS_SETUP"
+   _ns_setup
+   "$@"
 else
-   exec podman unshare "$@"
+   exec podman unshare bash -c 'eval "$NS_SETUP"; _ns_setup; "$@"' -- "$@"
 fi

--- a/docs/layer/sys-build-base.html
+++ b/docs/layer/sys-build-base.html
@@ -235,19 +235,20 @@
                 </tr>
                 <tr>
                     <td><code>IGconf_sys_apt_cachedir</code></td>
-                    <td>Cache directory for APT operations.
- Use this to specify the root directory APT uses when downloading packages.
- APT will re-use packages from this directory where possible, meaning that
- usage of this directory can decrease build time.
- By default, the cache dir resides in the chroot and is cleaned up
- automatically upon build completion.
- This is currently an experimental feature requiring some manual involvement.</td>
+                    <td>Optional host-side directory for caching APT package
+ downloads across builds. When set, the directory is bind-mounted into the chroot
+ as /var/cache/apt/archives so packages are written directly to the host and
+ reused on subsequent builds, reducing network usage and build time.
+ The directory must exist before the build commences.
+ By default (unset), the package cache resides only in the chroot and is
+ discarded at build completion.
+ This is currently an opt-in experimental feature.</td>
                     <td>
                            <code>&lt;empty&gt;</code>
                     </td>
                     <td>String value (may be empty)</td>
                     <td>
-                        <a href="variable-validation.html#set-policies" class="badge policy-force" title="Click for policy and validation help">force</a>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>

--- a/layer/base/sys-build-base.yaml
+++ b/layer/base/sys-build-base.yaml
@@ -57,16 +57,17 @@
 # X-Env-Var-cachedir-Set: y
 #
 # X-Env-Var-apt_cachedir:
-# X-Env-Var-apt_cachedir-Desc: Cache directory for APT operations.
-#  Use this to specify the root directory APT uses when downloading packages.
-#  APT will re-use packages from this directory where possible, meaning that
-#  usage of this directory can decrease build time.
-#  By default, the cache dir resides in the chroot and is cleaned up
-#  automatically upon build completion.
-#  This is currently an experimental feature requiring some manual involvement.
+# X-Env-Var-apt_cachedir-Desc: Optional host-side directory for caching APT package
+#  downloads across builds. When set, the directory is bind-mounted into the chroot
+#  as /var/cache/apt/archives so packages are written directly to the host and
+#  reused on subsequent builds, reducing network usage and build time.
+#  The directory must exist before the build commences.
+#  By default (unset), the package cache resides only in the chroot and is
+#  discarded at build completion.
+#  This is currently an opt-in experimental feature.
 # X-Env-Var-apt_cachedir-Required: n
 # X-Env-Var-apt_cachedir-Valid: string-or-empty
-# X-Env-Var-apt_cachedir-Set: force
+# X-Env-Var-apt_cachedir-Set: lazy
 #
 # X-Env-Var-buildroot: ${@WORKROOT}/build
 # X-Env-Var-buildroot-Desc: Global build root directory for source builds.

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -26,6 +26,15 @@ source "$IGTOP/lib/dependencies.sh"
 source "$IGTOP/lib/tools.sh"
 
 
+# Namespace setup (see bin/ns)
+_ns_setup() {
+   # unmount cache (defensive - cleanup hook should handle)
+   [[ -n "${_NS_APT_ARCHIVES:-}" ]] && \
+      trap "umount -q \"$_NS_APT_ARCHIVES\" 2>/dev/null || true" EXIT
+}
+export NS_SETUP="$(declare -f _ns_setup)"
+
+
 # cli
 cmd=${1:-}
 shift
@@ -308,7 +317,7 @@ prepare_build_config()
    # or other dynamically driven settings.
    process_conf_opt() {
       local key=${1:-} value=${2:-}
-      msg "-> $key : $value"
+      msg "$key : $value"
       case $key in
          IGconf_sys_apt_keydir)
             xmkdir "$value"
@@ -321,11 +330,20 @@ prepare_build_config()
 
          IGconf_sys_apt_cachedir)
             if [[ -n "$value" ]]; then
-              local cache=$(realpath -e "$value") 2>/dev/null || die "$key specifies invalid dir ($value)"
-              # @TODO passing --skip=cleanup/apt/cache needs bdebstrap 0.6.0+
-              #_bdebstrap+=( --aptopt 'APT::Keep-Downloaded-Packages "true"' )
-              #_bdebstrap+=( --aptopt 'Debug::pkgAcquire "true"' )
-              #_bdebstrap+=( --aptopt 'Debug::Acquire::file "true"' )
+              local cache
+              cache=$(realpath -e "$value" 2>/dev/null) || die "$value does not exist"
+              local archives=/var/cache/apt/archives
+              export _NS_APT_ARCHIVES="${IGconf_target_path}${archives}"
+
+              local num=$(find "$cache" -maxdepth 1 -name '*.deb' 2>/dev/null | wc -l)
+              msg "Apt cache: $num pkgs @ $cache"
+
+              _bdebstrap+=( --skip=cleanup/apt/cache )
+              _bdebstrap+=( --skip=cleanup/apt/lists )
+              _bdebstrap+=( --skip=essential/unlink )
+              _bdebstrap+=( --aptopt 'APT::Keep-Downloaded-Packages "true"' )
+              _bdebstrap+=( --setup-hook   "mkdir -p \"\$1${archives}/partial\" && mount --bind '$cache' \"\$1${archives}\"" )
+              _bdebstrap+=( --cleanup-hook "umount \"\$1${archives}\"" )
               value="$cache"
             fi
             ;;

--- a/scripts/bdebstrap/cleanup50-apt-cache
+++ b/scripts/bdebstrap/cleanup50-apt-cache
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Clean up if a host apt cache was used
+
+set -eu
+
+if ! igconf isval sys_apt_cachedir ; then
+   exit 0
+fi
+
+rm -rf $1/var/cache/apt/srcpkgcache.bin \
+       $1/var/cache/apt/pkgcache.bin
+
+rm -rf $1/var/lib/apt/lists/* \
+       $1/var/lib/apt/lists/partial/*
+
+if mountpoint -q "$1/var/cache/apt/archives" 2>/dev/null; then
+   exit 0
+fi
+
+rm -rf $1/var/cache/apt/archives/* \
+       $1/var/cache/apt/archives/partial/* \


### PR DESCRIPTION
Add support to bind mount a host directory into the chroot so apt uses it as a persistent package cache across builds, helping to avoid unnecessary downloads. Rudimentary testing shows a reduction in repeated build time of various build targets, although the benefit is network dependent.
This is currently an opt-in feature.
Closes #140 