### PR TITLE
feat: traits - part 1

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -9,7 +9,7 @@ link:../index.adoc[← Back to Main Documentation]
 
 == Overview
 
-rpi-image-gen provides a flexible, hierarchical approach to managing build variables through multiple configuration sources with clear precedence rules. The system is built around the `IGconf_` prefix namespace and supports both INI and YAML file formats.
+rpi-image-gen provides a flexible, hierarchical approach to managing build variables through multiple configuration sources with clear precedence rules. The system is built around the `IGconf_` prefix namespace and uses YAML configuration files.
 
 == Core Architecture
 
@@ -131,13 +131,9 @@ FINAL ENV
 
 == Configuration File Support
 
-The configuration system supports both INI and YAML file formats with automatic format detection based on file extension.
+The configuration system uses YAML configuration files with native support for hierarchical data and includes.
 
-=== YAML Configuration Format
-
-YAML provides the most flexible configuration format with native support for hierarchical data and includes.
-
-==== Mapping Sections
+=== Mapping Sections
 
 [source,yaml]
 ----
@@ -158,7 +154,7 @@ image:
   root_part_size: 300%
 ----
 
-==== List Sections
+=== List Sections
 
 In addition to mapping (key-value) sections, YAML configuration files support sequence (list) sections. List items are assigned 0-based numeric keys, producing the same `IGconf_<section>_<key>` variable format as mapping sections.
 
@@ -198,31 +194,9 @@ List sections do not merge with includes in the same way as mapping sections. Be
 ====
 
 
-=== INI Configuration Format
-
-INI format provides traditional section-based configuration:
-
-[source,ini]
-----
-!include base.cfg
-
-[env]
-MYVAR = UNCHANGED
-
-[device]
-class = pi5
-storage_type = sd
-hostname = ${IGconf_device_class}-$(tr -dc 'a-z' < /dev/urandom | head -c 6)
-
-[image]
-compression = zstd
-boot_part_size = 200%
-root_part_size = 300%
-----
-
 === Configuration Includes
 
-Both formats support including other configuration files to promote reusability and modularity. The include precedence order is shown in the table below.
+Configuration files support includes to promote reusability and modularity. The include precedence order is shown in the table below.
 
 [cols="1,6,5"]
 |===
@@ -241,22 +215,7 @@ Both formats support including other configuration files to promote reusability 
 |Default in-tree location, eg ```/usr/share/rpi-image-gen/config/```
 |===
 
-==== YAML Includes
-
-[source,yaml]
-----
-include:
-  file: shared/base.yaml
-----
-
-==== INI Includes
-
-[source,ini]
-----
-!include shared/base.cfg
-----
-
-Therefore, included files are resolved using:
+Included files are resolved using:
 
 1. **Parent directory**
 2. **Search path**
@@ -337,7 +296,7 @@ The configuration system supports multiple variable sources with a clear precede
 
 |2
 |Configuration Files
-|INI or YAML configuration files
+|YAML configuration files
 
 |3 (Lowest)
 |Layer Defaults
@@ -469,7 +428,7 @@ All dependencies are always included, i.e. variable names result in actual layer
 
 The configuration system processes files using the following steps:
 
-1. **Parse main configuration file** - Automatically detects INI or YAML format
+1. **Parse YAML configuration file**
 2. **Process includes recursively** - Follows include directives with circular dependency detection
 3. **Apply command line overrides** - Processes variables specified after `--`
 4. **Generate output** - Either loads into environment or writes to file
@@ -506,15 +465,11 @@ rpi-image-gen config myconfig.yaml --section device --write-to build.env -- IGco
 
 === Config Generation
 
-Generate example configuration files:
+Generate an example YAML configuration:
 
 [source,bash]
 ----
-# Generate boilerplate INI and YAML examples
 rpi-image-gen config --gen
-
-# Migrate INI to YAML format
-rpi-image-gen config legacy.cfg --migrate > modern.yaml
 ----
 
 == Integration with Layer System
@@ -590,7 +545,7 @@ config/
 
 * **Circular includes**: Detected automatically with clear error messages
 * **Missing include files**: Searches all configured paths before failing
-* **Invalid YAML/INI syntax**: Provides line numbers and context
+* **Invalid YAML syntax**: Provides line numbers and context
 * **Undefined variable expansion**: Fails fast with variable name
 * **Section/key conflicts**: Resolved by precedence rules
 
@@ -621,33 +576,6 @@ Layer collection output shows variable policy and evaluated value:
  [LAZY]  IGconf_device_variant=none (layer: device-base)
 ----
 
-== Migration and Compatibility
-
-=== INI to YAML Migration
-
-Use the built-in migration tool:
-
-[source,bash]
-----
-rpi-image-gen config legacy.cfg --migrate > modern.yaml
-----
-
-The migration tool:
-
-* **Preserves include directives** with updated syntax
-* **Maintains section structure** and variable relationships
-* **Updates file extensions** in include references
-* **Adds migration comments** for traceability
-
-=== Backward Compatibility
-
-The configuration system maintains compatibility with:
-
-* **Existing INI files** through automatic format detection
-* **Legacy include syntax** (`!include` vs `include:`)
-* **Environment variable patterns** used by previous versions
-* **Command-line interfaces** with extended functionality
-
 == Performance Considerations
 
 === Configuration Loading Performance
@@ -663,7 +591,7 @@ The rpi-image-gen configuration system provides a robust foundation for managing
 
 * **Hierarchical variable organisation** with the `IGconf_` namespace
 * **Multiple configuration sources** with clear precedence rules
-* **Flexible file formats** (INI and YAML) with include support
+* **YAML configuration files** with include support
 * **Variable expansion** supporting cross-references and environment integration
 * **Layer system integration** for variable discovery and validation
 * **Command-line tools** for configuration management and debugging

--- a/examples/custom_layers/README.md
+++ b/examples/custom_layers/README.md
@@ -4,6 +4,14 @@ The config file used by this example specifies a custom layer to build a system 
 
 Layer acme-sdk-v1.yaml uses the uchroot helper to simplify user chroot operations to ensure files are created in the user's home directory with appropriate permissions. The helper makes standard system variables available in the environment which abstracts and simplifies the operation.
 
+The trait/ directory demonstrates custom traits, building up a small hierarchy under hw:acme. hw.deb822 extends the built-in hw namespace (via its own Include:, adding to it rather than replacing it) with a sub-namespace, hw:acme, holding this vendor's own components (hw:acme:can, hw:acme:gps), a board descriptor (hw:acme:carrierv1), and a product descriptor (hw:acme:productv1):
+
+- hw:acme:can and hw:acme:gps each Triggers: the corresponding existing built-in generic trait (hw:can, hw:gps) - the activation responsibility lives on the specific component, not on whatever selects it, the same way hw:bluetooth:broadcom's presence implies hw:bluetooth.
+- hw:acme:carrierv1 Requires: an existing built-in token (hw:device:rpi:cm5-lite) and Triggers: its own two components - showing a custom trait can both depend on and activate built-in tokens by name, without redeclaring them.
+- hw:acme:productv1 Triggers: both carrierv1 and hw:device:rpi:cm5-lite directly, completing the picture: declaring just the product cascades all the way down through the carrier, its components, the generic hw:can/hw:gps traits, and the entire built-in device chain (SoC, storage, wlan, bluetooth, boot).
+
+Keeping custom traits under their own vendor sub-namespace (hw:acme:*) rather than adding them directly as new top-level hw:* siblings avoids ever colliding with a same-named token the built-in registry might add later.
+
 ```text
 examples/custom_layers/
 |-- acme.options
@@ -15,10 +23,21 @@ examples/custom_layers/
 |   `-- essential.yaml
 |-- profile
 |   `-- deb12-acme
+|-- trait
+|   |-- hw
+|   |   |-- acme
+|   |   |   `-- board.deb822
+|   |   `-- acme.deb822
+|   `-- hw.deb822
 |-- README.md
 `-- setup-functions
 ```
 
 ```bash
 rpi-image-gen build -S ./examples/custom_layers/ -c acme-integration.yaml
+```
+
+```bash
+# Inspect the custom traits, combined with the built-in registry:
+rpi-image-gen config --srcroot ./examples/custom_layers --trait=hw:acme
 ```

--- a/examples/custom_layers/trait/hw.deb822
+++ b/examples/custom_layers/trait/hw.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: ACME carrier board extension to the built-in hw namespace
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: hw/acme.deb822

--- a/examples/custom_layers/trait/hw/acme.deb822
+++ b/examples/custom_layers/trait/hw/acme.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-acme-Desc: ACME custom board trait definitions
+X-Env-Trait-acme-Valid: bool
+X-Env-Trait-acme-Include: acme/board.deb822

--- a/examples/custom_layers/trait/hw/acme/board.deb822
+++ b/examples/custom_layers/trait/hw/acme/board.deb822
@@ -1,0 +1,21 @@
+X-Env-Trait-can-Desc: CAN bus controller module on the ACME carrier board
+X-Env-Trait-can-Valid: bool
+X-Env-Trait-can-Triggers: when=y set (hw:can)=y
+
+X-Env-Trait-gps-Desc: GPS modem module on the ACME carrier board
+X-Env-Trait-gps-Valid: bool
+X-Env-Trait-gps-Triggers: when=y set (hw:gps)=y
+
+X-Env-Trait-carrierv1-Desc: ACME carrier board v1 - pairs with CM5 Lite, adds CAN, GPS and Ethernet
+X-Env-Trait-carrierv1-Valid: bool
+X-Env-Trait-carrierv1-Requires: hw:device:rpi:cm5-lite
+X-Env-Trait-carrierv1-Triggers:
+ when=y set (hw:acme:can)=y
+ when=y set (hw:acme:gps)=y
+ when=y set (hw:ethernet)=y
+
+X-Env-Trait-productv1-Desc: ACME product v1 - entire assembly with acmev1 carrier plus CM5 Lite
+X-Env-Trait-productv1-Valid: bool
+X-Env-Trait-productv1-Triggers:
+ when=y set (hw:acme:carrierv1)=y
+ when=y set (hw:device:rpi:cm5-lite)=y

--- a/site/conditions.py
+++ b/site/conditions.py
@@ -16,6 +16,7 @@ defined by the Python language specification:
 
 Supported comparison operators:  ==  !=  in  not in
 Supported boolean operators:     and  or
+Supported trait functions:       has()  not has()
 
 Variable names in expressions are resolved from a plain dict[str, str]
 passed in by the caller. The caller is responsible for building that dict
@@ -23,7 +24,7 @@ passed in by the caller. The caller is responsible for building that dict
 """
 
 import ast
-from typing import Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple, Optional
 
 
 class SyntaxExample(NamedTuple):
@@ -37,8 +38,10 @@ SYNTAX_EXAMPLES: List[SyntaxExample] = [
     SyntaxExample("!=",     "IGconf_device_user1pass != ''"),
     SyntaxExample("in",     "IGconf_device_class in ['pi4', 'cm4', 'pi5', 'cm5']"),
     SyntaxExample("not in", "IGconf_device_class not in ['zero2w']"),
-    SyntaxExample("and",    "IGconf_a == 'x' and IGconf_b == 'y'"),
-    SyntaxExample("or",     "IGconf_a == 'x' or IGconf_b == 'y'"),
+    SyntaxExample("and",     "IGconf_a == 'x' and IGconf_b == 'y'"),
+    SyntaxExample("or",      "IGconf_a == 'x' or IGconf_b == 'y'"),
+    SyntaxExample("has",     "has('hw:bluetooth')"),
+    SyntaxExample("not has", "not has('hw:bluetooth')"),
 ]
 
 
@@ -57,22 +60,25 @@ def validate(condition: str) -> None:
         tree = ast.parse(condition, mode='eval')
     except SyntaxError as e:
         raise ValueError(f"Invalid condition '{condition}': {e}") from e
-    if not isinstance(tree.body, (ast.Compare, ast.BoolOp)):
+    if not isinstance(tree.body, (ast.Compare, ast.BoolOp, ast.Call, ast.UnaryOp)):
         raise ValueError(
-            f"Invalid condition '{condition}': must be a comparison or boolean expression"
-            f" — e.g. IGconf_x == 'value' or IGconf_x in ['a', 'b']"
+            f"Invalid condition '{condition}': must be a comparison, boolean, or trait expression"
+            f" — e.g. IGconf_x == 'value', IGconf_x in ['a', 'b'], has('hw:bluetooth')"
         )
     _check_node(tree.body, condition)
 
 
-def evaluate(condition: str, variables: Dict[str, str]) -> bool:
+def evaluate(condition: str, variables: Dict[str, str],
+             provider_index: Optional[Dict[str, str]] = None) -> bool:
     """
     Evaluate a condition expression against a variable dict.
     Parses the expression and walks the AST, resolving variable names against
     the provided dict. Assumes validate() has already been called.
