### PR TITLE
feat: traits - part 2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,6 +106,7 @@ See the link:./examples[examples directory] for tips and help.
 * `site/` - Core Python engine classes
 * `templates/` - Templating assets, eg doc generation
 * `test/` - Test harness
+* `trait/` - Built-in trait token definitions (hardware/boot capability hierarchy)
 
 == Basic Usage
 

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -33,7 +33,7 @@ Resolves built-in and source directory root paths, config/layer/exec search path
 
 == site/config_loader.py
 
-Handles reading YAML/INI config files, resolving includes, and writing out the env file that feeds pipeline.
+Handles reading YAML config files, resolving includes, and writing out the env file that feeds pipeline. A `trait:` section is passed through as-is and serialised for pipeline.py to decode - forcing a trait on or off independent of any layer's `Provides:`. Also exposes the `ig config --trait` inspection CLI.
 
 == site/metadata_parser.py
 
@@ -54,10 +54,11 @@ Used by pipeline to perform final variable expansion.
 
 Discovery and introspection of all layers. Walks search roots, parses metadata, maintains the layer registry (self.layers, file paths, tags).
 Provides dependency graph operations (get build order, provider checks, reverse deps), schema checks used by pipeline pre-validation, and the user-facing ig CLI (list, describe, etc).
+Provider tokens are either plain labels or trait tokens (told apart by a colon), the latter resolved through a TraitRegistry - `_index_providers` expands hierarchy, fires Triggers, and validates Requires: for whatever a build's layers `Provides:`. A bare `Provides:` only activates a token, so it's boolean-only; other types need a Triggers: rule or a `trait:` config override for their value. Trait tokens can't appear in `AfterProvider` (rejected at parse time) since an ancestor/derived token has no single layer to order after.
 
 == site/trait_registry.py
 
-Loads trait token definitions (`X-Env-Trait-*` fields) from one or more `trait/` directories into a `TraitRegistry` - hierarchical tokens like `hw:storage:nvme`, built the same way layer files are (one deb822 stanza per file, reusing metadata_parser/env_types, no bespoke parsing). Hierarchy comes purely from position in each token's `Include:` chain. A token's `Valid:` can be any type the base validator classes support - `resolve()` takes a build's directly-declared tokens (a bare set, implying boolean "y", or an explicit `{token: value}` mapping) and returns the full active set as `{token: value}`: hierarchy ancestors and unconditional-Trigger targets always get "y" (structural activation, not an explicit assignment), while a `Triggers:` action's own value - validated against its *target's* type, not the declaring trait's, since Triggers routinely cross-target - carries through when it fires. Each declared token's own `Requires:` is validated along the way. Exposed for inspection via the `ig config --trait` CLI.
+Loads trait token definitions (`X-Env-Trait-*` fields) from one or more `trait/` directories into a `TraitRegistry` - hierarchical tokens like `hw:storage:nvme`, built the same way layer files are (deb822 stanzas). Hierarchy comes purely from position in each token's `Include:` chain. A token's `Valid:` can be any type the base validator classes support - `resolve()` takes a directly-declared trait token and returns the full active set as `{token: value}`. Hierarchy ancestors and Trigger assignments are validated against the *target's* type. Each declared token's own `Requires:` is validated along the way and available for inspection via the `ig config --trait` CLI.
 
 == site/pipeline.py
 

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -55,6 +55,10 @@ Used by pipeline to perform final variable expansion.
 Discovery and introspection of all layers. Walks search roots, parses metadata, maintains the layer registry (self.layers, file paths, tags).
 Provides dependency graph operations (get build order, provider checks, reverse deps), schema checks used by pipeline pre-validation, and the user-facing ig CLI (list, describe, etc).
 
+== site/trait_registry.py
+
+Loads trait token definitions (`X-Env-Trait-*` fields) from one or more `trait/` directories into a `TraitRegistry` - hierarchical tokens like `hw:storage:nvme`, built the same way layer files are (one deb822 stanza per file, reusing metadata_parser/env_types, no bespoke parsing). Hierarchy comes purely from position in each token's `Include:` chain. A token's `Valid:` can be any type the base validator classes support - `resolve()` takes a build's directly-declared tokens (a bare set, implying boolean "y", or an explicit `{token: value}` mapping) and returns the full active set as `{token: value}`: hierarchy ancestors and unconditional-Trigger targets always get "y" (structural activation, not an explicit assignment), while a `Triggers:` action's own value - validated against its *target's* type, not the declaring trait's, since Triggers routinely cross-target - carries through when it fires. Each declared token's own `Requires:` is validated along the way. Exposed for inspection via the `ig config --trait` CLI.
+
 == site/pipeline.py
 
 Main orchestrator for the application. Loads the base env file produced by config_loader, asks LayerManager for the dependency order, runs pre-resolution schema validation, runs the policy resolver (VariableResolver) to apply env vars, then validates env values against the resolved winning variable definitions before writing env/order outputs.

--- a/site/config_loader.py
+++ b/site/config_loader.py
@@ -1,8 +1,9 @@
+import json
 import os
 import sys
 import yaml
 from pathlib import Path
-from typing import Optional, Dict, Tuple
+from typing import Optional, Dict, Any, Tuple
 
 
 class ConfigLoader:
@@ -15,6 +16,7 @@ class ConfigLoader:
         self.file_format = self._detect_format()
 
         self.data: Dict[str, Dict[str, str]] = {}
+        self.trait_overrides: Dict[str, Any] = {}
         self.overrides: Dict[str, str] = {}
 
         self._load()
@@ -69,7 +71,7 @@ class ConfigLoader:
 
     def _load_yaml(self):
         """Load YAML file and convert to internal format"""
-        def _load_yaml_recursive(path: Path, visited: set) -> Dict[str, Dict[str, str]]:
+        def _load_yaml_recursive(path: Path, visited: set) -> tuple:
             if path in visited:
                 raise ValueError(f"Circular include detected in YAML files: {path}")
             visited.add(path)
@@ -83,8 +85,17 @@ class ConfigLoader:
             if not isinstance(yaml_data, dict):
                 raise ValueError(f"YAML file {path} must contain a mapping at root level")
 
+            # Extract trait section - pass-through, not converted to IGconf_* variables
+            trait_here: Dict[str, Any] = {}
+            if 'trait' in yaml_data:
+                trait_data = yaml_data.pop('trait')
+                if not isinstance(trait_data, dict):
+                    raise ValueError(f"'trait' section in {path} must be a mapping")
+                trait_here = trait_data
+
             # Handle include directive
             included_sections: Dict[str, Dict[str, str]] = {}
+            included_trait: Dict[str, Any] = {}
             if 'include' in yaml_data and isinstance(yaml_data['include'], list):
                 raise ValueError(
                     f"List includes are not supported in {path}"
@@ -94,7 +105,7 @@ class ConfigLoader:
                 if not inc_file:
                     raise ValueError(f"YAML include directive in {path} missing 'file' key")
                 inc_path = self._resolve_include(inc_file, path.parent)
-                included_sections = _load_yaml_recursive(inc_path, visited)
+                included_sections, included_trait = _load_yaml_recursive(inc_path, visited)
                 yaml_data.pop('include', None)
 
             # Convert current file sections
@@ -121,9 +132,11 @@ class ConfigLoader:
                                 file=sys.stderr,
                             )
                     merged[sect][k] = v
-            return merged
 
-        self.data = _load_yaml_recursive(Path(self.cfg_path).resolve(), set())
+            # Merge trait overrides: current file overrides included
+            return merged, {**included_trait, **trait_here}
+
+        self.data, self.trait_overrides = _load_yaml_recursive(Path(self.cfg_path).resolve(), set())
 
     def _load_overrides(self):
         """Load override file with key=value pairs and expand variables"""
