### PR TITLE
storage-binder: create by-slot links on Pi 4/5 when firmware reports partition 0

### DIFF
--- a/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
+++ b/layer/rpi/device/storage-binder/bin/rpi-bootdev-tag
@@ -55,10 +55,13 @@ case $BOOT_MODE in
    *) exit 1;; # Not a storage device, or one we can associate to a linux blkdev
 esac
 
-case $GEN in
-   4|5);;
-   *) [ $BOOT_PARTN -eq 0 ] && BOOT_PARTN=1;; # legacy compat
-esac
+# Firmware may report partition 0 when it didn't record a specific boot
+# partition (observed on Pi 4 SD boot: boot-mode=1, partition=0). Partition
+# numbering is 1-based, so 0 means "unset" -> treat as the first partition.
+# This fallback was previously gated to exclude GEN 4|5 on the assumption
+# they always report a valid partition; a partition-0 Pi 4/5 then derived a
+# non-existent /dev/<dev>p0 and died, so the by-slot links were never made.
+[ "$BOOT_PARTN" -eq 0 ] && BOOT_PARTN=1
 
 BOOT_BLKDEV="/dev/${BOOT_DEV}${PART_SEP}${BOOT_PARTN}"
 test -b "$BOOT_BLKDEV" || die "$BOOT_BLKDEV is invalid for boot mode $BOOT_MODE ($BOOT_DEV)"


### PR DESCRIPTION
## Problem

`rpi-bootdev-tag` fails to create the `/dev/disk/by-slot/*` symlinks on a Raspberry Pi 4 booting a `simple_dual` (by-slot) image from SD. The system hangs in the initramfs:

```
ALERT!  /dev/disk/by-slot/system does not exist
```

## Root cause

The tagger derives the boot block device from `chosen/bootloader/partition`. The `partition 0 -> 1` fallback is gated to exclude `GEN` 4|5:

```sh
case $GEN in
   4|5);;
   *) [ $BOOT_PARTN -eq 0 ] && BOOT_PARTN=1;; # legacy compat
esac
```

This assumes a Pi 4/5 always reports a valid 1-based partition. That is not always true — a Pi 4 Model B (Rev 1.1) reports:

```
boot-mode = 1   (SD)
partition = 0
```

so the tagger builds `/dev/mmcblk0p0` (which does not exist), fails the `test -b` sanity check, and dies:

```
ERROR: /dev/mmcblk0p0 is invalid for boot mode 1 (mmcblk0)
```

`RPI_ONBOOTDEV` is therefore never set, the `ID_FS_LABEL`-based by-slot rules never match, and the links are never created. The Pi 5 happens to report a non-zero partition, so it does not hit this.

## Fix

Partition numbers are 1-based, so `0` always means "unset" and can never be a valid device suffix. Make the `0 -> 1` coercion unconditional (it only ever changes an already-invalid value).

## Verification — Pi 4 Model B Rev 1.1, by-slot image on SD

Before:

```
$ rpi-bootdev-tag -u -d /dev/mmcblk0p2
ERROR: /dev/mmcblk0p0 is invalid for boot mode 1 (mmcblk0)     # exit 1
```

After:

```
$ rpi-bootdev-tag -u -d /dev/mmcblk0p2
RPI_ONBOOTDEV=1                                                # exit 0

$ udevadm trigger --subsystem-match=block --action=change && udevadm settle
$ ls -l /dev/disk/by-slot/
system -> ../../mmcblk0p2
boot   -> ../../mmcblk0p1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