+
+    provider_index must be supplied when the condition contains has() calls.
     """
     tree = ast.parse(condition, mode='eval')
-    return bool(_eval_node(tree.body, variables, condition))
+    return bool(_eval_node(tree.body, variables, condition, provider_index))
 
 
 # -----------------------------------------------------------------------------
@@ -133,22 +139,54 @@ def _check_node(node, condition: str) -> None:
         for elt in node.elts:
             _check_node(elt, condition)
 
+    elif isinstance(node, ast.UnaryOp):
+        # Only 'not has(...)' is supported. 'not' applied to a variable name
+        # (e.g. 'not IGconf_x') would silently invert the string's truthiness,
+        # which is never what a layer author intends.
+        if not isinstance(node.op, ast.Not):
+            raise ValueError(
+                f"Unsupported unary operator in '{condition}' — only 'not' is supported"
+            )
+        if not isinstance(node.operand, ast.Call):
+            raise ValueError(
+                f"'not' can only negate has() in '{condition}'"
+                f" — use != '' to test for a non-empty variable"
+            )
+        _check_node(node.operand, condition)
+
+    elif isinstance(node, ast.Call):
+        # Only has('token') is permitted — no other function calls.
+        if not (isinstance(node.func, ast.Name) and node.func.id == 'has'):
+            raise ValueError(
+                f"Unsupported function call in '{condition}' — only has() is permitted"
+            )
+        if len(node.args) != 1 or node.keywords:
+            raise ValueError(
+                f"has() requires exactly one string argument in '{condition}'"
+            )
+        if not isinstance(node.args[0], ast.Constant) or not isinstance(node.args[0].value, str):
+            raise ValueError(
+                f"has() argument must be a quoted string in '{condition}'"
+            )
+
     else:
         raise ValueError(
             f"Unsupported expression '{type(node).__name__}' in '{condition}'"
         )
 
 
-def _eval_node(node, variables: Dict[str, str], condition: str):
+def _eval_node(node, variables: Dict[str, str], condition: str,
+               provider_index: Optional[Dict[str, str]] = None):
     """
     Recursively evaluate an AST node and return a Python value.
 
     Compare nodes return bool. Name and Constant nodes return str.
     List and Tuple nodes return list[str] for use with 'in' / 'not in'.
+    Call nodes (has()) return bool. UnaryOp(Not) inverts its operand.
     """
     if isinstance(node, ast.Compare):
-        left = _eval_node(node.left, variables, condition)
-        right = _eval_node(node.comparators[0], variables, condition)
+        left = _eval_node(node.left, variables, condition, provider_index)
+        right = _eval_node(node.comparators[0], variables, condition, provider_index)
         op = node.ops[0]
         if isinstance(op, ast.Eq):    return left == right
         if isinstance(op, ast.NotEq): return left != right
@@ -158,8 +196,19 @@ def _eval_node(node, variables: Dict[str, str], condition: str):
     if isinstance(node, ast.BoolOp):
         # Use all() / any() so that short-circuit eval is preserved
         if isinstance(node.op, ast.And):
-            return all(_eval_node(v, variables, condition) for v in node.values)
-        return any(_eval_node(v, variables, condition) for v in node.values)
+            return all(_eval_node(v, variables, condition, provider_index) for v in node.values)
+        return any(_eval_node(v, variables, condition, provider_index) for v in node.values)
+
+    if isinstance(node, ast.UnaryOp):
+        return not _eval_node(node.operand, variables, condition, provider_index)
+
+    if isinstance(node, ast.Call):
+        token = node.args[0].value
+        if provider_index is None:
+            raise ValueError(
+                f"has() used in '{condition}' but no provider index is available"
+            )
+        return token in provider_index
 
     if isinstance(node, ast.Name):
         if node.id not in variables:
@@ -172,7 +221,7 @@ def _eval_node(node, variables: Dict[str, str], condition: str):
         return node.value
 
     if isinstance(node, (ast.List, ast.Tuple)):
-        return [_eval_node(e, variables, condition) for e in node.elts]
+        return [_eval_node(e, variables, condition, provider_index) for e in node.elts]
 
     raise ValueError(
         f"Unsupported node '{type(node).__name__}' in condition '{condition}'"

--- a/site/config_loader.py
+++ b/site/config_loader.py
@@ -1,9 +1,8 @@
-import configparser
 import os
 import sys
 import yaml
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Tuple
 
 
 class ConfigLoader:
@@ -15,16 +14,8 @@ class ConfigLoader:
         self.search_paths = [Path(p).resolve() for p in (search_paths or ["./config"])]
         self.file_format = self._detect_format()
 
-        # Data will be stored as Dict[str, Dict[str, str]] regardless of source format
         self.data: Dict[str, Dict[str, str]] = {}
-
-        # Track which values are overridden
         self.overrides: Dict[str, str] = {}
-
-        # For backward compat - maintain config attribute for INI files
-        if self.file_format == 'ini':
-            # Disable interpolation to allow literal % chars
-            self.config = configparser.ConfigParser(interpolation=None)
 
         self._load()
         if self.overrides_path:
@@ -34,11 +25,7 @@ class ConfigLoader:
         suffix = Path(self.cfg_path).suffix.lower()
         if suffix in ['.yaml', '.yml']:
             return 'yaml'
-        elif suffix in ['.ini', '.cfg', '.conf']:
-            return 'ini'
-        else:
-            # Backward compat
-            return 'ini'
+        raise ValueError(f"Unsupported config file format '{suffix}' — only .yaml and .yml are supported")
 
     def _resolve_include(self, inc_name: str, parent_dir: Path) -> Path:
         """Resolve include file by trying parent dir then configured search paths."""
@@ -77,13 +64,8 @@ class ConfigLoader:
         raise FileNotFoundError(f"Config file not found: {self.cfg_path}{search_info}")
 
     def _load(self):
-        # Resolve config file path using search paths
         self.cfg_path = self._resolve_config_path()
-
-        if self.file_format == 'yaml':
-            self._load_yaml()
-        else:
-            self._load_ini()
+        self._load_yaml()
 
     def _load_yaml(self):
         """Load YAML file and convert to internal format"""
@@ -113,7 +95,6 @@ class ConfigLoader:
                     raise ValueError(f"YAML include directive in {path} missing 'file' key")
                 inc_path = self._resolve_include(inc_file, path.parent)
                 included_sections = _load_yaml_recursive(inc_path, visited)
-                # Remove include key before merging
                 yaml_data.pop('include', None)
 
             # Convert current file sections
@@ -143,37 +124,6 @@ class ConfigLoader:
             return merged
 
         self.data = _load_yaml_recursive(Path(self.cfg_path).resolve(), set())
-
-    def _load_ini(self):
-        """Load INI file using configparser"""
-        def _load_ini_recursive(path: Path, visited: set, cfg: configparser.ConfigParser):
-            if path in visited:
-                raise ValueError(f"Circular include detected in INI files: {path}")
-            visited.add(path)
-
-            buffer_lines = []
-            with open(path, 'r') as f:
-                for line in f:
-                    stripped = line.strip()
-                    if stripped.startswith('!include'):
-                        parts = stripped.split(maxsplit=1)
-                        if len(parts) != 2:
-                            raise ValueError(f"Invalid !include directive in {path}: {line}")
-                        inc_name = parts[1].strip()
-                        inc_path = self._resolve_include(inc_name, path.parent)
-                        _load_ini_recursive(inc_path, visited, cfg)
-                    else:
-                        buffer_lines.append(line)
-
-            cfg.read_string(''.join(buffer_lines))
-
-        # Disable interpolation
-        self.config = configparser.ConfigParser(interpolation=None)
-        self.config.optionxform = str
-        _load_ini_recursive(Path(self.cfg_path).resolve(), set(), self.config)
-
-        for section in self.config.sections():
-            self.data[section] = dict(self.config[section].items())
 
     def _load_overrides(self):
         """Load override file with key=value pairs and expand variables"""
@@ -477,15 +427,14 @@ class ConfigLoader:
 
 
 def ConfigLoader_register_parser(subparsers):
-    parser = subparsers.add_parser("config", help="Config utilities (.ini/.yaml)")
-    parser.add_argument("cfg_path", nargs="?", help="Path to config file (.ini/.yaml) (required unless using --gen)")
+    parser = subparsers.add_parser("config", help="Config utilities (.yaml)")
+    parser.add_argument("cfg_path", nargs="?", help="Path to config file (.yaml) (required unless using --gen)")
     parser.add_argument("--section", help="Section to load (load all if omitted)")
     parser.add_argument("--path", metavar="DIRS", help="Colon-separated search path for included files")
     parser.add_argument("--no-expand", action="store_true", help="Disable $VAR expansion")
     parser.add_argument("--write-to", metavar="FILE", help="Write variables to file instead of env load")
     parser.add_argument("--overrides", metavar="FILE", help="Override file with key=value pairs")
-    parser.add_argument("--gen", action="store_true", help="Generate example .ini and .yaml with include syntax")
-    parser.add_argument("--migrate", action="store_true", help="Convert INI to YAML and write to stdout")
+    parser.add_argument("--gen", action="store_true", help="Generate example .yaml with include syntax")
     parser.set_defaults(func=_main)
 
 
@@ -496,10 +445,6 @@ def _main(args):
 
     if not args.cfg_path:
         print("Error: cfg_path is required unless --gen is used", file=sys.stderr)
-        return
-
-    if args.migrate:
-        _migrate_to_yaml(args.cfg_path, args)
         return
 
     try:
@@ -521,72 +466,8 @@ def _main(args):
         raise SystemExit(1)
 
 
-def _migrate_to_yaml(ini_path: str, args):
-    """Migrate INI syntax file to YAML and write to stdout"""
-    from pathlib import Path
-
-    yaml_data = {}
-    includes = []
-
-    # Parse the original file to extract includes and sections
-    ini_file = Path(ini_path)
-    current_section = None
-
-    with open(ini_file, 'r') as f:
-        for line in f:
-            stripped = line.strip()
-            if stripped.startswith('!include'):
-                parts = stripped.split(maxsplit=1)
-                if len(parts) == 2:
-                    inc_name = parts[1].strip()
-                    # Convert .cfg to .yaml extension for the include
-                    if inc_name.endswith('.cfg'):
-                        inc_name = inc_name[:-4] + '.yaml'
-                    includes.append(inc_name)
-            elif stripped.startswith('[') and stripped.endswith(']'):
-                current_section = stripped[1:-1]
-            elif stripped and not stripped.startswith('#') and '=' in stripped and current_section:
-                key, value = stripped.split('=', 1)
-                key = key.strip()
-                value = value.strip()
-                if current_section not in yaml_data:
-                    yaml_data[current_section] = {}
-                yaml_data[current_section][key] = value
-
-    # Write the YAML output
-    print("# Generated by rpi-image-gen config --migrate")
-    print()
-
-    # includes at the top
-    if includes:
-        for inc in includes:
-            print(f"include:")
-            print(f"  file: {inc}")
-            print()
-
-    # sections
-    if yaml_data:
-        yaml.dump(yaml_data, sys.stdout, default_flow_style=False, sort_keys=False, indent=2)
-
-
 def _generate_boilerplate():
-    ini_top = """
-!include base.cfg
-
-[device]
-variant = lite
-storage_type = sd
-"""
-
-    ini_base = """
-[device]
-class = cm5
-storage_type = emmc
-sector_size = 512
-"""
-
-    yaml_top = """
-include:
+    yaml_top = """include:
   file: base.yaml
 
 device:
@@ -594,14 +475,11 @@ device:
   storage_type: sd
 """
 