@@ -353,6 +366,11 @@ class ConfigLoader:
                 if override_key not in processed_env_keys:
                     # For override-only variables, write them directly
                     self._write_override_only_var(f, override_key, section)
+
+            # Serialise trait overrides as a reserved JSON-encoded key so
+            # pipeline.py can reconstruct them without re-parsing the config YAML.
+            if self.trait_overrides:
+                f.write(f'_IG_TRAIT_OVERRIDES={json.dumps(self.trait_overrides, separators=(",", ":"))}\n')
 
     def _write_override_only_var(self, file_handle, override_key: str, section_filter: Optional[str]):
         """Write an override-only variable that doesn't exist in config file"""

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -243,6 +243,12 @@ class XEnv:
     TRAIT_ATTR_SUFFIXES = ('Desc', 'Valid', 'Requires', 'Triggers', 'Include')
 
     @classmethod
+    def trait_base(cls, name: str) -> str:
+        """Build trait default-value field: X-Env-Trait-{name} (no suffix,
+        like X-Env-Var-{name})"""
+        return f"{cls.TRAIT_PREFIX}{name}"
+
+    @classmethod
     def trait_desc(cls, name: str) -> str:
         """Build trait description field: X-Env-Trait-{name}-Desc"""
         return f"{cls.TRAIT_PREFIX}{name}-Desc"
@@ -328,6 +334,15 @@ class XEnv:
         parsed = cls.parse_trait_field(field_name)
         return parsed[0] if parsed else None
 
+    @classmethod
+    def is_base_trait_field(cls, field_name: str, known_locals) -> bool:
+        """True if field_name is <local>'s default-value field. Can't tell
+        this apart from a typo'd suffix (X-Env-Trait-x-Bogus) by name alone,
+        so the caller passes the local names already discovered via -Desc."""
+        if not cls.is_trait_field(field_name) or cls.parse_trait_field(field_name) is not None:
+            return False
+        return field_name[len(cls.TRAIT_PREFIX):] in known_locals
+
 
 TRIGGER_DEFAULT_POLICY = "immediate"
 ACTION_PARSERS: Dict[str, Any] = {}
@@ -400,39 +415,34 @@ class TriggerRule:
 
 
 TRAIT_TOKEN_PATTERN = r'[a-z][a-z0-9]*(?::[a-z][a-z0-9_-]*)+'
-# Captures the target token and the raw value separately — the value's
-# syntax is validated in _parse_trait_triggers via the declaring trait's own
-# resolved Valid: validator (always BooleanValidator today), not a hardcoded
-# literal, so 'y'/'yes'/'true'/'1' are all accepted the same way they would
-# be anywhere else in this metadata scheme.
+# Captures the target token and the raw value separately. The value's syntax
+# is NOT validated here - the declaring trait's own type tells us nothing
+# about the TARGET's type (Triggers are routinely cross-targeting, eg an SoC
+# trait setting a sibling's clock-speed trait), and the target may not even
+# be loaded yet at this single-file parse point. That validation happens in
+# TraitRegistry, once the whole tree (and therefore every target's own
+# validator) is loaded - see _check_trigger_value there.
 _TRAIT_TRIGGER_ACTION_RE = re.compile(rf'^set \(({TRAIT_TOKEN_PATTERN})\)=(.+)$')
 
 
 @dataclass(frozen=True)
 class TraitTriggerRule:
-    """A single 'when=<condition> set (<token>)=y' rule from X-Env-Trait-Triggers.
-
-    Unlike TriggerRule (X-Env-Var-*-Triggers), the action always activates
-    its target - traits are presence-only, there is no value to carry
-    beyond on/off, and Triggers only ever turn one on (suppression is a
-    build-config override's job, not a Trigger's). 'when=y' is a literal,
-    always-true condition (unconditional push, the trait equivalent of
-    implies:), reusing the same when= grammar rather than a separate
-    unconditional-rule syntax.
-    """
+    """A single 'when=<condition> set (<token>)=<value>' rule from
+    X-Env-Trait-Triggers. Value is checked against the target's own Valid:
+    rule (TraitRegistry._check_trigger_value), no further restriction.
+    'when=y' means unconditional (the trait equivalent of implies:)."""
     condition: str
     target: str
+    value: str
 
 
-def _parse_trait_triggers(raw: str, trait_name: str, validator: BooleanValidator) -> List[TraitTriggerRule]:
-    """Parse X-Env-Trait-Triggers: one 'when=<condition> set (<token>)=y' rule
-    per line (DEB822 continuation lines, one physical line per rule).
+def _parse_trait_triggers(raw: str, trait_name: str) -> List[TraitTriggerRule]:
+    """Parse X-Env-Trait-Triggers: one 'when=<condition> set (<token>)=<value>'
+    rule per line (DEB822 continuation lines, one physical line per rule).
 
-    'validator' is the declaring trait's own, already-resolved Valid:
-    validator - guaranteed to be a BooleanValidator by from_metadata_fields
-    before this is called, so both the boolean-shape check and the
-    true-values check below delegate to it (validate()/describe()/
-    TRUE_VALUES) rather than hardcoding a duplicate class or value list."""
+    Purely syntactic here - the condition's grammar is validated, and the
+    action's shape ('set (<token>)=<value>') is checked, but the value
+    itself is carried through unvalidated. See TraitRegistry for why."""
     import conditions as _cond
 
     rules: List[TraitTriggerRule] = []
@@ -456,18 +466,7 @@ def _parse_trait_triggers(raw: str, trait_name: str, validator: BooleanValidator
                 f"Trait trigger action '{action}' for '{trait_name}' must be 'set (<token>)=<value>'"
             )
         target, value = match.group(1), match.group(2)
-        errors = validator.validate(value)
-        if errors:
-            raise ValueError(
-                f"Trait trigger action '{action}' for '{trait_name}': {errors[0]} "
-                f"({validator.describe()})"
-            )
-        if value.lower() not in validator.TRUE_VALUES:
-            raise ValueError(
-                f"Trait trigger action '{action}' for '{trait_name}' must set a true value "
-                f"(y/yes/true/1) - Triggers only ever activate a trait, never deactivate it"
-            )
-        rules.append(TraitTriggerRule(condition=condition, target=target))
+        rules.append(TraitTriggerRule(condition=condition, target=target, value=value))
     return rules
 
 
