### PR TITLE
storage-binder: support USB mass storage (USB-MSD) boot

### DIFF
--- a/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
+++ b/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 
-set -u
-
 # Tag an incoming block device as boot-device-backed for udev IMPORT.
 # This script is boot critical and must be compatible with minimal shell
 # environments such as klibc, and be as POSIX compliant as possible.
+
+set -u
 
 die() {
    msg="ERROR: $*"
@@ -42,16 +42,56 @@ read_dt_u32() {
 }
 
 
+# Locate the USB-attached disk that carries our boot partition.
+#
+# The firmware reports a USB boot only via boot-mode; unlike mmcblk0/nvme0n1 it
+# does NOT tell us which block device it booted from, and USB enumeration order
+# is not deterministic (sda/sdb can swap). We therefore identify the boot disk
+# by content: the USB-attached disk holding a vfat partition labelled BOOT (the
+# label this image stamps on its firmware partition, matched by 99-rpi-05-image
+# to by-slot/boot). Prints the disk kname (e.g. "sda") on success.
+usb_boot_disk() {
+   for d in /sys/block/sd*; do
+      [ -e "$d" ] || continue
+      # USB-attached? (sysfs device path passes through a usb controller)
+      case "$(readlink -f "$d/device" 2>/dev/null)" in
+         *[/]usb[0-9]*|*[/]usb/*) ;;
+         *) continue;;
+      esac
+      disk=${d##*/}
+      for p in "$d/$disk"*; do
+         [ -r "$p/partition" ] || continue
+         part=${p##*/}
+         if [ "$(blkid -s LABEL -o value "/dev/$part" 2>/dev/null)" = "BOOT" ] &&
+            [ "$(blkid -s TYPE  -o value "/dev/$part" 2>/dev/null)" = "vfat" ]; then
+            echo "$disk"
+            return 0
+         fi
+      done
+   done
+   return 1
+}
+
+
 MODEL=$(cat /proc/device-tree/model) || die "no model data"
 read -r _ _ GEN REV <<EOF
 $MODEL
 EOF
-BOOT_MODE=$(read_dt_u32 /proc/device-tree/chosen/bootloader/boot-mode) || die "no boot-mode"
+
+# RPI_BOOTDEV_TEST_BOOTMODE overrides the firmware boot-mode for offline
+# testing only; it is never set in normal operation.
+BOOT_MODE=${RPI_BOOTDEV_TEST_BOOTMODE:-$(read_dt_u32 /proc/device-tree/chosen/bootloader/boot-mode)} \
+   || die "no boot-mode"
 BOOT_PARTN=$(read_dt_u32 /proc/device-tree/chosen/bootloader/partition) || die "no boot-part"
 
 case $BOOT_MODE in
    1) BOOT_DEV=mmcblk0; PART_SEP=p;;
    6) BOOT_DEV=nvme0n1; PART_SEP=p;;
+   4|5)  # USB mass storage (USB-MSD). Discover the device by content since the
+         # firmware doesn't name it. Partitions are sdX1, sdX2, ... (no 'p').
+      BOOT_DEV=$(usb_boot_disk) || die "no USB boot disk (vfat BOOT partition) found"
+      PART_SEP=
+      ;;
    *) exit 1;; # Not a storage device, or one we can associate to a linux blkdev
 esac
 

--- a/layer/rpi/device/storage-binder/initramfs-tools/hooks/rpi-bootdev-install
+++ b/layer/rpi/device/storage-binder/initramfs-tools/hooks/rpi-bootdev-install
@@ -8,4 +8,6 @@ esac
 
 copy_exec /usr/bin/od
 copy_exec /usr/bin/rpi-bootdev-tag
+# blkid is needed by rpi-bootdev-tag's USB boot-disk discovery (label/type probe).
+copy_exec /sbin/blkid 2>/dev/null || copy_exec /usr/sbin/blkid 2>/dev/null || true
 copy_file config /etc/udev/rules.d/99-rpi-00-bootdev.rules /etc/udev/rules.d/99-rpi-00-bootdev.rules

--- a/layer/rpi/device/storage-binder/udev/rules.d/storage-binder.rules
+++ b/layer/rpi/device/storage-binder/udev/rules.d/storage-binder.rules
@@ -9,6 +9,12 @@ SUBSYSTEM=="block", KERNEL=="mmcblk0p*", ACTION=="add|change", \
 SUBSYSTEM=="block", KERNEL=="nvme0n1p*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME}"
 
+# Non-DM partitions: USB mass storage (sd*). The tagger only tags these when the
+# firmware boot-mode is USB and the disk carries our boot partition, so this is
+# a harmless no-op for any non-boot USB disk that happens to be attached.
+SUBSYSTEM=="block", KERNEL=="sd[a-z]*[0-9]", ACTION=="add|change", \
+  IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME}"
+
 # DM devices
 SUBSYSTEM=="block", KERNEL=="dm-*", ENV{DM_NAME}=="?*", ACTION=="add|change", \
   IMPORT{program}="/usr/bin/rpi-bootdev-tag -u -d $env{DEVNAME} -m $env{DM_NAME}"


### PR DESCRIPTION
The by-slot root resolver (rpi-bootdev-tag + storage-binder udev rules) only handled SD (boot-mode 1 -> mmcblk0) and NVMe (boot-mode 6 -> nvme0n1). When a Pi boots from USB mass storage the tagger hit the default case and exited, so no partition was tagged RPI_ONBOOTDEV and /dev/disk/by-slot/system was never created: the initramfs gives up waiting for the root device and drops to a shell.

Add USB-MSD support:
- rpi-bootdev-tag: handle boot-mode 4/5. The firmware does not name the USB device (and USB enumeration is non-deterministic), so discover the boot disk by content - the USB-attached disk carrying our vfat BOOT- labelled partition.
- storage-binder.rules: run sd* partitions through the tagger.
- rpi-bootdev-install: bundle blkid into the initramfs for the probe.

The label->by-slot rule (99-rpi-05-image) is already device-agnostic and needs no change.

Tested on a Pi 5 host: the tagger tags only the USB boot disk's partitions, and the full udev chain creates by-slot/{system,boot} -> the USB root/boot partitions. The exact USB boot-mode value(s) should be confirmed on hardware that boots from USB.