-    yaml_base = """
-device:
+    yaml_base = """device:
   class: cm5
   storage_type: emmc
   sector_size: 512
 """
 
-    print("INI example (top.cfg):\n" + ini_top)
-    print("base.cfg:\n" + ini_base)
-    print("YAML example (top.yaml):\n" + yaml_top)
+    print("top.yaml:\n" + yaml_top)
     print("base.yaml:\n" + yaml_base)

--- a/site/config_loader.py
+++ b/site/config_loader.py
@@ -434,7 +434,9 @@ def ConfigLoader_register_parser(subparsers):
     parser.add_argument("--no-expand", action="store_true", help="Disable $VAR expansion")
     parser.add_argument("--write-to", metavar="FILE", help="Write variables to file instead of env load")
     parser.add_argument("--overrides", metavar="FILE", help="Override file with key=value pairs")
+    parser.add_argument("-S", "--srcroot", dest="srcroot", metavar="DIR", help="Custom source tree (adds its trait/ to --trait search)")
     parser.add_argument("--gen", action="store_true", help="Generate example .yaml with include syntax")
+    parser.add_argument("--trait", metavar="TOKEN", nargs="?", const="", help="Expand a trait token and show its full token set; omit TOKEN to list all")
     parser.set_defaults(func=_main)
 
 
@@ -443,8 +445,13 @@ def _main(args):
         _generate_boilerplate()
         return
 
+    if args.trait is not None:
+        token = args.trait or args.cfg_path or ""
+        _show_trait(token, args)
+        return
+
     if not args.cfg_path:
-        print("Error: cfg_path is required unless --gen is used", file=sys.stderr)
+        print("Error: cfg_path is required unless --gen or --trait is used", file=sys.stderr)
         return
 
     try:
@@ -464,6 +471,70 @@ def _main(args):
     except (ValueError, FileNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
         raise SystemExit(1)
+
+
+def _show_trait(token: str, args):
+    from trait_registry import TraitRegistry
+
+    igroot = os.environ.get('IGTOP', str(Path(__file__).parent.parent))
+    seen = set()
+    trait_dirs = []
+    for root in filter(None, [
+        igroot,
+        getattr(args, 'srcroot', None) or '',
+        *(s.strip() for s in (args.path.split(':') if getattr(args, 'path', None) else [])),
+    ]):
+        d = os.path.join(root, 'trait')
+        r = os.path.realpath(d)
+        if r not in seen:
+            seen.add(r)
+            trait_dirs.append(d)
+
+    try:
+        registry = TraitRegistry(trait_dirs)
+        tokens = registry.all_tokens if not token else registry.by_prefix(token)
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if not tokens:
+        if token:
+            print(f"No trait tokens match '{token}'", file=sys.stderr)
+        return
+
+    import textwrap
+
+    bold = "\033[1m" if sys.stdout.isatty() else ""
+    reset = "\033[0m" if sys.stdout.isatty() else ""
+    cwd = Path.cwd()
+
+    entries = sorted(tokens.items())
+    for i, (t, source) in enumerate(entries):
+        try:
+            src = str(Path(source).relative_to(cwd))
+        except ValueError:
+            src = source
+        desc = registry.get_desc(t) or ""
+        valid = registry.get_valid(t) or ""
+        print(f"{bold}{t}{reset}")
+        if desc:
+            for line in textwrap.wrap(desc, width=76, initial_indent="  Desc: ", subsequent_indent="        "):
+                print(line)
+        if valid:
+            print(f"  Type: {valid}")
+        print(f"  File: {src}")
+        requires = registry.get_requires(t)
+        if requires:
+            print("  Requires:")
+            for r in requires:
+                print(f"    {r}")
+        implied = sorted(k for k in registry.expand(t) if k != t)
+        if implied:
+            print("  Activates:")
+            for k in implied:
+                print(f"    {k}")
+        if i < len(entries) - 1:
+            print()
 
 
 def _generate_boilerplate():

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -2,7 +2,7 @@ import re
 import shlex
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Any, Tuple
-from validators import BaseValidator, parse_validator
+from validators import BaseValidator, BooleanValidator, parse_validator
 
 
 # X-Env field helpers
@@ -233,6 +233,101 @@ class XEnv:
         """Check if field name is an X-Env-Layer field."""
         return field_name.startswith(cls.LAYER_PREFIX)
 
+    # === TRAIT FIELD METHODS ===
+    # One stanza per file (like layers), with the token's local name folded
+    # into the field key — X-Env-Trait-<local>-Desc etc. — exactly parallel
+    # to X-Env-Var-<name>-Desc. Local names are never uppercased (trait
+    # tokens stay lowercase), unlike var names.
+
+    TRAIT_PREFIX = "X-Env-Trait-"
+    TRAIT_ATTR_SUFFIXES = ('Desc', 'Valid', 'Requires', 'Triggers', 'Include')
+
+    @classmethod
+    def trait_desc(cls, name: str) -> str:
+        """Build trait description field: X-Env-Trait-{name}-Desc"""
+        return f"{cls.TRAIT_PREFIX}{name}-Desc"
+
+    @classmethod
+    def trait_valid(cls, name: str) -> str:
+        """Build trait validation-type field: X-Env-Trait-{name}-Valid"""
+        return f"{cls.TRAIT_PREFIX}{name}-Valid"
+
+    @classmethod
+    def trait_requires(cls, name: str) -> str:
+        """Build trait requires field: X-Env-Trait-{name}-Requires"""
+        return f"{cls.TRAIT_PREFIX}{name}-Requires"
+
+    @classmethod
+    def trait_triggers(cls, name: str) -> str:
+        """Build trait triggers field: X-Env-Trait-{name}-Triggers"""
+        return f"{cls.TRAIT_PREFIX}{name}-Triggers"
+
+    @classmethod
+    def trait_include(cls, name: str) -> str:
+        """Build trait include field: X-Env-Trait-{name}-Include"""
+        return f"{cls.TRAIT_PREFIX}{name}-Include"
+
+    # === PATTERN METHODS FOR SUPPORTED_FIELD_PATTERNS ===
+
+    @classmethod
+    def trait_desc_pattern(cls) -> str:
+        return f"{cls.TRAIT_PREFIX}*-Desc"
+
+    @classmethod
+    def trait_valid_pattern(cls) -> str:
+        return f"{cls.TRAIT_PREFIX}*-Valid"
+
+    @classmethod
+    def trait_requires_pattern(cls) -> str:
+        return f"{cls.TRAIT_PREFIX}*-Requires"
+
+    @classmethod
+    def trait_triggers_pattern(cls) -> str:
+        return f"{cls.TRAIT_PREFIX}*-Triggers"
+
+    @classmethod
+    def trait_include_pattern(cls) -> str:
+        return f"{cls.TRAIT_PREFIX}*-Include"
+
+    @classmethod
+    def is_trait_field(cls, field_name: str) -> bool:
+        """Check if field name is an X-Env-Trait field."""
+        return field_name.startswith(cls.TRAIT_PREFIX)
+
+    @classmethod
+    def parse_trait_field(cls, field_name: str) -> Optional[Tuple[str, str]]:
+        """
+        Parse a trait field into (local_name, attribute_suffix).
+
+        Suffix-anchored rather than dash-position-anchored: local names can
+        contain hyphens (vc-firmware, aes-accel), unlike IGconf var names, so
+        "split on first/last dash" doesn't work. Matches against the fixed,
+        known suffix set instead. Returns None for anything else, including
+        a well-formed-looking field whose suffix isn't recognised (typos) —
+        callers treat that as "not a trait attribute field".
+        """
+        if not cls.is_trait_field(field_name):
+            return None
+        rest = field_name[len(cls.TRAIT_PREFIX):]
+        for suffix in cls.TRAIT_ATTR_SUFFIXES:
+            marker = f'-{suffix}'
+            if rest.endswith(marker) and len(rest) > len(marker):
+                return (rest[:-len(marker)], suffix)
+        return None
+
+    @classmethod
+    def is_trait_desc_field(cls, field_name: str) -> bool:
+        """Check if field name is a trait's -Desc field (the discovery
+        anchor for enumerating local names, since Desc is mandatory)."""
+        parsed = cls.parse_trait_field(field_name)
+        return parsed is not None and parsed[1] == 'Desc'
+
+    @classmethod
+    def extract_trait_local_name(cls, field_name: str) -> Optional[str]:
+        """Extract the local name from any recognised trait attribute field."""
+        parsed = cls.parse_trait_field(field_name)
+        return parsed[0] if parsed else None
+
 
 TRIGGER_DEFAULT_POLICY = "immediate"
 ACTION_PARSERS: Dict[str, Any] = {}
@@ -302,6 +397,146 @@ class TriggerRule:
     target: str
     value: str
     policy: str = TRIGGER_DEFAULT_POLICY
+
+
+TRAIT_TOKEN_PATTERN = r'[a-z][a-z0-9]*(?::[a-z][a-z0-9_-]*)+'
+# Captures the target token and the raw value separately — the value's
+# syntax is validated in _parse_trait_triggers via the declaring trait's own
+# resolved Valid: validator (always BooleanValidator today), not a hardcoded
+# literal, so 'y'/'yes'/'true'/'1' are all accepted the same way they would
+# be anywhere else in this metadata scheme.
+_TRAIT_TRIGGER_ACTION_RE = re.compile(rf'^set \(({TRAIT_TOKEN_PATTERN})\)=(.+)$')
+
+
+@dataclass(frozen=True)
+class TraitTriggerRule:
+    """A single 'when=<condition> set (<token>)=y' rule from X-Env-Trait-Triggers.
+
+    Unlike TriggerRule (X-Env-Var-*-Triggers), the action always activates
+    its target - traits are presence-only, there is no value to carry
+    beyond on/off, and Triggers only ever turn one on (suppression is a
+    build-config override's job, not a Trigger's). 'when=y' is a literal,
+    always-true condition (unconditional push, the trait equivalent of
+    implies:), reusing the same when= grammar rather than a separate
+    unconditional-rule syntax.
+    """
+    condition: str
+    target: str
+
+
+def _parse_trait_triggers(raw: str, trait_name: str, validator: BooleanValidator) -> List[TraitTriggerRule]:
+    """Parse X-Env-Trait-Triggers: one 'when=<condition> set (<token>)=y' rule
+    per line (DEB822 continuation lines, one physical line per rule).
+
+    'validator' is the declaring trait's own, already-resolved Valid:
+    validator - guaranteed to be a BooleanValidator by from_metadata_fields
+    before this is called, so both the boolean-shape check and the
+    true-values check below delegate to it (validate()/describe()/
+    TRUE_VALUES) rather than hardcoding a duplicate class or value list."""
+    import conditions as _cond
+
+    rules: List[TraitTriggerRule] = []
+    for line in (l.strip() for l in str(raw).splitlines()):
+        if not line:
+            continue
+        if not line.startswith("when="):
+            raise ValueError(
+                f"Trait trigger rule '{line}' for '{trait_name}' must start with 'when='"
+            )
+        condition, action = _split_condition_and_action(line, trait_name)
+        # 'y' is a literal sentinel (unconditional push), not a real
+        # expression - the one case resolve() itself special-cases before
+        # ever calling conditions.evaluate(). Everything else must be a
+        # genuine, syntactically valid condition.
+        if condition != 'y':
+            _cond.validate(condition)
+        match = _TRAIT_TRIGGER_ACTION_RE.match(action)
+        if not match:
+            raise ValueError(
+                f"Trait trigger action '{action}' for '{trait_name}' must be 'set (<token>)=<value>'"
+            )
+        target, value = match.group(1), match.group(2)
+        errors = validator.validate(value)
+        if errors:
+            raise ValueError(
+                f"Trait trigger action '{action}' for '{trait_name}': {errors[0]} "
+                f"({validator.describe()})"
+            )
+        if value.lower() not in validator.TRUE_VALUES:
+            raise ValueError(
+                f"Trait trigger action '{action}' for '{trait_name}' must set a true value "
+                f"(y/yes/true/1) - Triggers only ever activate a trait, never deactivate it"
+            )
+        rules.append(TraitTriggerRule(condition=condition, target=target))
+    return rules
+
+
+class EnvTrait:
+    """Represents a single trait token definition (one local name's
+    X-Env-Trait-<local>-* field group within a file's stanza)."""
+
+    def __init__(self, name: str, desc: str = "", valid: str = "bool",
+                 validator: Optional[BaseValidator] = None,
+                 requires: Optional[List[str]] = None,
+                 triggers: Optional[List[TraitTriggerRule]] = None,
+                 include: Optional[List[str]] = None,
+                 source: str = "", position: int = 0):
+        self.name = name
+        self.desc = desc
+        self.valid = valid
+        self.validator = validator or BooleanValidator()
+        self.requires = requires or []
+        self.triggers = triggers or []
+        self.include = include or []
+        self.source = source
+        self.position = position
+
+    @classmethod
+    def from_metadata_fields(cls, local_name: str, metadata_dict: Dict[str, str],
+                              source: str = "", position: int = 0) -> 'EnvTrait':
+        """Create an EnvTrait for one local name found in a file's fields.
+
+        'local_name' is the raw, as-written field-key fragment — it may be a
+        full token (top-level scan) or a relative suffix to be prefixed by
+        whichever node's Include pulled this file in. Resolving it to a full
+        name and validating the result is the registry's job
+        (TraitRegistry), not this parser's — it doesn't know the inherited
+        prefix. Caller (MetadataContainer) only invokes this when
+        XEnv.trait_desc(local_name) is present, mirroring EnvVariable's base
+        field being required to declare a variable.
+        """
+        desc = metadata_dict.get(XEnv.trait_desc(local_name), "").strip()
+        if not desc:
+            raise ValueError(f"{source}: trait '{local_name}' must have {XEnv.trait_desc(local_name)}")
+
+        valid = metadata_dict.get(XEnv.trait_valid(local_name), "").strip()
+        try:
+            validator = parse_validator(valid)
+        except ValueError as exc:
+            raise ValueError(f"{source}: trait '{local_name}' {XEnv.trait_valid(local_name)}: {exc}") from exc
+        if not isinstance(validator, BooleanValidator):
+            raise ValueError(
+                f"{source}: trait '{local_name}' {XEnv.trait_valid(local_name)} must be 'bool' - traits are "
+                f"presence-only (every Triggers: action activates a trait, it never carries an "
+                f"arbitrary value), got '{valid}' ({validator.describe()})"
+            )
+
+        requires_raw = metadata_dict.get(XEnv.trait_requires(local_name), "")
+        requires = EnvLayer._parse_dependency_list(requires_raw)
+
+        triggers_raw = metadata_dict.get(XEnv.trait_triggers(local_name), "")
+        triggers = _parse_trait_triggers(triggers_raw, local_name, validator) if triggers_raw.strip() else []
+
+        # File paths, not dependency tokens - _parse_dependency_list's charset
+        # check rejects '/' and '.', so it doesn't fit here.
+        include_raw = metadata_dict.get(XEnv.trait_include(local_name), "")
+        include = [i.strip() for i in include_raw.split(',') if i.strip()]
+
+        return cls(
+            name=local_name, desc=desc, valid=valid, validator=validator,
+            requires=requires, triggers=triggers, include=include,
+            source=source, position=position,
+        )
 
 
 class EnvVariable:
@@ -416,10 +651,16 @@ class EnvVariable:
         )
 
     @staticmethod