@@ -477,6 +476,7 @@ class EnvTrait:
 
     def __init__(self, name: str, desc: str = "", valid: str = "bool",
                  validator: Optional[BaseValidator] = None,
+                 default: Optional[str] = None,
                  requires: Optional[List[str]] = None,
                  triggers: Optional[List[TraitTriggerRule]] = None,
                  include: Optional[List[str]] = None,
@@ -485,6 +485,7 @@ class EnvTrait:
         self.desc = desc
         self.valid = valid
         self.validator = validator or BooleanValidator()
+        self.default = default
         self.requires = requires or []
         self.triggers = triggers or []
         self.include = include or []
@@ -514,18 +515,34 @@ class EnvTrait:
             validator = parse_validator(valid)
         except ValueError as exc:
             raise ValueError(f"{source}: trait '{local_name}' {XEnv.trait_valid(local_name)}: {exc}") from exc
-        if not isinstance(validator, BooleanValidator):
-            raise ValueError(
-                f"{source}: trait '{local_name}' {XEnv.trait_valid(local_name)} must be 'bool' - traits are "
-                f"presence-only (every Triggers: action activates a trait, it never carries an "
-                f"arbitrary value), got '{valid}' ({validator.describe()})"
-            )
+
+        # Every trait needs a default, same as X-Env-Var. Bool implicitly
+        # defaults to 'n', an empty-ok string type to "" - anything else
+        # must declare one via the bare base field.
+        default = metadata_dict.get(XEnv.trait_base(local_name))
+        if default is None:
+            if isinstance(validator, BooleanValidator):
+                default = "n"
+            elif not validator.validate(""):
+                default = ""
+            else:
+                raise ValueError(
+                    f"{source}: trait '{local_name}' is {XEnv.trait_valid(local_name)}: {valid} "
+                    f"but has no default value - add {XEnv.trait_base(local_name)}: <value>"
+                )
+        else:
+            errors = validator.validate(default)
+            if errors:
+                raise ValueError(
+                    f"{source}: trait '{local_name}' default value '{default}': {errors[0]} "
+                    f"({validator.describe()})"
+                )
 
         requires_raw = metadata_dict.get(XEnv.trait_requires(local_name), "")
         requires = EnvLayer._parse_dependency_list(requires_raw)
 
         triggers_raw = metadata_dict.get(XEnv.trait_triggers(local_name), "")
-        triggers = _parse_trait_triggers(triggers_raw, local_name, validator) if triggers_raw.strip() else []
+        triggers = _parse_trait_triggers(triggers_raw, local_name) if triggers_raw.strip() else []
 
         # File paths, not dependency tokens - _parse_dependency_list's charset
         # check rejects '/' and '.', so it doesn't fit here.
@@ -533,7 +550,7 @@ class EnvTrait:
         include = [i.strip() for i in include_raw.split(',') if i.strip()]
 
         return cls(
-            name=local_name, desc=desc, valid=valid, validator=validator,
+            name=local_name, desc=desc, valid=valid, validator=validator, default=default,
             requires=requires, triggers=triggers, include=include,
             source=source, position=position,
         )
@@ -1005,25 +1022,7 @@ class MetadataContainer:
                     # Skip other types of errors - they'll be caught during validation
                     pass
 
-        # Extract traits. Validated eagerly here (mirroring EnvLayer's own
-        # inline _validate_layer_fields call) rather than only via the
-        # separate --lint aggregator, so a typo'd attribute suffix is a hard
-        # error the moment the file loads, for every consumer alike.
-        # Delegates to metadata_parser.is_field_supported() - the same
-        # SUPPORTED_FIELD_PATTERNS-driven check --lint uses - rather than a
-        # second, independent notion of "supported", exactly as
-        # _validate_layer_fields does for X-Env-Layer-* fields (import
-        # deferred to here to avoid a circular import at module load).
-        try:
-            from metadata_parser import is_field_supported
-        except ImportError:
-            is_field_supported = None
-        if is_field_supported is not None:
-            for key in container.raw_metadata.keys():
-                if XEnv.is_trait_field(key) and not is_field_supported(key):
-                    fname = filepath.split('/')[-1] if filepath else "unknown"
-                    raise ValueError(f"Unsupported trait field '{key}' in {fname}")
-
+        # Extract traits.
         trait_position = 0
         for key in container.raw_metadata.keys():
             if XEnv.is_trait_desc_field(key):
@@ -1036,6 +1035,20 @@ class MetadataContainer:
                     trait_position += 1
                 except ValueError as e:
                     raise ValueError(f"Invalid specifier for trait {local_name}: {e}")
+
+        # Eager unsupported-field check, mirroring EnvLayer. Runs after
+        # trait discovery above (not before) since telling a base field
+        # apart from a typo'd suffix needs the discovered local names.
+        try:
+            from metadata_parser import is_field_supported
+        except ImportError:
+            is_field_supported = None
+        if is_field_supported is not None:
+            for key in container.raw_metadata.keys():
+                if (XEnv.is_trait_field(key) and not is_field_supported(key)
+                        and not XEnv.is_base_trait_field(key, container.traits.keys())):
+                    fname = filepath.split('/')[-1] if filepath else "unknown"
+                    raise ValueError(f"Unsupported trait field '{key}' in {fname}")
 
         # Extract required/optional environment variable lists
         required_vars_str = container.raw_metadata.get(XEnv.var_requires(), "")

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -818,6 +818,13 @@ class EnvLayer:
 
         after_provider_str = metadata_dict.get(XEnv.layer_after_provider(), "")
         after_provider = cls._parse_dependency_list(after_provider_str, doc_mode)
+        if not doc_mode:
+            for token in after_provider:
+                if ':' in token:
+                    raise ValueError(
+                        f"{XEnv.layer_after_provider()}: '{token}' is a trait token - trait tokens "
+                        f"cannot be used in AfterProvider (use RequiresProvider instead)"
+                    )
 
         conflicts_str = metadata_dict.get(XEnv.layer_conflicts(), "")
         conflicts = cls._parse_dependency_list(conflicts_str, doc_mode)
@@ -1120,10 +1127,12 @@ class VariableResolver:
     def __init__(self):
         pass
 
-    def resolve(self, variable_definitions: Dict[str, List[EnvVariable]]) -> Dict[str, EnvVariable]:
+    def resolve(self, variable_definitions: Dict[str, List[EnvVariable]],
+                provider_index: Optional[Dict[str, Any]] = None) -> Dict[str, EnvVariable]:
         """
         Resolve variables and trigger injections until the injected set reaches
-        a stable fixed point.
+        a stable fixed point. 'provider_index' is passed through to condition
+        evaluation so has() works inside variable Triggers:/Conflicts:.
         """
         max_iterations = self.MAX_TRIGGER_ITERATIONS
         base_defs: Dict[str, List[EnvVariable]] = {k: list(v) for k, v in variable_definitions.items()}
@@ -1132,7 +1141,7 @@ class VariableResolver:
 
         for _ in range(max_iterations):
             resolved = self._resolve_pass(current_defs)
-            trigger_defs = self._collect_trigger_definitions(resolved)
+            trigger_defs = self._collect_trigger_definitions(resolved, provider_index)
             next_defs = self._merge_base_and_triggers(base_defs, trigger_defs)
             next_signature = self._definition_map_signature(next_defs)
             if next_signature == current_signature:
@@ -1294,7 +1303,8 @@ class VariableResolver:
                 merged.append(conflict)
         return merged
 
-    def _collect_trigger_definitions(self, resolved: Dict[str, EnvVariable]) -> Dict[str, List[EnvVariable]]:
+    def _collect_trigger_definitions(self, resolved: Dict[str, EnvVariable],
+                                      provider_index: Optional[Dict[str, Any]] = None) -> Dict[str, List[EnvVariable]]:
         """Build trigger-sourced definitions based on resolved values."""
         trigger_defs: Dict[str, List[EnvVariable]] = {}
         for env_var in resolved.values():
@@ -1303,6 +1313,7 @@ class VariableResolver:
                     rule.condition,
                     resolved,
                     env_var.source_layer,
+                    provider_index,
                 ):
                     continue
                 if rule.action != "set":
@@ -1338,6 +1349,7 @@ class VariableResolver:
         condition: str,
         resolved: Dict[str, EnvVariable],
         source_layer: Optional[str] = None,
