### PR TITLE
examples: fix merged-usr firmware paths

### DIFF
--- a/examples/slim/device/mypi5/myboard.yaml
+++ b/examples/slim/device/mypi5/myboard.yaml
@@ -33,12 +33,12 @@ mmdebstrap:
     - path-exclude=/usr/lib/linux-image-*-v8/broadcom/bcm2837*
     - path-exclude=/usr/share/doc/firmware-brcm80211/
     - path-include=/usr/share/doc/firmware-brcm80211/copyright
-    - path-exclude=/lib/firmware/cypress/*
-    - path-include=/lib/firmware/cypress/cyfmac43455*
-    - path-exclude=/lib/firmware/brcm/*
-    - path-include=/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5*
-    - path-include=/lib/firmware/brcm/brcmfmac43455-sdio.txt
-    - path-include=/lib/firmware/brcm/BCM4345C0.raspberrypi,5*
+    - path-exclude=/usr/lib/firmware/cypress/*
+    - path-include=/usr/lib/firmware/cypress/cyfmac43455*
+    - path-exclude=/usr/lib/firmware/brcm/*
+    - path-include=/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5*
+    - path-include=/usr/lib/firmware/brcm/brcmfmac43455-sdio.txt
+    - path-include=/usr/lib/firmware/brcm/BCM4345C0.raspberrypi,5*
   customize-hooks:
     - mkdir -p $1/boot/firmware
     - ln -sf firmware/overlays $1/boot/overlays


### PR DESCRIPTION
## Summary

`examples/slim/device/mypi5/myboard.yaml` uses `dpkgopts` rules to trim the firmware installed by `firmware-brcm80211` down to the single chip used by Pi 5.
On Debian Trixie, these rules have no effect at all: the untrimmed firmware set for every Raspberry Pi model (plus several unrelated other boards) silently ends up in the built image, with no error at build time.

## Root cause

https://github.com/raspberrypi/rpi-image-gen/blob/510ff06b1514a8dacea7426da52ae9ff7df7ae29/examples/slim/device/mypi5/myboard.yaml#L36-L41

These rules target `/lib/firmware/...`, which matches the literal path recorded in the `firmware-brcm80211` `.deb` itself:

```
$ dpkg -c firmware-brcm80211_*.deb | grep raspberry
lrwxrwxrwx root/root 0 ... ./lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin -> ../cypress/cyfmac43455-sdio.bin
...
```

However, Debian's merged-usr transition means `dpkg` now canonicalizes `/lib/*` to `/usr/lib/*` before evaluating `--path-exclude` & `--path-include` glob patterns.
A rule written against `/lib/...` therefore matches nothing.

## How to reproduce

On `master`, build `examples/slim/config/pi5-slim.yaml`, then:
```
$ ls -1 /usr/lib/firmware/brcm/*raspberry*.bin
/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,0-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,3-model-b.bin
/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-2-w.bin
/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.bin
/usr/lib/firmware/brcm/brcmfmac43430b0-sdio.raspberrypi,model-zero-2-w.bin
/usr/lib/firmware/brcm/brcmfmac43436-sdio.raspberrypi,model-zero-2-w.bin
/usr/lib/firmware/brcm/brcmfmac43436s-sdio.raspberrypi,0-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43436s-sdio.raspberrypi,model-zero-2-w.bin
/usr/lib/firmware/brcm/brcmfmac43439-sdio.raspberrypi,0-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,3-model-a-plus.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,500.bin
/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,400.bin
```

Every Pi model is present, not just the Pi 5.

## Fix

Rewritting the rules from `/lib/firmware` to `/usr/lib/firmware` resolves it.
Rebuilding the example now produces the expected output:

```
$ ls -1 /usr/lib/firmware/brcm/*raspberry*.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.bin
/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,500.bin
```

## Note

Would it make more sense to fix this at the tool level instead?
A helper that resolves `path-exclude` & `path-include` rules against what's actually recorded in the `.deb`, rather than the eventual on-disk target path, would avoid this whole class of merged-usr surprise, here and in any future layer.
Happy to look into that if it's a direction you'd want, either way, this PR fixes the immediate issue.