-    def _parse_set_policy(value: Optional[str]) -> str:
-        """Parse Set policy value into canonical form."""
+    def _parse_set_policy(value: Optional[str], default: str = "immediate") -> str:
+        """Parse Set policy value into canonical form.
+
+        'default' is what an omitted field resolves to — callers with a
+        different natural default (e.g. traits defaulting to 'skip') pass
+        it explicitly. The value vocabulary and its meaning are unchanged
+        either way.
+        """
         if value is None:
-            return "immediate"
+            return default
         val = str(value).strip().lower()
 
         if val in ["false", "0", "no", "n"]:
@@ -722,6 +963,7 @@ class MetadataContainer:
     def __init__(self, filepath: str = ""):
         self.filepath = filepath
         self.variables: Dict[str, EnvVariable] = {}
+        self.traits: Dict[str, EnvTrait] = {}
         self.layer: Optional[EnvLayer] = None
         self.var_prefix: str = ""
         self.required_vars: List[str] = []
@@ -762,6 +1004,38 @@ class MetadataContainer:
                 except Exception as e:
                     # Skip other types of errors - they'll be caught during validation
                     pass
+
+        # Extract traits. Validated eagerly here (mirroring EnvLayer's own
+        # inline _validate_layer_fields call) rather than only via the
+        # separate --lint aggregator, so a typo'd attribute suffix is a hard
+        # error the moment the file loads, for every consumer alike.
+        # Delegates to metadata_parser.is_field_supported() - the same
+        # SUPPORTED_FIELD_PATTERNS-driven check --lint uses - rather than a
+        # second, independent notion of "supported", exactly as
+        # _validate_layer_fields does for X-Env-Layer-* fields (import
+        # deferred to here to avoid a circular import at module load).
+        try:
+            from metadata_parser import is_field_supported
+        except ImportError:
+            is_field_supported = None
+        if is_field_supported is not None:
+            for key in container.raw_metadata.keys():
+                if XEnv.is_trait_field(key) and not is_field_supported(key):
+                    fname = filepath.split('/')[-1] if filepath else "unknown"
+                    raise ValueError(f"Unsupported trait field '{key}' in {fname}")
+
+        trait_position = 0
+        for key in container.raw_metadata.keys():
+            if XEnv.is_trait_desc_field(key):
+                local_name = XEnv.extract_trait_local_name(key)
+                try:
+                    trait = EnvTrait.from_metadata_fields(
+                        local_name, container.raw_metadata, source=filepath, position=trait_position
+                    )
+                    container.traits[local_name] = trait
+                    trait_position += 1
+                except ValueError as e:
+                    raise ValueError(f"Invalid specifier for trait {local_name}: {e}")
 
         # Extract required/optional environment variable lists
         required_vars_str = container.raw_metadata.get(XEnv.var_requires(), "")
@@ -1108,10 +1382,13 @@ class VariableResolver:
         # Variable is set in environment or no applicable definitions
         return None
 
-    def _get_first_by_position(self, definitions: List[EnvVariable]) -> EnvVariable:
+    @staticmethod
+    def _get_first_by_position(definitions: List[Any]) -> Any:
         """
-        Get the earliest definition by layer position.
+        Get the earliest definition by position.
         If positions tie, prefer the first definition in list order.
+        Generic over any object with a '.position' attribute - also used by
+        TraitRegistry for X-Env-Trait-* Set-policy resolution.
         """
         best_idx = 0
         best = definitions[0]
@@ -1124,10 +1401,13 @@ class VariableResolver:
                 best = definition
         return best
 
-    def _get_last_by_position(self, definitions: List[EnvVariable]) -> EnvVariable:
+    @staticmethod
+    def _get_last_by_position(definitions: List[Any]) -> Any:
         """
-        Get the latest definition by layer position.
+        Get the latest definition by position.
         If positions tie, prefer the last definition in list order.
+        Generic over any object with a '.position' attribute - also used by
+        TraitRegistry for X-Env-Trait-* Set-policy resolution.
         """
         best_idx = 0
         best = definitions[0]

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -6,7 +6,7 @@ import yaml
 from debian import deb822
 from typing import Dict
 from validators import parse_validator
-from env_types import EnvVariable, EnvLayer, MetadataContainer, XEnv, VariableResolver
+from env_types import EnvVariable, EnvLayer, EnvTrait, MetadataContainer, XEnv, VariableResolver
 from logger import log_error
 
 
@@ -145,6 +145,13 @@ SUPPORTED_FIELD_PATTERNS = {
     XEnv.var_requires_valid(): {"type": "single", "description": "Validation rules for required environment variables"},
     XEnv.var_optional(): {"type": "single", "description": "Optional environment variables used by this layer"},
     XEnv.var_optional_valid(): {"type": "single", "description": "Validation rules for optional environment variables"},
+
+    # Trait definition patterns (these match multiple fields, keyed by local name)
+    XEnv.trait_desc_pattern(): {"type": "pattern", "description": "Trait token description"},
+    XEnv.trait_valid_pattern(): {"type": "pattern", "description": "Trait validation type (always bool)"},
+    XEnv.trait_requires_pattern(): {"type": "pattern", "description": "Trait necessity-only validation constraint"},
+    XEnv.trait_triggers_pattern(): {"type": "pattern", "description": "Trait derivation/push rules"},
+    XEnv.trait_include_pattern(): {"type": "pattern", "description": "Further trait files to load as children of this node"},
 }
 
 def is_field_supported(field_name: str) -> bool:
@@ -161,15 +168,21 @@ def is_field_supported(field_name: str) -> bool:
                 if field_name.startswith(pattern) and '-' not in field_name[len(pattern):]:
                     return True
             elif "*" in pattern:
-                # Variable attribute pattern (X-Env-Var-*-Desc)
+                # Attribute pattern (X-Env-Var-*-Desc, X-Env-Trait-*-Desc, ...)
                 pattern_parts = pattern.split("*")
                 if len(pattern_parts) == 2:
                     prefix, suffix = pattern_parts
                     if field_name.startswith(prefix) and field_name.endswith(suffix):
-                        # Extract the variable name part
                         var_part = field_name[len(prefix):-len(suffix) if suffix else len(field_name)]
-                        if var_part and '-' not in var_part:  # Valid variable name
-                            return True
+                        if not var_part:
+                            continue
+                        # IGconf var names never contain a dash, so rejecting
+                        # one here is a real typo check for X-Env-Var-*.
+                        # Trait local names legitimately do (vc-firmware,
+                        # aes-accel), so the same check doesn't apply there.
+                        if prefix.startswith(XEnv.VAR_PREFIX) and '-' in var_part:
+                            continue
+                        return True
 
     return False
 
@@ -1069,6 +1082,10 @@ class Metadata:
         """Check if this metadata contains X-Env-Layer information"""
         return self._container.layer is not None
 
+    def get_traits(self) -> Dict[str, EnvTrait]:
+        """Get trait definitions from X-Env-Trait metadata fields, keyed by local name."""
+        return self._container.traits
+
     # Note: Placeholder handling moved to MetadataContainer class
 
 
@@ -1108,6 +1125,32 @@ def print_env_var_descriptions(meta: 'Metadata', indent: int = 0):
                 print(f"{pad}      {cond}{t.action} {t.target}={t.value} policy={t.policy}")
         if env_var.conflicts:
             print(f"{pad}    Conflicts: {', '.join(env_var.conflicts)}")
+        print()
+
+
+def print_trait_descriptions(meta: 'Metadata', indent: int = 0):
+    """Pretty-print trait descriptions for a Metadata object."""
+    traits = meta.get_traits()
+    if not traits:
+        return
+
+    pad = " " * indent
+
+    print(f"{pad}Traits:")
+
+    for local_name, trait in traits.items():
+        print(f"{pad}  Trait: {local_name}")
+        if trait.desc:
+            print(f"{pad}    Desc: {trait.desc}")
+        print(f"{pad}    Type: {trait.valid}")
+        if trait.requires:
+            print(f"{pad}    Requires: {', '.join(trait.requires)}")
+        if trait.triggers:
+            print(f"{pad}    Triggers:")
+            for rule in trait.triggers:
+                print(f"{pad}      when={rule.condition} set ({rule.target})=y")
+        if trait.include:
+            print(f"{pad}    Include: {', '.join(trait.include)}")
         print()
 
 
@@ -1471,6 +1514,11 @@ def _main(args):
                 # Display per-variable detail via existing helper
                 if meta.get_all_env_vars():
                     print_env_var_descriptions(meta)
+                    has_content = True
+
+                # Display per-trait detail via existing helper
+                if meta.get_traits():
+                    print_trait_descriptions(meta)
                     has_content = True
 
                 if not has_content:

--- a/site/trait_registry.py
+++ b/site/trait_registry.py
@@ -201,8 +201,9 @@ class TraitRegistry:
            nothing changes. A self-targeting rule fires on its condition
            alone - a cross-targeting rule also requires its source token to
            be active.