+        provider_index: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """
         Evaluate a trigger condition expression against resolved variables.
@@ -1362,7 +1374,7 @@ class VariableResolver:
 
         layer_note = f" (layer: {source_layer})" if source_layer else ""
         try:
-            return _cond.evaluate(condition, variables)
+            return _cond.evaluate(condition, variables, provider_index)
         except ValueError as e:
             raise ValueError(f"{e}{layer_note}") from e
 

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass
 import yaml
 
@@ -17,6 +17,8 @@ from metadata_parser import Metadata
 from metadata_parser import print_env_var_descriptions
 
 from logger import log_warning, log_failure, log_error, log_info
+from trait_registry import provider_token_type
+from validators import BooleanValidator
 
 
 @dataclass(frozen=True)
@@ -35,6 +37,8 @@ class LayerManager:
         show_loaded: bool = False,
         doc_mode: bool = False,
         fail_on_lint: bool = False,
+        trait_dirs: Optional[List[str]] = None,
+        trait_overrides: Optional[Dict[str, Any]] = None,
     ):
         if search_paths is None:
             search_paths = ['./layer']
@@ -54,21 +58,27 @@ class LayerManager:
         self.show_loaded = show_loaded
         self.doc_mode = doc_mode  # Relaxed loader, eg does not run generators for dynamic layers
         self.fail_on_lint = fail_on_lint
-        # provider index will be built after layers are loaded
+        # provider index is (re)built per build scope by _index_providers(), not globally here
         self.provider_index: Dict[str, str] = {}
-        self.provider_conflicts: Dict[str, Set[str]] = {}
+        # resolved trait values for this build scope (token -> value, eg "y"
+        # for a plain boolean presence, or an actual value like "1800" for a
+        # typed trait) - a separate dict from provider_index, which only
+        # ever tracks membership/attribution, never a value.
+        self.trait_values: Dict[str, str] = {}
         self.generated_root: Optional[Path] = None
         self.load_errors: Dict[str, str] = {}
         self.pending_generators: Dict[Tuple[str, str], tuple] = {}  # (layer_name, version) -> (cmd, input, output)
+        self._trait_overrides: Dict[str, Any] = trait_overrides or {}
+        self.trait_registry = None
+        if trait_dirs:
+            from trait_registry import TraitRegistry
+            self.trait_registry = TraitRegistry(trait_dirs)
 
         for path in self.search_paths:
             if not path.exists():
                 log_warning(f"Search path '{path}' does not exist")
 
         self.load_layers()
-
-        # now that self.layers is populated, build provider index
-        self._build_provider_index()
 
 
     def _handle_layer_load_error(self, rel_path: Path, message: str, exc: Optional[Exception] = None, layer_name: Optional[str] = None) -> None:
@@ -138,19 +148,95 @@ class LayerManager:
         v = self._latest_version(name)
         return (name, v) if v is not None else None
 
-    def _build_provider_index(self):
-        """Index providers to unique layer names"""
-        for (lname, _version), layer in self.layers.items():
-            info = layer.get_layer_info()
+    def _index_providers(self, build_order: List[str]) -> None:
+        """Index every provider token active for this build into provider_index.
+
+        Labels are opaque strings. Trait tokens resolve through
+        trait_registry (hierarchy expansion, Triggers, Requires:) - only the
+        direct declaration is duplicate-checked, so two layers sharing an
+        expanded ancestor is fine. Bare Provides: only activates a token, so
+        it's boolean-only; other types need a Triggers: rule or a trait:
+        override for their value.
+        """
+        self.provider_index = {}
+        self.trait_values = {}
+        directly_declared: Dict[str, str] = {}
+        declared_traits: Dict[str, str] = {}
+
+        # Seeded before layer Provides: below, so an invalid override is
+        # always validated and a valid one always wins attribution, even if
+        # a layer's own Trigger cascade would reach the same token first.
+        forced = set()
+        for token, value in self._trait_overrides.items():
+            if value is False:
+                continue  # handled in the removal pass below
+            if not self.trait_registry:
+                raise ValueError(f"trait override: '{token}' set but no trait registry is loaded")
+            if token not in self.trait_registry:
+                raise ValueError(f"trait override: '{token}' is not defined in the trait registry")
+            if value is True:
+                validator = self.trait_registry.get_validator(token)
+                if not isinstance(validator, BooleanValidator):
+                    raise ValueError(
+                        f"trait override: '{token}' is not a boolean trait ({validator.describe()}) - "
+                        f"give it an explicit value, eg trait: {{ {token}: <value> }}, not a bare true"
+                    )
+                declared_traits[token] = "y"
+            else:
+                declared_traits[token] = str(value)
+            forced.add(token)
+
+        for lname in build_order:
+            info = self.get_layer_info(lname)
             if not info:
                 continue
             for prov in info.get('provides', []):
-                existing = self.provider_index.get(prov)
+                existing = directly_declared.get(prov)
                 if existing and existing != lname:
-                    # record conflict but keep the first provider mapping (first-wins semantics)
-                    self.provider_conflicts.setdefault(prov, set()).update({existing, lname})
-                else:
+                    raise ValueError(
+                        f"Provider conflict: '{prov}' is declared by multiple layers: {existing}, {lname}"
+                    )
+                directly_declared[prov] = lname
+                if provider_token_type(prov) == 'label':
                     self.provider_index[prov] = lname
+                else:
+                    if not self.trait_registry:
+                        raise ValueError(
+                            f"Layer '{lname}' declares trait token '{prov}' but no trait registry is loaded"
+                        )
+                    if prov not in self.trait_registry:
+                        raise ValueError(f"Layer '{lname}' declares unknown trait '{prov}'")
+                    validator = self.trait_registry.get_validator(prov)
+                    if not isinstance(validator, BooleanValidator):
+                        raise ValueError(
+                            f"Layer '{lname}' provides '{prov}' bare, but it is not a boolean trait "
+                            f"({validator.describe()}) - Provides: only ever activates a trait, it "
+                            f"cannot carry a value; set it via a Triggers: rule or a trait: config override"
+                        )
+                    declared_traits.setdefault(prov, "y")
+
+        if declared_traits:
+            try:
+                active = self.trait_registry.resolve(declared_traits)
+            except ValueError as exc:
+                raise ValueError(f"Trait resolution failed: {exc}") from exc
+            for token in declared_traits:
+                source = '_config_' if token in forced else directly_declared[token]
+                for t in self.trait_registry.expand(token):
+                    self.provider_index.setdefault(t, source)
+            for token in active:
+                self.provider_index.setdefault(token, '(derived)')
+            self.trait_values = dict(active)
+
+        for token, value in self._trait_overrides.items():
+            if value is False:
+                to_remove = [t for t in self.provider_index
+                             if t == token or t.startswith(token + ':')]
+                if not to_remove:
+                    log_warning(f"trait override: '{token}' not in provider index")
+                for t in to_remove:
+                    self.provider_index.pop(t)
+                    self.trait_values.pop(t, None)
 
     def load_layers(self):
         """Discover and load all layer files, creating Metadata objects for each"""
@@ -510,8 +596,9 @@ class LayerManager:
         for layer in target_layers:
             add_layer_and_deps(layer)
 
-        # Fail if any capability is claimed by more than one layer
-        self._check_provider_conflicts_in_scope(build_order)
+        # Index providers for the build set (labels + trait tokens); also
+        # checks direct-declaration conflicts and validates trait Requires:
+        self._index_providers(build_order)
 
         # Apply AfterProvider ordering constraints
         build_order = self._apply_provider_ordering(build_order)
@@ -522,27 +609,24 @@ class LayerManager:
         return build_order
 
     def _validate_provider_requirements(self, build_order: List[str]) -> None:
-        """Validate that all required providers are satisfied by layers in the build order"""
-        # Collect all providers available in the build order
-        available_providers = set()
-        for layer_name in build_order:
-            layer_info = self.get_layer_info(layer_name)
-            if layer_info:
-                available_providers.update(layer_info.get('provides', []))
-
-        # Check both RequiresProvider (validation-only) and AfterProvider (validation + ordering)
+        """Must run after _index_providers() - provider_index already has
+        expanded trait ancestors, so RequiresProvider on eg hw:storage is
+        satisfied by a layer that only directly provides hw:storage:nvme."""
         for layer_name in build_order:
             layer_info = self.get_layer_info(layer_name)
             if layer_info:
                 for required_provider in (layer_info.get('provider_requires', []) +
                                           layer_info.get('after_provider', [])):
-                    if required_provider not in available_providers:
-                        raise ValueError(f"Layer '{layer_name}' requires provider '{required_provider}' but no layer in the dependency chain provides it")
+                    if required_provider not in self.provider_index:
+                        raise ValueError(
+                            f"Layer '{layer_name}' requires provider '{required_provider}' "
+                            f"but no layer in the dependency chain provides it"
+                        )
 
     def _apply_provider_ordering(self, build_order: List[str]) -> List[str]:
         """Stable-sort build_order so each AfterProvider consumer follows its provider."""
-        # Raw provides only - ordering is relative to the declaring layer only
-        # @TODO include capability token checking
+        # Labels only - trait tokens are rejected in AfterProvider at parse
+        # time, since an ancestor/derived token has no single layer to order after.
         cap_to_layer = {}
         for layer_name in build_order:
             layer_info = self.get_layer_info(layer_name)
@@ -619,20 +703,6 @@ class LayerManager:
             )
 
         return result
-
-    def _check_provider_conflicts_in_scope(self, layer_names: List[str]) -> None:
-        """Validate that no provider conflicts exist within the given scope of layers."""
-        # Build provider mapping only for the layers in scope
-        scope_providers = {}
-        for layer_name in layer_names:
-            layer_info = self.get_layer_info(layer_name)
-            if layer_info:
-                for provider in layer_info.get('provides', []):
-                    if provider in scope_providers:
-                        # Found a conflict within scope
-                        existing_layer = scope_providers[provider]
-                        raise ValueError(f"Provider conflict: '{provider}' is provided by multiple layers: {existing_layer}, {layer_name}")
-                    scope_providers[provider] = layer_name
 
     def _load_layer_yaml(self, filepath: str) -> Optional[dict]:
         try:

--- a/site/metadata_parser.py
+++ b/site/metadata_parser.py
@@ -427,8 +427,13 @@ class Metadata:
                 continue
             if XEnv.is_layer_field(field_name) or XEnv.is_var_field(field_name):
                 continue
-            if not is_field_supported(field_name):
-                unknown_fields[field_name] = f"'{field_name}' is not supported"
+            if is_field_supported(field_name):
+                continue
+            # A bare base field (default value) looks like a typo'd suffix
+            # unless <local> is a real, already-discovered local name.
+            if XEnv.is_base_trait_field(field_name, self._container.traits.keys()):
+                continue
+            unknown_fields[field_name] = f"'{field_name}' is not supported"
         return unknown_fields
 
     def validate_layer_schema(self):

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from collections import OrderedDict
 from typing import List, Optional, Dict, Tuple
@@ -46,6 +47,19 @@ def _pipeline_main(args):
     LogConfig.set_verbose(True)
 
     assignments: OrderedDict[str, str] = load_env_file(args.env_in)
+
+    # Extract trait overrides before seeding the environment - this is a
+    # reserved key, not an IGconf_* variable, and must not enter os.environ.
+    trait_overrides_raw = assignments.pop('_IG_TRAIT_OVERRIDES', None)
+    if trait_overrides_raw:
+        try:
+            trait_overrides = json.loads(trait_overrides_raw)
+        except json.JSONDecodeError as exc:
+            log_error(f"malformed _IG_TRAIT_OVERRIDES in env file: {exc}")
+            raise SystemExit(1)
+    else:
+        trait_overrides = {}
+
     # Seed environment with incoming assignments, but do not override any
     # pre-existing values (e.g., CLI overrides passed through the wrapper).
     for key, value in assignments.items():
@@ -56,10 +70,24 @@ def _pipeline_main(args):
         else:
             os.environ[key] = value
 
+    # Trait search dirs: IGROOT first, then SRCROOT, deduped by realpath -
+    # mirrors config_loader.py's _show_trait dir-assembly convention.
+    igroot = os.environ.get('IGROOT', '')
+    srcroot = os.environ.get('SRCROOT', '')
+    seen_trait_dirs = set()
+    trait_dirs = []
+    for root in filter(None, [igroot, srcroot]):
+        d = os.path.join(root, 'trait')
+        r = os.path.realpath(d)
+        if r not in seen_trait_dirs:
+            seen_trait_dirs.add(r)
+            trait_dirs.append(d)
+
     try:
-        manager = LayerManager(search_paths, ['*.yaml'], fail_on_lint=True)
+        manager = LayerManager(search_paths, ['*.yaml'], fail_on_lint=True,
+                                trait_dirs=trait_dirs, trait_overrides=trait_overrides)
     except ValueError as exc:
-        log_error(f"Error: {exc}")
+        log_error(f"{exc}")
         raise SystemExit(1)
 
     resolved_layers: List[str] = []
@@ -76,13 +104,13 @@ def _pipeline_main(args):
     try:
         build_order = manager.get_build_order(resolved_layers)
     except ValueError as exc:
-        log_error(f"Error: {exc}")
+        log_error(f"{exc}")
         raise SystemExit(1)
 
     try:
         manager.run_generators_for_layers(build_order)
     except ValueError as exc:
-        log_error(f"Error: {exc}")
+        log_error(f"{exc}")
         raise SystemExit(1)
 
     if not _validate_layers(manager, build_order):
@@ -99,10 +127,12 @@ def _pipeline_main(args):
     try:
         applied_values = _apply_layers(manager, build_order)
     except ValueError as exc:
-        log_error(f"Error: {exc}")
+        log_error(f"{exc}")
         raise SystemExit(1)
     for var_name, value in applied_values.items():
         assignments[var_name] = value
+
+    _log_providers(manager, build_order)
 
     if args.plan_out:
         _write_layer_plan(args.plan_out, build_order, manager)
@@ -147,6 +177,21 @@ def _inject_root_anchors(anchor_map: Dict[str, Dict[str, Optional[str]]], env_as
         value = env_assignments.get(root_var)
         if value:
             anchor_map.setdefault(f"@{root_var}", {"var": root_var, "value": value})
+
+
+def _log_providers(manager: LayerManager, build_order: List[str]) -> None:
+    build_set = set(build_order)
+    index = {t: l for t, l in manager.provider_index.items()
+             if l in build_set or l in ('_config_', '(derived)')}
+    if not index:
+        return
+    col = max(len(t) for t in index) + 2
+    log_info("PROVIDERS")
+    for token in sorted(index):
+        layer = '(config)' if index[token] == '_config_' else index[token]
+        value = manager.trait_values.get(token)
+        suffix = f"  = {value}" if value not in (None, "y") else ""
+        log_info(f"  {token:<{col}}{layer}{suffix}")
 
 
 def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) -> None:
@@ -222,7 +267,7 @@ def _apply_layers(
 ) -> OrderedDict[str, str]:
     variable_definitions = _collect_variable_definitions(manager, build_order)
     resolver = VariableResolver()
-    resolved_variables = resolver.resolve(variable_definitions)
+    resolved_variables = resolver.resolve(variable_definitions, manager.provider_index)
 
     applied: "OrderedDict[str, str]" = OrderedDict()
     ordered_vars = sorted(resolved_variables.values(), key=lambda env_var: env_var.position)
@@ -359,6 +404,27 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
                 )
                 ok = False
 
+    # Include trigger-injected variables so their required/validator checks are
+    # not silently skipped. resolver.resolve() runs the full trigger loop,
+    # including has()-gated triggers evaluated against provider_index.
+    trigger_resolved = resolver.resolve(variable_definitions, manager.provider_index)
+    for var_name, env_var in trigger_resolved.items():
+        if var_name in selected:
+            continue
+        selected[var_name] = env_var
+        current = os.environ.get(env_var.name)
+        if env_var.required and (current is None or current == ""):
+            log_error(f"[FAIL] {env_var.name} - REQUIRED but not set (layer: {env_var.source_layer})")
+            ok = False
+        elif current is not None and env_var.validator:
+            errors = env_var.validate_value(current)
+            if errors:
+                reason = "; ".join(errors)
+                log_error(
+                    f"[FAIL] {env_var.name}={current} (invalid value, reason: {reason}, layer: {env_var.source_layer})"
+                )
+                ok = False
+
     # Validate conflict expressions against resolved variable values.
     import conditions as _cond
 
@@ -379,7 +445,7 @@ def _validate_resolved(manager: LayerManager, build_order: List[str]) -> bool:
                 continue
             seen_exprs.add(expr)
             try:
-                fired = _cond.evaluate(expr, variables)
+                fired = _cond.evaluate(expr, variables, manager.provider_index)
             except ValueError:
                 continue
             if fired:

--- a/site/trait_registry.py
+++ b/site/trait_registry.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set, Union
 
 from metadata_parser import Metadata
 from env_types import EnvTrait, TRAIT_TOKEN_PATTERN
+from validators import BooleanValidator
 import conditions as _cond
 
 TOKEN_RE = re.compile(rf'^{TRAIT_TOKEN_PATTERN}$')
@@ -94,8 +95,12 @@ class TraitRegistry:
             for dep in trait.requires:
                 self._check_reference(dep, path, trait.name, "Requires")
             for rule in trait.triggers:
-                if rule.target != trait.name:
+                if rule.target == trait.name:
+                    target_validator = trait.validator
+                else:
                     self._check_reference(rule.target, path, trait.name, "Triggers")
+                    target_validator = self._definitions[rule.target].validator
+                self._check_trigger_value(rule, target_validator, path, trait.name)
 
             # A namespace node can be (re)defined once per root - a different
             # root extending it (eg, an OEM adding children under 'hw') is
@@ -141,6 +146,17 @@ class TraitRegistry:
                 f"{path}: '{name}' {field} references '{target}', a namespace node, not a trait"
             )
 
+    def _check_trigger_value(self, rule, validator, path: Path, name: str) -> None:
+        """Value must satisfy the TARGET's own Valid: rule, not the
+        declaring trait's - Triggers are routinely cross-targeting (eg an
+        SoC trait setting a sibling's clock-speed trait)."""
+        errors = validator.validate(rule.value)
+        if errors:
+            raise ValueError(
+                f"{path}: '{name}' Triggers action 'set ({rule.target})={rule.value}': "
+                f"{errors[0]} ({validator.describe()})"
+            )
+
     def expand(self, token: str) -> Dict[str, str]:
         """Closure of one token: hierarchy ancestors plus unconditional
         (when=y) Triggers, recursively. Conditional Triggers need a build's
@@ -174,6 +190,10 @@ class TraitRegistry:
         d = self._resolved.get(token)
         return d.valid if d else None
 
+    def get_validator(self, token: str):
+        d = self._resolved.get(token)
+        return d.validator if d else None
+
     def get_requires(self, token: str) -> List[str]:
         d = self._resolved.get(token)
         return d.requires if d else []
@@ -192,11 +212,47 @@ class TraitRegistry:
             if t == prefix or t.startswith(prefix + ':')
         }
 
-    def resolve(self, declared: Set[str]) -> Set[str]:
-        """Simulate a build's accumulated trait set from a set of directly
-        declared tokens (TODO layer manager injection point).
+    def _activate(self, token: str, value: str, active: Dict[str, str], seen: Set[str]) -> None:
+        """Activate 'token' with 'value', cascading to hierarchy ancestors
+        and unconditional (when=y) Triggers - mirrors _expand() but carries
+        values, not source paths. A boolean ancestor is always activated as
+        'y' regardless of its own load-time default ('n' means "at rest",
+        not "when activated"); a non-boolean ancestor uses its own default,
+        since there's no other value to fall back on. First write wins per
+        token, same dedup-via-seen as expand()."""
+        if token in seen:
+            return
+        seen.add(token)
+        parts = token.split(':')
+        for i in range(2, len(parts)):
+            ancestor = ':'.join(parts[:i])
+            ancestor_trait = self._resolved[ancestor]
+            ancestor_value = "y" if isinstance(ancestor_trait.validator, BooleanValidator) else ancestor_trait.default
+            self._activate(ancestor, ancestor_value, active, seen)
+        if token not in active:
+            trait = self._resolved[token]
+            errors = trait.validator.validate(value)
+            if errors:
+                raise ValueError(
+                    f"'{token}' cannot be set to '{value}': {errors[0]} ({trait.validator.describe()})"
+                )
+            active[token] = value
+        for rule in self._resolved[token].triggers:
+            if rule.condition == 'y':
+                self._activate(rule.target, rule.value, active, seen)
 
-        1. Expand each declared token (hierarchy + unconditional Triggers).
+    def resolve(self, declared: Union[Set[str], Dict[str, str]]) -> Dict[str, str]:
+        """Simulate a build's accumulated trait values from a set of
+        directly declared tokens (what LayerManager supplies from layers'
+        Provides, plus any trait: config overrides). A bare Set[str] is
+        shorthand for "every declared token gets its own canonical 'y'" -
+        only valid when every declared token is boolean; anything else must
+        be passed as an explicit {token: value} mapping, since there's no
+        sensible default for eg an int-typed trait (this is enforced by
+        _activate's own validation, not a separate check here).
+
+        1. Seed each declared token's value, then activate it (hierarchy
+           ancestors + unconditional Triggers cascade from there).
         2. Fixed point: fire any Trigger whose condition now holds, until
            nothing changes. A self-targeting rule fires on its condition
            alone - a cross-targeting rule also requires its source token to
@@ -205,11 +261,14 @@ class TraitRegistry:
            direct declaration, hierarchy ancestor, or a Trigger. If a token
            is active, its own preconditions must hold too.
         """
-        active: Set[str] = set()
-        for token in declared:
+        if not isinstance(declared, dict):
+            declared = {token: "y" for token in declared}
+
+        active: Dict[str, str] = {}
+        for token, value in declared.items():
             if token not in self._resolved:
                 raise ValueError(f"Unknown trait token: '{token}'")