-        3. Validate Requires: but only for directly-declared tokens - a
-           token only reached via a Trigger carries no such promise.
+        3. Validate Requires for every active token, however it got there -
+           direct declaration, hierarchy ancestor, or a Trigger. If a token
+           is active, its own preconditions must hold too.
         """
         active: Set[str] = set()
         for token in declared:
@@ -230,7 +231,7 @@ class TraitRegistry:
                                 changed = True
 
         unmet: Dict[str, List[str]] = {}
-        for token in declared:
+        for token in active:
             missing = [r for r in self._resolved[token].requires if r not in active]
             if missing:
                 unmet[token] = missing

--- a/site/trait_registry.py
+++ b/site/trait_registry.py
@@ -1,0 +1,242 @@
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Union
+
+from metadata_parser import Metadata
+from env_types import EnvTrait, TRAIT_TOKEN_PATTERN
+import conditions as _cond
+
+TOKEN_RE = re.compile(rf'^{TRAIT_TOKEN_PATTERN}$')
+NAMESPACE_NODE_RE = re.compile(r'^[a-z][a-z0-9]*$')
+
+
+def provider_token_type(token: str) -> str:
+    """Return 'trait' for namespaced tokens (containing ':'), 'label' otherwise."""
+    return 'trait' if ':' in token else 'label'
+
+
+class TraitRegistry:
+    """
+    Loads trait token definitions from one or more trait/ directories.
+
+    Each file is one deb822 stanza that can define several sibling local names
+    (X-Env-Trait-<local>-Desc etc), all sharing whichever prefix the Include:
+    that pulled the file in established. Hierarchy comes purely from
+    position in the Include: chain - a local name is always a single,
+    colon-free segment.
+
+    Directories are scanned in order - put the built-in root first so OEM
+    extensions can reference its tokens. Within a directory the top-level
+    *.deb822 scan is single-level, not recursive: a file only meant to be
+    reached via Include must live in a subdirectory, or it loads twice -
+    once correctly via Include and once directly by the scan with the wrong
+    (empty) prefix, and whichever wins the race silently shadows the other.
+    Include: also defines load order (parent before child), which is what
+    makes forward-reference checking possible.
+
+    A token is never legitimately defined twice - the only supported
+    override is a build config file's `trait:` section (see resolve()), not a
+    second definition - so any duplicate is a hard error.
+    """
+
+    def __init__(self, trait_dirs: Union[str, Path, List[Union[str, Path]]]):
+        if not isinstance(trait_dirs, list):
+            trait_dirs = [trait_dirs]
+        trait_dirs = [Path(d) for d in trait_dirs]
+
+        self._definitions: Dict[str, EnvTrait] = {}
+        # Namespace nodes only: which root(s) have defined this name, so the
+        # duplicate check can tell a cross-root extension (fine) from a
+        # same-root copy/paste (error).
+        self._namespace_roots: Dict[str, Set[int]] = {}
+        self._position = 0
+        visited: Set[Path] = set()
+        for root_index, trait_dir in enumerate(trait_dirs):
+            if not trait_dir.is_dir():
+                continue
+            for deb822_file in sorted(trait_dir.glob('*.deb822')):
+                self._load_file(deb822_file.resolve(), visited, prefix=None, root_index=root_index)
+
+        # Namespace nodes (bare identifiers, e.g. 'hw') are load-time
+        # scaffolding - they only carry Include: and hand their name down as
+        # a prefix, so they're excluded here and can never satisfy a
+        # Requires:/Triggers: reference. No orphaned children are possible:
+        # a node is always added before its own.
+        # Include: is followed, so every ancestor of a resolved token is always
+        # loaded first.
+        self._resolved: Dict[str, EnvTrait] = {
+            token: trait for token, trait in self._definitions.items() if ':' in token
+        }
+
+    def _load_file(self, path: Path, visited: Set[Path], prefix: Optional[str], root_index: int) -> None:
+        """Load one file's local names. 'prefix' is the full name of whichever
+        node's Include: pulled this file in - None for a top-level scanned
+        file. Each local name is resolved to prefix:local_name or used as-is.
+        'root_index' is which trait_dirs entry this file traces back to, and 
+        is inherited unchanged through Include: recursion.
+        """
+        if path in visited:
+            return
+        visited.add(path)
+
+        meta = Metadata(str(path))
+        for local_name, trait in meta.get_traits().items():
+            full_name = f"{prefix}:{local_name}" if prefix is not None else local_name
+            if ':' in full_name:
+                if not TOKEN_RE.match(full_name):
+                    raise ValueError(f"{path}: invalid trait token name '{full_name}'")
+            elif not NAMESPACE_NODE_RE.match(full_name):
+                raise ValueError(f"{path}: invalid namespace node name '{full_name}'")
+            trait.name = full_name
+            trait.position = self._position
+            self._position += 1
+
+            for dep in trait.requires:
+                self._check_reference(dep, path, trait.name, "Requires")
+            for rule in trait.triggers:
+                if rule.target != trait.name:
+                    self._check_reference(rule.target, path, trait.name, "Triggers")
+
+            # A namespace node can be (re)defined once per root - a different
+            # root extending it (eg, an OEM adding children under 'hw') is
+            # expected/possible, but two top-level files in the same root both
+            # defining it is a mistake. Real tokens always need exactly one
+            # definition, regardless of root.
+            if ':' in trait.name:
+                existing = self._definitions.get(trait.name)
+                if existing is not None:
+                    raise ValueError(
+                        f"Duplicate trait definition: '{trait.name}' is defined in both "
+                        f"{existing.source} and {path}"
+                    )
+            else:
+                seen_roots = self._namespace_roots.setdefault(trait.name, set())
+                if root_index in seen_roots:
+                    existing = self._definitions[trait.name]
+                    raise ValueError(
+                        f"Duplicate trait definition: namespace node '{trait.name}' is defined "
+                        f"twice within the same source root, in both {existing.source} and {path}"
+                    )
+                seen_roots.add(root_index)
+            self._definitions[trait.name] = trait
+
+            for inc in trait.include:
+                inc_path = (path.parent / inc).resolve()
+                if not inc_path.exists():
+                    raise FileNotFoundError(
+                        f"Include '{inc}' not found (from {path}, node '{trait.name}')"
+                    )
+                self._load_file(inc_path, visited, prefix=trait.name, root_index=root_index)
+
+    def _check_reference(self, target: str, path: Path, name: str, field: str) -> None:
+        """A Requires:/Triggers: target is always a full name (never
+        relative) and must resolve to an already-defined real trait, not a
+        namespace node."""
+        if target not in self._definitions:
+            raise ValueError(
+                f"{path}: '{name}' {field} forward reference to '{target}' before it's defined"
+            )
+        if ':' not in target:
+            raise ValueError(
+                f"{path}: '{name}' {field} references '{target}', a namespace node, not a trait"
+            )
+
+    def expand(self, token: str) -> Dict[str, str]:
+        """Closure of one token: hierarchy ancestors plus unconditional
+        (when=y) Triggers, recursively. Conditional Triggers need a build's
+        accumulated token set, see resolve()."""
+        if token not in self._resolved:
+            raise ValueError(f"'{token}' is not defined in the registry")
+        result: Dict[str, str] = {}
+        self._expand(token, result, set())
+        return result
+
+    def _expand(self, token: str, result: Dict[str, str], seen: Set[str]) -> None:
+        if token in seen:
+            return
+        seen.add(token)
+        parts = token.split(':')
+        for i in range(2, len(parts)):
+            self._expand(':'.join(parts[:i]), result, seen)
+        result[token] = self._resolved[token].source
+        for rule in self._resolved[token].triggers:
+            if rule.condition == 'y':
+                self._expand(rule.target, result, seen)
+
+    def __contains__(self, token: str) -> bool:
+        return token in self._resolved
+
+    def get_desc(self, token: str) -> Optional[str]:
+        d = self._resolved.get(token)
+        return d.desc if d else None
+
+    def get_valid(self, token: str) -> Optional[str]:
+        d = self._resolved.get(token)
+        return d.valid if d else None
+
+    def get_requires(self, token: str) -> List[str]:
+        d = self._resolved.get(token)
+        return d.requires if d else []
+
+    @property
+    def all_tokens(self) -> Dict[str, str]:
+        return {t: d.source for t, d in self._resolved.items()}
+
+    def by_prefix(self, prefix: str) -> Dict[str, str]:
+        """Every real token equal to 'prefix' or nested under it at a colon
+        boundary (e.g. 'hw:soc' matches 'hw:soc:bcm2712', not 'hw:soccer').
+        A trailing colon is stripped, so 'hw:' and 'hw' are the same """
+        prefix = prefix.rstrip(':')
+        return {
+            t: d.source for t, d in self._resolved.items()
+            if t == prefix or t.startswith(prefix + ':')
+        }
+
+    def resolve(self, declared: Set[str]) -> Set[str]:
+        """Simulate a build's accumulated trait set from a set of directly
+        declared tokens (TODO layer manager injection point).
+
+        1. Expand each declared token (hierarchy + unconditional Triggers).
+        2. Fixed point: fire any Trigger whose condition now holds, until
+           nothing changes. A self-targeting rule fires on its condition
+           alone - a cross-targeting rule also requires its source token to
+           be active.
+        3. Validate Requires: but only for directly-declared tokens - a
+           token only reached via a Trigger carries no such promise.
+        """
+        active: Set[str] = set()
+        for token in declared:
+            if token not in self._resolved:
+                raise ValueError(f"Unknown trait token: '{token}'")
+            active.update(self.expand(token).keys())
+
+        changed = True
+        while changed:
+            changed = False
+            for token, trait in self._resolved.items():
+                for rule in trait.triggers:
+                    if rule.target in active:
+                        continue
+                    if rule.target == token:
+                        fires = rule.condition == 'y' or _cond.evaluate(rule.condition, {}, active)
+                    else:
+                        fires = token in active and (
+                            rule.condition == 'y' or _cond.evaluate(rule.condition, {}, active)
+                        )
+                    if fires:
+                        for t in self.expand(rule.target):
+                            if t not in active:
+                                active.add(t)
+                                changed = True
+
+        unmet: Dict[str, List[str]] = {}
+        for token in declared:
+            missing = [r for r in self._resolved[token].requires if r not in active]
+            if missing:
+                unmet[token] = missing
+        if unmet:
+            msgs = [f"{t}: Requires not satisfied, missing: {', '.join(m)}"
+                    for t, m in sorted(unmet.items())]
+            raise ValueError('\n'.join(msgs))
+
+        return active

--- a/site/validators.py
+++ b/site/validators.py
@@ -22,10 +22,17 @@ class BaseValidator(ABC):
 
 
 class BooleanValidator(BaseValidator):
+    # Single source of truth for accepted spellings, split by truthiness so
+    # callers that need to distinguish true from false (e.g. trait Triggers:
+    # actions, which may only ever assert true) don't have to hardcode their
+    # own parallel list that could drift out of sync with this one.
+    TRUE_VALUES = ("true", "1", "yes", "y")
+    FALSE_VALUES = ("false", "0", "no", "n")
+
     def validate(self, value: Optional[str]) -> list[str]:
         if value is None:
             return ["Value cannot be None"]
-        if value.lower() not in ("true", "false", "1", "0", "yes", "no", "y", "n"):
+        if value.lower() not in self.TRUE_VALUES + self.FALSE_VALUES:
             return [f"Value '{value}' is not a valid boolean."]
         return []
 

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -5,6 +5,7 @@ ROOT=$(readlink -f "$(dirname $0)")
 
 ${ROOT}/meta/run-tests.sh
 ${ROOT}/layer/run-tests.sh
+${ROOT}/trait/run-tests.sh
 ${ROOT}/configurations/run-tests.sh
 ${ROOT}/idp/run-tests.sh
 

--- a/test/trait/fixtures/by-prefix-boundary/children/leaves.deb822
+++ b/test/trait/fixtures/by-prefix-boundary/children/leaves.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-soc-Desc: real branch
+X-Env-Trait-soc-Valid: bool
+
+X-Env-Trait-soccer-Desc: shares a string prefix with 'soc' but not a colon boundary
+X-Env-Trait-soccer-Valid: bool

--- a/test/trait/fixtures/by-prefix-boundary/top.deb822
+++ b/test/trait/fixtures/by-prefix-boundary/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/fixtures/conditional-triggers/children/leaves.deb822
+++ b/test/trait/fixtures/conditional-triggers/children/leaves.deb822
@@ -1,0 +1,9 @@
+X-Env-Trait-a-Desc: token a
+X-Env-Trait-a-Valid: bool
+
+X-Env-Trait-b-Desc: token b
+X-Env-Trait-b-Valid: bool
+
+X-Env-Trait-derived-Desc: only true when both a and b are present
+X-Env-Trait-derived-Valid: bool
+X-Env-Trait-derived-Triggers: when=has('hw:a') and has('hw:b') set (hw:derived)=y

--- a/test/trait/fixtures/conditional-triggers/top.deb822
+++ b/test/trait/fixtures/conditional-triggers/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/fixtures/forward-ref/trait/children/leaves.deb822
+++ b/test/trait/fixtures/forward-ref/trait/children/leaves.deb822
@@ -1,0 +1,6 @@
+X-Env-Trait-y-Desc: relative name resolves to hw:y - references a token not yet defined
+X-Env-Trait-y-Valid: bool
+X-Env-Trait-y-Requires: hw:late
+
+X-Env-Trait-late-Desc: defined after y in this same file, so y cannot see it yet
+X-Env-Trait-late-Valid: bool

--- a/test/trait/fixtures/forward-ref/trait/top.deb822
+++ b/test/trait/fixtures/forward-ref/trait/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/fixtures/namespace-node-reference/trait/children/leaf.deb822
+++ b/test/trait/fixtures/namespace-node-reference/trait/children/leaf.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-leaf-Desc: tries to Require the namespace node itself, not a real trait
+X-Env-Trait-leaf-Valid: bool
+X-Env-Trait-leaf-Requires: ns

--- a/test/trait/fixtures/namespace-node-reference/trait/top.deb822
+++ b/test/trait/fixtures/namespace-node-reference/trait/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-ns-Desc: bare namespace node
+X-Env-Trait-ns-Valid: bool
+X-Env-Trait-ns-Include: children/leaf.deb822

--- a/test/trait/fixtures/namespace-same-root-duplicate/trait/bogus.deb822
+++ b/test/trait/fixtures/namespace-same-root-duplicate/trait/bogus.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: accidental collision - meant to be a new namespace, not 'hw' again
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/bogus.deb822

--- a/test/trait/fixtures/namespace-same-root-duplicate/trait/children/bogus.deb822
+++ b/test/trait/fixtures/namespace-same-root-duplicate/trait/children/bogus.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-bogus-Desc: bogus child
+X-Env-Trait-bogus-Valid: bool

--- a/test/trait/fixtures/namespace-same-root-duplicate/trait/children/real.deb822
+++ b/test/trait/fixtures/namespace-same-root-duplicate/trait/children/real.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-real-Desc: real child
+X-Env-Trait-real-Valid: bool

--- a/test/trait/fixtures/namespace-same-root-duplicate/trait/hw.deb822
+++ b/test/trait/fixtures/namespace-same-root-duplicate/trait/hw.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: real namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/real.deb822

--- a/test/trait/fixtures/oem-duplicate/trait/hw.deb822
+++ b/test/trait/fixtures/oem-duplicate/trait/hw.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: OEM tries to redefine the built-in hw:pcie token
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: hw/oem.deb822

--- a/test/trait/fixtures/oem-duplicate/trait/hw/oem.deb822
+++ b/test/trait/fixtures/oem-duplicate/trait/hw/oem.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-pcie-Desc: OEM redefinition, should never be allowed to win
+X-Env-Trait-pcie-Valid: bool

--- a/test/trait/fixtures/oem-srcroot/carrier.deb822
+++ b/test/trait/fixtures/oem-srcroot/carrier.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-carrier-Desc: OEM carrier board namespace
+X-Env-Trait-carrier-Valid: bool
+X-Env-Trait-carrier-Include: carrier/acme.deb822

--- a/test/trait/fixtures/oem-srcroot/carrier/acme.deb822
+++ b/test/trait/fixtures/oem-srcroot/carrier/acme.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-v1-Desc: ACME carrier board v1, adds Bluetooth via a Broadcom module
+X-Env-Trait-v1-Valid: bool
+X-Env-Trait-v1-Requires: hw:bluetooth

--- a/test/trait/fixtures/oem-srcroot/hw.deb822
+++ b/test/trait/fixtures/oem-srcroot/hw.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: OEM extension to the built-in hw namespace
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: hw/oem.deb822

--- a/test/trait/fixtures/oem-srcroot/hw/oem.deb822
+++ b/test/trait/fixtures/oem-srcroot/hw/oem.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-customboard-Desc: ACME custom carrier board indicator
+X-Env-Trait-customboard-Valid: bool

--- a/test/trait/invalid-trait-trigger-non-boolean.deb822
+++ b/test/trait/invalid-trait-trigger-non-boolean.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-b-Desc: tries to set hw:a to a non-boolean value
+X-Env-Trait-b-Valid: bool
+X-Env-Trait-b-Triggers: when=y set (hw:a)=100

--- a/test/trait/invalid-trait-trigger-not-true.deb822
+++ b/test/trait/invalid-trait-trigger-not-true.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-b-Desc: tries to set hw:a to false
+X-Env-Trait-b-Valid: bool
+X-Env-Trait-b-Triggers: when=y set (hw:a)=false

--- a/test/trait/invalid-trait-unsupported-field.deb822
+++ b/test/trait/invalid-trait-unsupported-field.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-x-Desc: a real trait
+X-Env-Trait-x-Valid: bool
+X-Env-Trait-x-Bogus: not a recognised attribute

--- a/test/trait/invalid-trait-valid-type.deb822
+++ b/test/trait/invalid-trait-valid-type.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-x-Desc: claims a non-boolean type the engine can never produce
+X-Env-Trait-x-Valid: int:1-100

--- a/test/trait/run-tests.sh
+++ b/test/trait/run-tests.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+# DEB822 trait registry test suite
+# Usage: just run it
+
+IGTOP=$(readlink -f "$(dirname "$0")/../../")
+TRAIT="${IGTOP}/test/trait"
+
+PATH="$IGTOP/bin:$PATH"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+declare -a FAILED_TEST_NAMES=()
+
+print_header() {
+    echo -e "${BLUE}================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}================================${NC}"
+}
+
+print_test() {
+    echo -e "${YELLOW}Testing: $1${NC}"
+}
+
+print_pass() {
+    echo -e "${GREEN}✓ PASS: $1${NC}"
+    ((PASSED_TESTS++))
+}
+
+print_fail() {
+    echo -e "${RED}✗ FAIL: $1${NC}"
+    echo -e "${RED}  Error: $2${NC}"
+    ((FAILED_TESTS++))
+    FAILED_TEST_NAMES+=("$1")
+}
+
+run_test() {
+    local test_name="$1"
+    local command="$2"
+    local expected_exit_code="$3"
+    local description="$4"
+
+    ((TOTAL_TESTS++))
+    print_test "$test_name"
+
+    local output
+    output=$(eval "$command" 2>&1)
+    local actual_exit_code=$?
+
+    if [ "$actual_exit_code" -eq "$expected_exit_code" ]; then
+        print_pass "$description"
+    else
+        print_fail "$description" "Expected exit code $expected_exit_code, got $actual_exit_code. Output: $output"
+    fi
+
+    echo ""
+}
+
+print_summary() {
+    echo -e "${BLUE}================================${NC}"
+    echo -e "${BLUE}TEST SUMMARY${NC}"
+    echo -e "${BLUE}================================${NC}"
+    echo -e "Total tests: $TOTAL_TESTS"
+    echo -e "${GREEN}Passed: $PASSED_TESTS${NC}"
+    echo -e "${RED}Failed: $FAILED_TESTS${NC}"
+
+    if [ ${#FAILED_TEST_NAMES[@]} -gt 0 ]; then
+        echo -e "\n${RED}Failed tests:${NC}"
+        for test in "${FAILED_TEST_NAMES[@]}"; do
+            echo -e "${RED}  - $test${NC}"
+        done
+    fi
+
+    if [ $FAILED_TESTS -eq 0 ]; then
+        echo -e "\n${GREEN}All tests passed!${NC}"
+        exit 0
+    else
+        echo -e "\n${RED}Some tests failed. Please check the output above.${NC}"
+        exit 1
+    fi
+}
+
+print_header "TRAIT REGISTRY TESTS"
+
+# Essentially lint / validation checkers
+run_test "invalid-trait-valid-type-parse" \
+    "ig metadata --parse ${TRAIT}/invalid-trait-valid-type.deb822" \
+    1 \
+    "Trait with non-bool Valid: should fail to parse"
+
+run_test "invalid-trait-valid-type-validate" \
+    "ig metadata --validate ${TRAIT}/invalid-trait-valid-type.deb822" \
+    1 \
+    "Trait with non-bool Valid: should fail to validate"
+
+run_test "invalid-trait-trigger-non-boolean-parse" \
+    "ig metadata --parse ${TRAIT}/invalid-trait-trigger-non-boolean.deb822" \
+    1 \
+    "Trait Triggers: action with a non-boolean value should fail to parse"
+
+run_test "invalid-trait-trigger-non-boolean-validate" \
+    "ig metadata --validate ${TRAIT}/invalid-trait-trigger-non-boolean.deb822" \
+    1 \
+    "Trait Triggers: action with a non-boolean value should fail to validate"
+
+run_test "invalid-trait-trigger-not-true-parse" \
+    "ig metadata --parse ${TRAIT}/invalid-trait-trigger-not-true.deb822" \
+    1 \
+    "Trait Triggers: action setting a false-ish value should fail to parse"
+
+run_test "invalid-trait-trigger-not-true-validate" \
+    "ig metadata --validate ${TRAIT}/invalid-trait-trigger-not-true.deb822" \
+    1 \
+    "Trait Triggers: action setting a false-ish value should fail to validate"
+
+run_test "invalid-trait-unsupported-field-parse" \
+    "ig metadata --parse ${TRAIT}/invalid-trait-unsupported-field.deb822" \
+    1 \
+    "Trait with a typo'd/unsupported attribute field should fail to parse"
+
+run_test "invalid-trait-unsupported-field-validate" \
+    "ig metadata --validate ${TRAIT}/invalid-trait-unsupported-field.deb822" \
+    1 \
+    "Trait with a typo'd/unsupported attribute field should fail to validate"
+
+# Multi-file tree loading errors - each fixture's trait/ combines with the
+# built-in tree via -S, exactly as a real OEM srcroot would.
+run_test "trait-forward-reference-is-error" \
+    "ig config --trait -S ${TRAIT}/fixtures/forward-ref" \
+    1 \
+    "A Requires: forward reference to a not-yet-loaded token should be a hard error"
+
+run_test "trait-namespace-node-reference-is-error" \
+    "ig config --trait -S ${TRAIT}/fixtures/namespace-node-reference" \
+    1 \
+    "Requires: referencing a bare namespace node should be a hard error"
+
+run_test "trait-duplicate-definition-across-srcroot-is-error" \
+    "ig config --trait -S ${TRAIT}/fixtures/oem-duplicate" \
+    1 \
+    "Redefining an existing built-in token from an external srcroot should be a hard error"
+
+run_test "trait-namespace-node-duplicate-within-same-root-is-error" \
+    "ig config --trait -S ${TRAIT}/fixtures/namespace-same-root-duplicate" \
+    1 \
+    "Two top-level files in the same root both defining the same namespace node should be a hard error"
+
+# Functional verification - resolve() semantics (conditional Triggers,
+# Requires validate-only gating) that the --trait CLI never exercises,
+# since it only ever calls expand()/by_prefix(), not resolve().
+run_test "trait-registry-deb822-parsing" \
+    "python3 ${TRAIT}/test_trait_registry.py" \
+    0 \
+    "DEB822 trait registry resolve() semantics not reachable via the CLI"
+
+print_summary

--- a/test/trait/test_trait_registry.py
+++ b/test/trait/test_trait_registry.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for the trait registry (site/trait_registry.py).
+
+Single-file validation and load-time errors are covered static fixtures.
+Only resolve() behaviour lives here.
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SITE_DIR = REPO_ROOT / "site"
+TRAIT_DIR = REPO_ROOT / "trait"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+if str(SITE_DIR) not in sys.path:
+    sys.path.insert(0, str(SITE_DIR))
+
+from trait_registry import TraitRegistry
+
+
+def case_by_prefix_colon_boundary() -> None:
+    # 'hw:soc' must not match 'hw:soccer'
+    r = TraitRegistry(str(FIXTURES_DIR / "by-prefix-boundary"))
+    matches = set(r.by_prefix("hw:soc"))
+    if matches != {"hw:soc"}:
+        raise SystemExit(f"by_prefix('hw:soc') matched {matches}")
+
+
+def case_conditional_triggers_self_targeting() -> None:
+    # derived should only fire once both a and b are active
+    r = TraitRegistry(str(FIXTURES_DIR / "conditional-triggers"))
+
+    if "hw:derived" in r.resolve({"hw:a"}):
+        raise SystemExit("hw:derived fired with only one condition met")
+
+    if "hw:derived" not in r.resolve({"hw:a", "hw:b"}):
+        raise SystemExit("hw:derived did not fire with both conditions met")
+
+
+def case_external_srcroot_extends_real_tree() -> None:
+    # OEM srcroot loaded alongside the built-in tree: a new namespace, plus
+    # extending the built-in hw namespace with a child of its own
+    r = TraitRegistry([str(TRAIT_DIR), str(FIXTURES_DIR / "oem-srcroot")])
+
+    if "carrier:v1" not in r.all_tokens:
+        raise SystemExit("carrier:v1 not loaded from external srcroot")
+    if "hw:customboard" not in r.all_tokens:
+        raise SystemExit("hw:customboard not loaded from external srcroot")
+    if "hw:device:rpi:cm5" not in r.all_tokens:
+        raise SystemExit("built-in tokens missing alongside external srcroot")
+
+    try:
+        r.resolve({"carrier:v1"})
+    except ValueError as exc:
+        if "hw:bluetooth" not in str(exc):
+            raise SystemExit(f"wrong Requires error: {exc}")
+    else:
+        raise SystemExit("carrier:v1 without hw:bluetooth should fail")
+
+    active = r.resolve({"carrier:v1", "hw:bluetooth"})
+    if "carrier:v1" not in active or "hw:bluetooth" not in active:
+        raise SystemExit("carrier:v1 + hw:bluetooth should resolve cleanly")
+
+
+def main() -> None:
+    case_by_prefix_colon_boundary()
+    case_conditional_triggers_self_targeting()
+    case_external_srcroot_extends_real_tree()
+
+
+if __name__ == "__main__":
+    main()

--- a/trait/boot.deb822
+++ b/trait/boot.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-boot-Desc: Boot mechanism facts - how the device boots, what the boot chain requires
+X-Env-Trait-boot-Valid: bool
+X-Env-Trait-boot-Include: boot/generic.deb822,boot/rpi.deb822

--- a/trait/boot/generic.deb822
+++ b/trait/boot/generic.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-gpt-Desc: Bootloader has GPT support
+X-Env-Trait-gpt-Valid: bool

--- a/trait/boot/rpi.deb822
+++ b/trait/boot/rpi.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-rpi-Desc: Raspberry Pi-specific boot configuration
+X-Env-Trait-rpi-Valid: bool
+X-Env-Trait-rpi-Include: rpi/features.deb822

--- a/trait/boot/rpi/features.deb822
+++ b/trait/boot/rpi/features.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-vc-firmware-Desc: Device boot requires the Raspberry Pi VideoCore firmware loading chain
+X-Env-Trait-vc-firmware-Valid: bool
+
+X-Env-Trait-dtbootpartn-Desc: Bootloader propagates a valid (non-zero) boot partition number via Device Tree
+X-Env-Trait-dtbootpartn-Valid: bool

--- a/trait/hw.deb822
+++ b/trait/hw.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: Hardware presence facts - silicon traits, onboard peripherals, accessible interfaces
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: hw/crypto.deb822,hw/arch.deb822,hw/isa.deb822,hw/uarch.deb822,hw/exec.deb822,hw/periph.deb822,hw/soc.deb822,hw/device.deb822

--- a/trait/hw/arch.deb822
+++ b/trait/hw/arch.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-arch-Desc: CPU architecture identity
+X-Env-Trait-arch-Valid: bool
+X-Env-Trait-arch-Include: arch/arm.deb822

--- a/trait/hw/arch/arm.deb822
+++ b/trait/hw/arch/arm.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-arm-Desc: ARM-specific architecture extensions
+X-Env-Trait-arm-Valid: bool
+X-Env-Trait-arm-Include: arm/extensions.deb822

--- a/trait/hw/arch/arm/extensions.deb822
+++ b/trait/hw/arch/arm/extensions.deb822
@@ -1,0 +1,7 @@
+X-Env-Trait-aes-accel-Desc: Arm AES hardware acceleration
+X-Env-Trait-aes-accel-Valid: bool
+X-Env-Trait-aes-accel-Triggers: when=y set (hw:crypto:aes-accel)=y
+
+X-Env-Trait-sha-accel-Desc: Arm SHA hardware acceleration
+X-Env-Trait-sha-accel-Valid: bool
+X-Env-Trait-sha-accel-Triggers: when=y set (hw:crypto:sha-accel)=y

--- a/trait/hw/crypto.deb822
+++ b/trait/hw/crypto.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-crypto-Desc: Hardware cryptography acceleration
+X-Env-Trait-crypto-Valid: bool
+X-Env-Trait-crypto-Include: crypto/accel.deb822

--- a/trait/hw/crypto/accel.deb822
+++ b/trait/hw/crypto/accel.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-aes-accel-Desc: Accelerated AES operations
+X-Env-Trait-aes-accel-Valid: bool
+
+X-Env-Trait-sha-accel-Desc: Accelerated SHA operations
+X-Env-Trait-sha-accel-Valid: bool

--- a/trait/hw/device.deb822
+++ b/trait/hw/device.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-device-Desc: Device platform identity
+X-Env-Trait-device-Valid: bool
+X-Env-Trait-device-Include: device/rpi.deb822

--- a/trait/hw/device/rpi.deb822
+++ b/trait/hw/device/rpi.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-rpi-Desc: Raspberry Pi device family
+X-Env-Trait-rpi-Valid: bool
+X-Env-Trait-rpi-Include: rpi/sbc/pi3.deb822,rpi/sbc/pi4.deb822,rpi/sbc/pi5.deb822,rpi/sbc/zero2w.deb822,
+ rpi/cm.deb822,rpi/cm/cm4.deb822,rpi/cm/cm4-lite.deb822,rpi/cm/cm4s.deb822,rpi/cm/cm4s-lite.deb822,
+ rpi/cm/cm5.deb822,rpi/cm/cm5-lite.deb822

--- a/trait/hw/device/rpi/cm.deb822
+++ b/trait/hw/device/rpi/cm.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-cm-Desc: Raspberry Pi Compute Module family
+X-Env-Trait-cm-Valid: bool

--- a/trait/hw/device/rpi/cm/cm4-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm4-lite.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm4-lite-Valid: bool
 X-Env-Trait-cm4-lite-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm4-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm4-lite.deb822
@@ -1,0 +1,12 @@
+X-Env-Trait-cm4-lite-Desc: Raspberry Pi CM4 Lite - BCM2711 platform, no eMMC (SD card via carrier board)
+X-Env-Trait-cm4-lite-Valid: bool
+X-Env-Trait-cm4-lite-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/cm/cm4.deb822
+++ b/trait/hw/device/rpi/cm/cm4.deb822
@@ -1,0 +1,12 @@
+X-Env-Trait-cm4-Desc: Raspberry Pi CM4 - BCM2711 platform (eMMC, WiFi, Bluetooth)
+X-Env-Trait-cm4-Valid: bool
+X-Env-Trait-cm4-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:emmc)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/cm/cm4.deb822
+++ b/trait/hw/device/rpi/cm/cm4.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm4-Valid: bool
 X-Env-Trait-cm4-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm4s-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm4s-lite.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm4s-lite-Valid: bool
 X-Env-Trait-cm4s-lite-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm4s-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm4s-lite.deb822
@@ -1,0 +1,10 @@
+X-Env-Trait-cm4s-lite-Desc: Raspberry Pi CM4S Lite - BCM2711 platform, SODIMM form factor, no eMMC (SD via carrier board, no WiFi/BT)
+X-Env-Trait-cm4s-lite-Valid: bool
+X-Env-Trait-cm4s-lite-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/cm/cm4s.deb822
+++ b/trait/hw/device/rpi/cm/cm4s.deb822
@@ -1,0 +1,10 @@
+X-Env-Trait-cm4s-Desc: Raspberry Pi CM4S - BCM2711 platform, SODIMM form factor (eMMC, no WiFi/BT)
+X-Env-Trait-cm4s-Valid: bool
+X-Env-Trait-cm4s-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:emmc)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/cm/cm4s.deb822
+++ b/trait/hw/device/rpi/cm/cm4s.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm4s-Valid: bool
 X-Env-Trait-cm4s-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm5-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm5-lite.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm5-lite-Valid: bool
 X-Env-Trait-cm5-lite-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm5-lite.deb822
+++ b/trait/hw/device/rpi/cm/cm5-lite.deb822
@@ -1,0 +1,11 @@
+X-Env-Trait-cm5-lite-Desc: Raspberry Pi CM5 Lite - BCM2712 platform, no eMMC (SD card via carrier board)
+X-Env-Trait-cm5-lite-Valid: bool
+X-Env-Trait-cm5-lite-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y

--- a/trait/hw/device/rpi/cm/cm5.deb822
+++ b/trait/hw/device/rpi/cm/cm5.deb822
@@ -3,6 +3,7 @@ X-Env-Trait-cm5-Valid: bool
 X-Env-Trait-cm5-Triggers:
  when=y set (hw:device:rpi:cm)=y
  when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/cm/cm5.deb822
+++ b/trait/hw/device/rpi/cm/cm5.deb822
@@ -1,0 +1,11 @@
+X-Env-Trait-cm5-Desc: Raspberry Pi CM5 - BCM2712 platform (eMMC, WiFi, Bluetooth)
+X-Env-Trait-cm5-Valid: bool
+X-Env-Trait-cm5-Triggers:
+ when=y set (hw:device:rpi:cm)=y
+ when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (hw:storage:emmc)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y

--- a/trait/hw/device/rpi/sbc/pi3.deb822
+++ b/trait/hw/device/rpi/sbc/pi3.deb822
@@ -1,0 +1,9 @@
+X-Env-Trait-pi3-Desc: Raspberry Pi 3 - BCM2837 platform (quad Cortex-A53)
+X-Env-Trait-pi3-Valid: bool
+X-Env-Trait-pi3-Triggers:
+ when=y set (hw:soc:bcm2837)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (hw:ethernet)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/sbc/pi4.deb822
+++ b/trait/hw/device/rpi/sbc/pi4.deb822
@@ -1,0 +1,12 @@
+X-Env-Trait-pi4-Desc: Raspberry Pi 4 - BCM2711 platform (quad Cortex-A72)
+X-Env-Trait-pi4-Valid: bool
+X-Env-Trait-pi4-Triggers:
+ when=y set (hw:soc:bcm2711)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (hw:ethernet)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/device/rpi/sbc/pi5.deb822
+++ b/trait/hw/device/rpi/sbc/pi5.deb822
@@ -1,0 +1,12 @@
+X-Env-Trait-pi5-Desc: Raspberry Pi 5 - BCM2712 platform (quad Cortex-A76)
+X-Env-Trait-pi5-Valid: bool
+X-Env-Trait-pi5-Triggers:
+ when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:eeprom:rpi)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (hw:ethernet)=y
+ when=y set (hw:pcie)=y
+ when=y set (boot:gpt)=y
+ when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/sbc/pi5.deb822
+++ b/trait/hw/device/rpi/sbc/pi5.deb822
@@ -2,11 +2,11 @@ X-Env-Trait-pi5-Desc: Raspberry Pi 5 - BCM2712 platform (quad Cortex-A76)
 X-Env-Trait-pi5-Valid: bool
 X-Env-Trait-pi5-Triggers:
  when=y set (hw:soc:bcm2712)=y
+ when=y set (hw:pcie:bus)=y
  when=y set (hw:storage:sd)=y
  when=y set (hw:eeprom:rpi)=y
  when=y set (hw:wlan:broadcom)=y
  when=y set (hw:bluetooth:broadcom)=y
  when=y set (hw:ethernet)=y
- when=y set (hw:pcie)=y
  when=y set (boot:gpt)=y
  when=y set (boot:rpi:dtbootpartn)=y

--- a/trait/hw/device/rpi/sbc/zero2w.deb822
+++ b/trait/hw/device/rpi/sbc/zero2w.deb822
@@ -1,0 +1,8 @@
+X-Env-Trait-zero2w-Desc: Raspberry Pi Zero 2 W - RP3A0 SiP (SD card, Wifi, Bluetooth)
+X-Env-Trait-zero2w-Valid: bool
+X-Env-Trait-zero2w-Triggers:
+ when=y set (hw:soc:rp3a0)=y
+ when=y set (hw:storage:sd)=y
+ when=y set (hw:wlan:broadcom)=y
+ when=y set (hw:bluetooth:broadcom)=y
+ when=y set (boot:rpi:vc-firmware)=y

--- a/trait/hw/exec.deb822
+++ b/trait/hw/exec.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-exec-Desc: Execution capability
+X-Env-Trait-exec-Valid: bool
+X-Env-Trait-exec-Include: exec/kernel.deb822,exec/user.deb822

--- a/trait/hw/exec/kernel.deb822
+++ b/trait/hw/exec/kernel.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-kernel-Desc: Kernel boot execution state capability
+X-Env-Trait-kernel-Valid: bool
+X-Env-Trait-kernel-Include: kernel/arm.deb822,kernel/x86.deb822

--- a/trait/hw/exec/kernel/arm.deb822
+++ b/trait/hw/exec/kernel/arm.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-aarch32-Desc: Can boot a 32-bit (AArch32) kernel
+X-Env-Trait-aarch32-Valid: bool
+
+X-Env-Trait-aarch64-Desc: Can boot a 64-bit (AArch64) kernel
+X-Env-Trait-aarch64-Valid: bool

--- a/trait/hw/exec/kernel/x86.deb822
+++ b/trait/hw/exec/kernel/x86.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-x86_64-Desc: Can boot a 64-bit (x86_64) kernel
+X-Env-Trait-x86_64-Valid: bool

--- a/trait/hw/exec/user.deb822
+++ b/trait/hw/exec/user.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-user-Desc: Userspace execution state capability
+X-Env-Trait-user-Valid: bool
+X-Env-Trait-user-Include: user/arm.deb822,user/x86.deb822

--- a/trait/hw/exec/user/arm.deb822
+++ b/trait/hw/exec/user/arm.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-aarch32-Desc: Can execute 32-bit (AArch32) user code
+X-Env-Trait-aarch32-Valid: bool
+
+X-Env-Trait-aarch64-Desc: Can execute 64-bit (AArch64) user code
+X-Env-Trait-aarch64-Valid: bool

--- a/trait/hw/exec/user/x86.deb822
+++ b/trait/hw/exec/user/x86.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-x86_64-Desc: Can execute 64-bit (x86_64) user code
+X-Env-Trait-x86_64-Valid: bool

--- a/trait/hw/isa.deb822
+++ b/trait/hw/isa.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-isa-Desc: Instruction Set Architecture identity
+X-Env-Trait-isa-Valid: bool
+X-Env-Trait-isa-Include: isa/arm.deb822

--- a/trait/hw/isa/arm.deb822
+++ b/trait/hw/isa/arm.deb822
@@ -1,0 +1,5 @@
+X-Env-Trait-armv7-Desc: Armv7-A ISA
+X-Env-Trait-armv7-Valid: bool
+
+X-Env-Trait-armv8-Desc: Armv8-A ISA
+X-Env-Trait-armv8-Valid: bool

--- a/trait/hw/periph.deb822
+++ b/trait/hw/periph.deb822
@@ -1,0 +1,27 @@
+X-Env-Trait-bluetooth-Desc: Bluetooth hardware
+X-Env-Trait-bluetooth-Valid: bool
+X-Env-Trait-bluetooth-Include: periph/bluetooth.deb822
+
+X-Env-Trait-wlan-Desc: Wireless LAN hardware
+X-Env-Trait-wlan-Valid: bool
+X-Env-Trait-wlan-Include: periph/wlan.deb822
+
+X-Env-Trait-pcie-Desc: PCIe interface - accessible via expansion connector
+X-Env-Trait-pcie-Valid: bool
+
+X-Env-Trait-storage-Desc: Onboard or directly attached storage
+X-Env-Trait-storage-Valid: bool
+X-Env-Trait-storage-Include: periph/storage.deb822
+
+X-Env-Trait-eeprom-Desc: EEPROM for bootloader or configuration storage
+X-Env-Trait-eeprom-Valid: bool
+X-Env-Trait-eeprom-Include: periph/eeprom.deb822
+
+X-Env-Trait-ethernet-Desc: Wired Ethernet interface - present on-board for some SBCs, carrier-dependent for Compute Modules
+X-Env-Trait-ethernet-Valid: bool
+
+X-Env-Trait-can-Desc: CAN bus controller
+X-Env-Trait-can-Valid: bool
+
+X-Env-Trait-gps-Desc: GPS receiver
+X-Env-Trait-gps-Valid: bool

--- a/trait/hw/periph.deb822
+++ b/trait/hw/periph.deb822
@@ -6,8 +6,9 @@ X-Env-Trait-wlan-Desc: Wireless LAN hardware
 X-Env-Trait-wlan-Valid: bool
 X-Env-Trait-wlan-Include: periph/wlan.deb822
 
-X-Env-Trait-pcie-Desc: PCIe interface - accessible via expansion connector
+X-Env-Trait-pcie-Desc: PCIe-related capability
 X-Env-Trait-pcie-Valid: bool
+X-Env-Trait-pcie-Include: periph/pcie.deb822
 
 X-Env-Trait-storage-Desc: Onboard or directly attached storage
 X-Env-Trait-storage-Valid: bool

--- a/trait/hw/periph/bluetooth.deb822
+++ b/trait/hw/periph/bluetooth.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-broadcom-Desc: Broadcom Bluetooth hardware
+X-Env-Trait-broadcom-Valid: bool

--- a/trait/hw/periph/eeprom.deb822
+++ b/trait/hw/periph/eeprom.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-rpi-Desc: Raspberry Pi SPI EEPROM - bootloader configuration storage
+X-Env-Trait-rpi-Valid: bool

--- a/trait/hw/periph/pcie.deb822
+++ b/trait/hw/periph/pcie.deb822
@@ -1,0 +1,12 @@
+X-Env-Trait-bus-Desc: Physical PCIe lane exposed for user peripheral or storage
+ attachment
+X-Env-Trait-bus-Valid: bool
+
+X-Env-Trait-socket-Desc: Standard, rigid PCIe socket allowing direct card
+ insertion without intermediate cabling (any connector type)
+X-Env-Trait-socket-Valid: bool
+X-Env-Trait-socket-Requires: hw:pcie:bus
+
+X-Env-Trait-m2-Desc: PCIe-capable M.2 socket
+X-Env-Trait-m2-Valid: bool
+X-Env-Trait-m2-Triggers: when=y set (hw:pcie:socket)=y

--- a/trait/hw/periph/storage.deb822
+++ b/trait/hw/periph/storage.deb822
@@ -1,0 +1,9 @@
+X-Env-Trait-sd-Desc: SD card slot
+X-Env-Trait-sd-Valid: bool
+
+X-Env-Trait-emmc-Desc: Onboard eMMC storage soldered to the board
+X-Env-Trait-emmc-Valid: bool
+
+X-Env-Trait-nvme-Desc: NVMe storage slot
+X-Env-Trait-nvme-Valid: bool
+X-Env-Trait-nvme-Requires: hw:pcie

--- a/trait/hw/periph/storage.deb822
+++ b/trait/hw/periph/storage.deb822
@@ -4,6 +4,6 @@ X-Env-Trait-sd-Valid: bool
 X-Env-Trait-emmc-Desc: Onboard eMMC storage soldered to the board
 X-Env-Trait-emmc-Valid: bool
 
-X-Env-Trait-nvme-Desc: NVMe storage slot
+X-Env-Trait-nvme-Desc: NVMe storage (soldered or socket-attached)
 X-Env-Trait-nvme-Valid: bool
-X-Env-Trait-nvme-Requires: hw:pcie
+X-Env-Trait-nvme-Requires: hw:pcie:bus

--- a/trait/hw/periph/wlan.deb822
+++ b/trait/hw/periph/wlan.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-broadcom-Desc: Broadcom WiFi hardware
+X-Env-Trait-broadcom-Valid: bool

--- a/trait/hw/soc.deb822
+++ b/trait/hw/soc.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-soc-Desc: System-on-Chip identity
+X-Env-Trait-soc-Valid: bool
+X-Env-Trait-soc-Include: soc/broadcom.deb822,soc/rpi.deb822

--- a/trait/hw/soc.deb822
+++ b/trait/hw/soc.deb822
@@ -1,3 +1,3 @@
 X-Env-Trait-soc-Desc: System-on-Chip identity
 X-Env-Trait-soc-Valid: bool
-X-Env-Trait-soc-Include: soc/broadcom.deb822,soc/rpi.deb822
+X-Env-Trait-soc-Include: soc/generic.deb822,soc/broadcom.deb822,soc/rpi.deb822

--- a/trait/hw/soc/broadcom.deb822
+++ b/trait/hw/soc/broadcom.deb822
@@ -1,0 +1,36 @@
+X-Env-Trait-bcm2712-Desc: Broadcom BCM2712 - Raspberry Pi 5 / CM5 (quad Cortex-A76)
+X-Env-Trait-bcm2712-Valid: bool
+X-Env-Trait-bcm2712-Triggers:
+ when=y set (hw:uarch:cortex-a76)=y
+ when=y set (hw:arch:arm:aes-accel)=y
+ when=y set (hw:arch:arm:sha-accel)=y
+ when=y set (hw:exec:kernel:aarch64)=y
+ when=y set (hw:exec:user:aarch64)=y
+ when=y set (hw:exec:user:aarch32)=y
+
+X-Env-Trait-bcm2711-Desc: Broadcom BCM2711 - Raspberry Pi 4 / CM4 / CM4S (quad Cortex-A72)
+X-Env-Trait-bcm2711-Valid: bool
+X-Env-Trait-bcm2711-Triggers:
+ when=y set (hw:uarch:cortex-a72)=y
+ when=y set (hw:exec:kernel:aarch64)=y
+ when=y set (hw:exec:kernel:aarch32)=y
+ when=y set (hw:exec:user:aarch64)=y
+ when=y set (hw:exec:user:aarch32)=y
+
+X-Env-Trait-bcm2837-Desc: Broadcom BCM2837 - Raspberry Pi 3 / CM3 (quad Cortex-A53)
+X-Env-Trait-bcm2837-Valid: bool
+X-Env-Trait-bcm2837-Triggers:
+ when=y set (hw:uarch:cortex-a53)=y
+ when=y set (hw:exec:kernel:aarch64)=y
+ when=y set (hw:exec:kernel:aarch32)=y
+ when=y set (hw:exec:user:aarch64)=y
+ when=y set (hw:exec:user:aarch32)=y
+
+X-Env-Trait-bcm2710-Desc: Broadcom BCM2710 (BCM2710A1) - quad Cortex-A53 die (used in BCM2837 package and RP3A0 SiP)
+X-Env-Trait-bcm2710-Valid: bool
+X-Env-Trait-bcm2710-Triggers:
+ when=y set (hw:uarch:cortex-a53)=y
+ when=y set (hw:exec:kernel:aarch64)=y
+ when=y set (hw:exec:kernel:aarch32)=y
+ when=y set (hw:exec:user:aarch64)=y
+ when=y set (hw:exec:user:aarch32)=y

--- a/trait/hw/soc/broadcom.deb822
+++ b/trait/hw/soc/broadcom.deb822
@@ -7,6 +7,7 @@ X-Env-Trait-bcm2712-Triggers:
  when=y set (hw:exec:kernel:aarch64)=y
  when=y set (hw:exec:user:aarch64)=y
  when=y set (hw:exec:user:aarch32)=y
+ when=y set (hw:soc:pcie)=y
 
 X-Env-Trait-bcm2711-Desc: Broadcom BCM2711 - Raspberry Pi 4 / CM4 / CM4S (quad Cortex-A72)
 X-Env-Trait-bcm2711-Valid: bool
@@ -16,6 +17,7 @@ X-Env-Trait-bcm2711-Triggers:
  when=y set (hw:exec:kernel:aarch32)=y
  when=y set (hw:exec:user:aarch64)=y
  when=y set (hw:exec:user:aarch32)=y
+ when=y set (hw:soc:pcie)=y
 
 X-Env-Trait-bcm2837-Desc: Broadcom BCM2837 - Raspberry Pi 3 / CM3 (quad Cortex-A53)
 X-Env-Trait-bcm2837-Valid: bool

--- a/trait/hw/soc/generic.deb822
+++ b/trait/hw/soc/generic.deb822
@@ -1,0 +1,4 @@
+X-Env-Trait-pcie-Desc: PCIe controller present in the SoC silicon. A board
+ using this SoC does not necessarily expose it as a usable interface (see
+ hw:pcie:bus)
+X-Env-Trait-pcie-Valid: bool

--- a/trait/hw/soc/rpi.deb822
+++ b/trait/hw/soc/rpi.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-rp3a0-Desc: Raspberry Pi RP3A0 - SiP containing BCM2710A1 die and 512 MB DRAM
+X-Env-Trait-rp3a0-Valid: bool
+X-Env-Trait-rp3a0-Triggers: when=y set (hw:soc:bcm2710)=y

--- a/trait/hw/uarch.deb822
+++ b/trait/hw/uarch.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-uarch-Desc: Microarchitecture identity
+X-Env-Trait-uarch-Valid: bool
+X-Env-Trait-uarch-Include: uarch/arm.deb822

--- a/trait/hw/uarch/arm.deb822
+++ b/trait/hw/uarch/arm.deb822
@@ -1,0 +1,15 @@
+X-Env-Trait-cortex-a76-Desc: ARM Cortex-A76 microarchitecture
+X-Env-Trait-cortex-a76-Valid: bool
+X-Env-Trait-cortex-a76-Triggers: when=y set (hw:isa:armv8)=y
+
+X-Env-Trait-cortex-a72-Desc: ARM Cortex-A72 microarchitecture
+X-Env-Trait-cortex-a72-Valid: bool
+X-Env-Trait-cortex-a72-Triggers:
+ when=y set (hw:isa:armv7)=y
+ when=y set (hw:isa:armv8)=y
+
+X-Env-Trait-cortex-a53-Desc: ARM Cortex-A53 microarchitecture
+X-Env-Trait-cortex-a53-Valid: bool
+X-Env-Trait-cortex-a53-Triggers:
+ when=y set (hw:isa:armv7)=y
+ when=y set (hw:isa:armv8)=y


### PR DESCRIPTION
This is the first part of a planned multi-stage submission (already tested end to end) which introduces a trait token registry to rpi-image-gen. The registry is a tree of DEB822 metadata files describing hardware and boot-mechanism facts (eg `hw:storage:nvme`, `hw:soc:bcm2712`, `boot:gpt`), parsed through the existing X-Env metadata/env/validator machinery. This opens the door to layers being able to understand much more about the underlying hardware platform that the build is targeting.

- `site/trait_registry.py` (new) - resolves the tree into semantic tokens, expands `Triggers:` (a trait activating others), validates `Requires:` (trait dependencies), and exposes the result via `rpi-image-gen config --trait`.
- `has()` / `not has()` added to `conditions.py`, so a condition can test trait presence anywhere the existing `IGconf_*` condition syntax is accepted. These helpers are not yet reachable from the layer engine.
- OEM source roots (ie `-S <path/to/custom/tree`) can add their own trait tokens and extend built-in namespaces via `Includes: `. See `examples/custom_layers/`.
- New `test/trait/` component with static DEB822 fixtures for lint and a Python-driven test for load/resolve (eg forward references, duplicate defs, etc).

We need to drop INI file syntax support from the config parser because it will not support how traits can be overridden from the config file.

## Scope

This is intentionally the first of several planned steps:

- **Traits are boolean only in this PR.** `X-Env-Trait-*-Valid` is hard-wired to `bool`.  Support of typed (eg, int/string/regex/enum) traits, reusing the same validator infrastructure, will follow in a subsequent PR.
- **Not wired into the layer engine.** Nothing here changes Layer Manager or how `X-Env-Layer-Provides`/`RequiresProvider` behave - no existing layer or build is affected.

Net effect: purely additive, self-contained (`trait/` directory, one new module, plus a handful of extensions to existing shared parsing/validator code). **No behavioural change to any current build.**