-            active.update(self.expand(token).keys())
+            self._activate(token, value, active, set())
 
         changed = True
         while changed:
@@ -225,10 +284,10 @@ class TraitRegistry:
                             rule.condition == 'y' or _cond.evaluate(rule.condition, {}, active)
                         )
                     if fires:
-                        for t in self.expand(rule.target):
-                            if t not in active:
-                                active.add(t)
-                                changed = True
+                        before = len(active)
+                        self._activate(rule.target, rule.value, active, set())
+                        if len(active) != before:
+                            changed = True
 
         unmet: Dict[str, List[str]] = {}
         for token in active:

--- a/site/trait_registry.py
+++ b/site/trait_registry.py
@@ -153,8 +153,7 @@ class TraitRegistry:
         errors = validator.validate(rule.value)
         if errors:
             raise ValueError(
-                f"{path}: '{name}' Triggers action 'set ({rule.target})={rule.value}': "
-                f"{errors[0]} ({validator.describe()})"
+                f"{path}: '{name}' Triggers action 'set ({rule.target})={rule.value}': {errors[0]}"
             )
 
     def expand(self, token: str) -> Dict[str, str]:
@@ -233,9 +232,7 @@ class TraitRegistry:
             trait = self._resolved[token]
             errors = trait.validator.validate(value)
             if errors:
-                raise ValueError(
-                    f"'{token}' cannot be set to '{value}': {errors[0]} ({trait.validator.describe()})"
-                )
+                raise ValueError(f"'{token}': {errors[0]}")
             active[token] = value
         for rule in self._resolved[token].triggers:
             if rule.condition == 'y':

--- a/site/validators.py
+++ b/site/validators.py
@@ -328,12 +328,11 @@ def parse_validator(rule_str: str) -> BaseValidator:
     elif rule_str == "int":
         return IntegerValidator()
     elif rule_str.startswith("int:"):
-        try:
-            range_str = rule_str.split(":", 1)[1]
-            min_val, max_val = map(int, range_str.split("-"))
-            return IntegerValidator(min_val, max_val)
-        except Exception as e:
-            raise ValueError(f"Invalid int range format '{rule_str}': {e}")
+        range_str = rule_str.split(":", 1)[1]
+        parts = range_str.split("-")
+        if len(parts) != 2 or not all(p.lstrip("+").isdigit() for p in parts):
+            raise ValueError(f"Invalid '{rule_str}':\n{IntegerValidator.get_help_text()}")
+        return IntegerValidator(int(parts[0]), int(parts[1]))
     elif rule_str.startswith("regex:"):
         pattern = rule_str.split(":", 1)[1]
         return RegexValidator(pattern)

--- a/test/layer/invalid-afterprovider-trait-token.yaml
+++ b/test/layer/invalid-afterprovider-trait-token.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-invalid-afterprovider-trait-token
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-AfterProvider: hw:pcie
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/provider-trait-nvme-only.yaml
+++ b/test/layer/provider-trait-nvme-only.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-trait-nvme-only
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: hw:storage:nvme
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/provider-trait-nvme-with-pcie.yaml
+++ b/test/layer/provider-trait-nvme-with-pcie.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-trait-nvme-with-pcie
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: hw:pcie:bus,hw:storage:nvme
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/provider-trait-wants-storage.yaml
+++ b/test/layer/provider-trait-wants-storage.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-provider-trait-wants-storage
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-RequiresProvider: hw:storage
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/run-tests.sh
+++ b/test/layer/run-tests.sh
@@ -734,6 +734,76 @@ run_test "provider-ordering-cycle" \
 
 cleanup_env
 
+# Invalid - trait token used in AfterProvider (parse-time rejection)
+run_test "invalid-afterprovider-trait-token-parse" \
+    "ig metadata --parse ${LAYERS}/invalid-afterprovider-trait-token.yaml" \
+    1 \
+    "A trait token (colon-containing) in AfterProvider should fail to parse"
+
+run_test "invalid-afterprovider-trait-token-validate" \
+    "ig metadata --validate ${LAYERS}/invalid-afterprovider-trait-token.yaml" \
+    1 \
+    "A trait token (colon-containing) in AfterProvider should fail to validate"
+
+# Provider-trait wiring: TraitRegistry plugged into LayerManager's provider
+# index. These use the real built-in trait/ tree (IGROOT set to the repo
+# root, not the fake make_pipeline_env path), so RequiresProvider on a
+# hierarchy ancestor and an unmet Requires: on a directly-provided trait
+# token are exercised against real tokens (hw:pcie, hw:storage, hw:storage:nvme).
+cleanup_env
+run_test "provider-trait-satisfied" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-trait-nvme-with-pcie.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-provider-trait-nvme-with-pcie --path "$TMP_DIR" \
+        --env-out "$TMP_OUT" >/dev/null && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_DIR"' \
+    0 \
+    "A layer directly providing hw:pcie and hw:storage:nvme together should build cleanly"
+
+cleanup_env
+run_test "provider-trait-unmet-requires" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-trait-nvme-only.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-provider-trait-nvme-only --path "$TMP_DIR" \
+        --env-out "$TMP_OUT" >/dev/null; RESULT=$?; \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_DIR"; \
+     exit $RESULT' \
+    1 \
+    "Providing hw:storage:nvme without hw:pcie should fail its unmet Requires:"
+
+cleanup_env
+run_test "provider-trait-ancestor-satisfies-requiresprovider" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-trait-nvme-with-pcie.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/provider-trait-wants-storage.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" \
+        --layers test-provider-trait-nvme-with-pcie test-provider-trait-wants-storage \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" >/dev/null && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_DIR"' \
+    0 \
+    "RequiresProvider on a trait hierarchy ancestor (hw:storage) should be satisfied by a layer that only directly provides a child (hw:storage:nvme)"
+
+cleanup_env
+
+# An invalid trait: override value must be caught even when a layer's own
+# Provides: cascade would also reach the same (ancestor) token - overrides
+# are seeded before layers precisely so this race can't hide a bad value.
+run_test "provider-trait-invalid-override-not-masked-by-layer-cascade" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/provider-trait-nvme-with-pcie.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n_IG_TRAIT_OVERRIDES={\"hw:storage\":100}\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-provider-trait-nvme-with-pcie \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" >/dev/null; RESULT=$?; \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_DIR"; \
+     exit $RESULT' \
+    1 \
+    "An invalid trait: override value for a token also reached via a layer's cascade (hw:storage, an ancestor of hw:storage:nvme) should still be rejected"
+
+cleanup_env
+
 run_test "pipeline-build-order" \
     'TMP_ENV=$(mktemp) && TMP_ENV_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" && \

--- a/test/trait/fixtures/trigger-can-deactivate/children/leaves.deb822
+++ b/test/trait/fixtures/trigger-can-deactivate/children/leaves.deb822
@@ -1,0 +1,6 @@
+X-Env-Trait-x-Desc: boolean target, explicitly deactivated by y
+X-Env-Trait-x-Valid: bool
+
+X-Env-Trait-y-Desc: explicitly sets x to false when active
+X-Env-Trait-y-Valid: bool
+X-Env-Trait-y-Triggers: when=y set (hw:x)=false

--- a/test/trait/fixtures/trigger-can-deactivate/top.deb822
+++ b/test/trait/fixtures/trigger-can-deactivate/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/fixtures/trigger-value-non-boolean/trait/children/leaves.deb822
+++ b/test/trait/fixtures/trigger-value-non-boolean/trait/children/leaves.deb822
@@ -1,0 +1,6 @@
+X-Env-Trait-x-Desc: boolean target
+X-Env-Trait-x-Valid: bool
+
+X-Env-Trait-y-Desc: tries to set hw:x to a non-boolean value
+X-Env-Trait-y-Valid: bool
+X-Env-Trait-y-Triggers: when=y set (hw:x)=100

--- a/test/trait/fixtures/trigger-value-non-boolean/trait/top.deb822
+++ b/test/trait/fixtures/trigger-value-non-boolean/trait/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/fixtures/typed-trait/children/leaves.deb822
+++ b/test/trait/fixtures/typed-trait/children/leaves.deb822
@@ -1,0 +1,7 @@
+X-Env-Trait-freq-Desc: clock frequency in MHz
+X-Env-Trait-freq: 1500
+X-Env-Trait-freq-Valid: int:600-3000
+
+X-Env-Trait-turbo-Desc: turbo mode, bumps the clock to 3000
+X-Env-Trait-turbo-Valid: bool
+X-Env-Trait-turbo-Triggers: when=y set (hw:freq)=3000

--- a/test/trait/fixtures/typed-trait/top.deb822
+++ b/test/trait/fixtures/typed-trait/top.deb822
@@ -1,0 +1,3 @@
+X-Env-Trait-hw-Desc: namespace node
+X-Env-Trait-hw-Valid: bool
+X-Env-Trait-hw-Include: children/leaves.deb822

--- a/test/trait/invalid-trait-trigger-non-boolean.deb822
+++ b/test/trait/invalid-trait-trigger-non-boolean.deb822
@@ -1,3 +1,0 @@
-X-Env-Trait-b-Desc: tries to set hw:a to a non-boolean value
-X-Env-Trait-b-Valid: bool
-X-Env-Trait-b-Triggers: when=y set (hw:a)=100

--- a/test/trait/invalid-trait-trigger-not-true.deb822
+++ b/test/trait/invalid-trait-trigger-not-true.deb822
@@ -1,3 +1,0 @@
-X-Env-Trait-b-Desc: tries to set hw:a to false
-X-Env-Trait-b-Valid: bool
-X-Env-Trait-b-Triggers: when=y set (hw:a)=false

--- a/test/trait/invalid-trait-valid-malformed.deb822
+++ b/test/trait/invalid-trait-valid-malformed.deb822
@@ -1,0 +1,2 @@
+X-Env-Trait-x-Desc: claims a malformed Valid: rule the engine can't parse
+X-Env-Trait-x-Valid: int:not-a-number-100

--- a/test/trait/invalid-trait-valid-type.deb822
+++ b/test/trait/invalid-trait-valid-type.deb822
@@ -1,2 +1,0 @@
-X-Env-Trait-x-Desc: claims a non-boolean type the engine can never produce
-X-Env-Trait-x-Valid: int:1-100

--- a/test/trait/run-tests.sh
+++ b/test/trait/run-tests.sh
@@ -91,35 +91,15 @@ print_summary() {
 print_header "TRAIT REGISTRY TESTS"
 
 # Essentially lint / validation checkers
-run_test "invalid-trait-valid-type-parse" \
-    "ig metadata --parse ${TRAIT}/invalid-trait-valid-type.deb822" \
+run_test "invalid-trait-valid-malformed-parse" \
+    "ig metadata --parse ${TRAIT}/invalid-trait-valid-malformed.deb822" \
     1 \
-    "Trait with non-bool Valid: should fail to parse"
+    "Trait with a malformed Valid: rule should fail to parse"
 
-run_test "invalid-trait-valid-type-validate" \
-    "ig metadata --validate ${TRAIT}/invalid-trait-valid-type.deb822" \
+run_test "invalid-trait-valid-malformed-validate" \
+    "ig metadata --validate ${TRAIT}/invalid-trait-valid-malformed.deb822" \
     1 \
-    "Trait with non-bool Valid: should fail to validate"
-
-run_test "invalid-trait-trigger-non-boolean-parse" \
-    "ig metadata --parse ${TRAIT}/invalid-trait-trigger-non-boolean.deb822" \
-    1 \
-    "Trait Triggers: action with a non-boolean value should fail to parse"
-
-run_test "invalid-trait-trigger-non-boolean-validate" \
-    "ig metadata --validate ${TRAIT}/invalid-trait-trigger-non-boolean.deb822" \
-    1 \
-    "Trait Triggers: action with a non-boolean value should fail to validate"
-
-run_test "invalid-trait-trigger-not-true-parse" \
-    "ig metadata --parse ${TRAIT}/invalid-trait-trigger-not-true.deb822" \
-    1 \
-    "Trait Triggers: action setting a false-ish value should fail to parse"
-
-run_test "invalid-trait-trigger-not-true-validate" \
-    "ig metadata --validate ${TRAIT}/invalid-trait-trigger-not-true.deb822" \
-    1 \
-    "Trait Triggers: action setting a false-ish value should fail to validate"
+    "Trait with a malformed Valid: rule should fail to validate"
 
 run_test "invalid-trait-unsupported-field-parse" \
     "ig metadata --parse ${TRAIT}/invalid-trait-unsupported-field.deb822" \
@@ -152,6 +132,15 @@ run_test "trait-namespace-node-duplicate-within-same-root-is-error" \
     "ig config --trait -S ${TRAIT}/fixtures/namespace-same-root-duplicate" \
     1 \
     "Two top-level files in the same root both defining the same namespace node should be a hard error"
+
+# Triggers: action value is checked against the TARGET's own type, which
+# needs the whole tree loaded - not reachable via single-file ig metadata
+# --parse/--validate, only via the registry (hence -S here, not a bare
+# metadata check).
+run_test "trait-trigger-value-non-boolean-is-error" \
+    "ig config --trait -S ${TRAIT}/fixtures/trigger-value-non-boolean" \
+    1 \
+    "A Triggers: action setting a non-boolean value on a boolean target should be a hard error"
 
 # Functional verification - resolve() semantics (conditional Triggers,
 # Requires validate-only gating) that the --trait CLI never exercises,

--- a/test/trait/test_trait_registry.py
+++ b/test/trait/test_trait_registry.py
@@ -36,6 +36,47 @@ def case_conditional_triggers_self_targeting() -> None:
         raise SystemExit("hw:derived did not fire with both conditions met")
 
 
+def case_typed_trait_carries_value() -> None:
+    # hw:freq is int-typed, not boolean - resolve() must carry its actual
+    # value through, not just membership
+    r = TraitRegistry(str(FIXTURES_DIR / "typed-trait"))
+
+    active = r.resolve({"hw:freq": "1800"})
+    if active.get("hw:freq") != "1800":
+        raise SystemExit(f"expected hw:freq=1800, got {active.get('hw:freq')}")
+
+    # a Trigger from another trait can also set it, carrying its own value
+    active = r.resolve({"hw:turbo": "y"})
+    if active.get("hw:freq") != "3000":
+        raise SystemExit(f"turbo Trigger should set hw:freq=3000, got {active.get('hw:freq')}")
+
+    # out-of-range value must be rejected, not silently accepted
+    try:
+        r.resolve({"hw:freq": "9999"})
+    except ValueError as exc:
+        if "hw:freq" not in str(exc):
+            raise SystemExit(f"expected error naming hw:freq, got: {exc}")
+    else:
+        raise SystemExit("hw:freq=9999 is out of range (600-3000) and should be rejected")
+
+    # a bare Set[str] declaration has no sensible default for a non-boolean
+    # trait - must fail, not silently coerce to some value
+    try:
+        r.resolve({"hw:freq"})
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("bare declaration of a non-boolean trait should be rejected")
+
+
+def case_trigger_can_deactivate() -> None:
+    # y sets x to false - no bool-specific "must be true" restriction
+    r = TraitRegistry(str(FIXTURES_DIR / "trigger-can-deactivate"))
+    active = r.resolve({"hw:y": "y"})
+    if active.get("hw:x") != "false":
+        raise SystemExit(f"expected hw:x=false, got {active.get('hw:x')}")
+
+
 def case_external_srcroot_extends_real_tree() -> None:
     # OEM srcroot loaded alongside the built-in tree: a new namespace, plus
     # extending the built-in hw namespace with a child of its own
@@ -64,6 +105,8 @@ def case_external_srcroot_extends_real_tree() -> None:
 def main() -> None:
     case_by_prefix_colon_boundary()
     case_conditional_triggers_self_targeting()
+    case_typed_trait_carries_value()
+    case_trigger_can_deactivate()
     case_external_srcroot_extends_real_tree()
 
 


### PR DESCRIPTION
Remove hard coded bool type and instead, extend `X-Env-Trait-*-Valid` to support any type backed by the validator (env_types.py/validators.py). Type checking for trait assignments moves into TraitRegistry, so a value being set on a trait is validated against that trait's declared type (same as any other `X-Env` variable declared by a layer).

Hook up traits into the layer/provider pipeline. Main changes:
- A Provider can now be a trait token - not just a plain label. All providers route through a shared index that expands trait hierarchy and fires Triggers.
- New trait: config file section allows overriding trait values.
- The new `has() / not has()` helpers now reach variable-level Triggers:/Conflicts by routing the provider index through VariableResolver, meaning that actions can now take place conditionally based on trait presence.
- Pipeline now emits all providers at build time.