### PR TITLE
engine: trait integration

### DIFF
--- a/docs/config/index.adoc
+++ b/docs/config/index.adoc
@@ -196,7 +196,26 @@ List sections do not merge with includes in the same way as mapping sections. Be
 
 === Configuration Includes
 
-Configuration files support includes to promote reusability and modularity. The include precedence order is shown in the table below.
+Configuration files support includes to promote reusability and modularity.
+
+A single file is included using a mapping with a `file` key:
+
+[source,yaml]
+----
+include:
+  file: base.yaml
+----
+
+Multiple files are included using a list of filenames. Files are processed in order - later entries override earlier ones. The including file overrides all included content.
+
+[source,yaml]
+----
+include:
+  - device/cm5.yaml
+  - device/cm5io.yaml
+----
+
+Include files are resolved using the following search order:
 
 [cols="1,6,5"]
 |===
@@ -215,10 +234,10 @@ Configuration files support includes to promote reusability and modularity. The 
 |Default in-tree location, eg ```/usr/share/rpi-image-gen/config/```
 |===
 
-Included files are resolved using:
-
-1. **Parent directory**
-2. **Search path**
+[WARNING]
+====
+The list-section merge warning above applies equally to multiple includes. If two included files both define a list section (e.g. `packages`), they merge positionally - later entries override earlier ones by index rather than appending. For predictable results, define list sections in only one file in an include chain.
+====
 
 == Section Names
 
@@ -429,7 +448,7 @@ All dependencies are always included, i.e. variable names result in actual layer
 The configuration system processes files using the following steps:
 
 1. **Parse YAML configuration file**
-2. **Process includes recursively** - Follows include directives with circular dependency detection
+2. **Process includes recursively** - Follows include directives (single or list) in order, with circular dependency detection
 3. **Apply command line overrides** - Processes variables specified after `--`
 4. **Generate output** - Either loads into environment or writes to file
 

--- a/site/README.adoc
+++ b/site/README.adoc
@@ -55,6 +55,7 @@ Used by pipeline to perform final variable expansion.
 Discovery and introspection of all layers. Walks search roots, parses metadata, maintains the layer registry (self.layers, file paths, tags).
 Provides dependency graph operations (get build order, provider checks, reverse deps), schema checks used by pipeline pre-validation, and the user-facing ig CLI (list, describe, etc).
 Provider tokens are either plain labels or trait tokens (told apart by a colon), the latter resolved through a TraitRegistry - `_index_providers` expands hierarchy, fires Triggers, and validates Requires: for whatever a build's layers `Provides:`. A bare `Provides:` only activates a token, so it's boolean-only; other types need a Triggers: rule or a `trait:` config override for their value. Trait tokens can't appear in `AfterProvider` (rejected at parse time) since an ancestor/derived token has no single layer to order after.
+Conditional dependencies are supported via `X-Env-Layer-Requires` using the form `name when=<expr>` where a layer is only pulled in if `<expr>` is true. This is evaluatged against the provider index as built from the unconditional layers alone - a single pass, not a fixed point. Therefore a condition gated on a token only supplied by another conditionally-pulled layer never fires.
 
 == site/trait_registry.py
 
@@ -66,7 +67,7 @@ Main orchestrator for the application. Loads the base env file produced by confi
 
 == site/conditions.py
 
-Expression parser and evaluator for build-time conditions. Used by both trigger rules and conflict expressions to validate syntax at layer-load time and evaluate conditions against the resolved variable set at build time. Expressions use standard Python comparison syntax. See https://docs.python.org/3/reference/expressions.html#comparisons
+Expression parser and evaluator for build-time conditions. Used by trigger rules, conflict expressions, and conditional layer `Requires:` to validate syntax at layer-load time and evaluate conditions against the resolved variable set (and via `has()`/`not has()` for provider tokens) at build time. Expressions use standard Python comparison syntax. See https://docs.python.org/3/reference/expressions.html#comparisons
 
 == site/validators.py
 

--- a/site/config_loader.py
+++ b/site/config_loader.py
@@ -93,20 +93,29 @@ class ConfigLoader:
                     raise ValueError(f"'trait' section in {path} must be a mapping")
                 trait_here = trait_data
 
-            # Handle include directive
+            # Handle include directive(s)
+            # Single form: include: file: foo.yaml
+            # List form:   include: [foo.yaml, bar.yaml]  (later entries override earlier)
             included_sections: Dict[str, Dict[str, str]] = {}
             included_trait: Dict[str, Any] = {}
-            if 'include' in yaml_data and isinstance(yaml_data['include'], list):
-                raise ValueError(
-                    f"List includes are not supported in {path}"
-                )
-            if 'include' in yaml_data and isinstance(yaml_data['include'], dict):
-                inc_file = yaml_data['include'].get('file')
-                if not inc_file:
-                    raise ValueError(f"YAML include directive in {path} missing 'file' key")
-                inc_path = self._resolve_include(inc_file, path.parent)
-                included_sections, included_trait = _load_yaml_recursive(inc_path, visited)
-                yaml_data.pop('include', None)
+            inc_directive = yaml_data.pop('include', None)
+            if inc_directive is not None:
+                if isinstance(inc_directive, dict):
+                    inc_files = [inc_directive.get('file')]
+                    if not inc_files[0]:
+                        raise ValueError(f"YAML include directive in {path} missing 'file' key")
+                elif isinstance(inc_directive, list):
+                    if not all(isinstance(e, str) for e in inc_directive):
+                        raise ValueError(f"'include' list in {path} must contain filename strings")
+                    inc_files = inc_directive
+                else:
+                    raise ValueError(f"'include' in {path} must be a mapping or list of filenames")
+                for inc_file in inc_files:
+                    inc_path = self._resolve_include(inc_file, path.parent)
+                    inc_sections, inc_trait = _load_yaml_recursive(inc_path, visited)
+                    for sect, mapping in inc_sections.items():
+                        included_sections.setdefault(sect, {}).update(mapping)
+                    included_trait.update(inc_trait)
 
             # Convert current file sections
             curr_sections: Dict[str, Dict[str, str]] = {}

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -765,6 +765,7 @@ class EnvLayer:
 
     def __init__(self, name: str, description: str = "", version: str = "1.0.0",
                  category: str = "general", deps: List[str] = None,
+                 conditional_deps: List[Tuple[str, str]] = None,
                  provides: List[str] = None, requires_provider: List[str] = None,
                  after_provider: List[str] = None,
                  conflicts: List[str] = None, layer_type: str = "static",
@@ -775,6 +776,7 @@ class EnvLayer:
         self.version = version
         self.category = category
         self.deps = deps or []
+        self.conditional_deps: List[Tuple[str, str]] = conditional_deps or []  # [(layer_name, condition)]
         self.provides = provides or []
         self.requires_provider = requires_provider or []
         self.after_provider = after_provider or []
@@ -808,7 +810,7 @@ class EnvLayer:
 
         # Parse dependency lists
         requires_str = metadata_dict.get(XEnv.layer_requires(), "")
-        requires = cls._parse_dependency_list(requires_str, doc_mode)
+        requires, conditional_deps = cls._parse_requires(requires_str, doc_mode)
 
         provides_str = metadata_dict.get(XEnv.layer_provides(), "")
         provides = cls._parse_dependency_list(provides_str, doc_mode)
@@ -842,6 +844,7 @@ class EnvLayer:
             version=version,
             category=category,
             deps=requires,
+            conditional_deps=conditional_deps,
             provides=provides,
             requires_provider=requires_provider,
             after_provider=after_provider,
@@ -851,6 +854,52 @@ class EnvLayer:
             config_file=config_file,
             sets=sets,
         )
+
+    @staticmethod
+    def _parse_requires(requires_str: str, doc_mode: bool = False) -> Tuple[List[str], List[Tuple[str, str]]]:
+        """Parse X-Env-Layer-Requires into unconditional and conditional dep lists.
+
+        A token of the form 'name when=expr' is conditional: returned as
+        (name, expr) in the second list, only pulled into the build if expr
+        evaluates to true against the provider index. All other tokens are
+        unconditional and returned in the first list, validated the same way
+        as every other dependency-list field.
+        """
+        if not requires_str.strip():
+            return [], []
+
+        import conditions as _cond
+
+        unconditional_tokens = []
+        conditional: List[Tuple[str, str]] = []
+
+        for dep in requires_str.split(','):
+            token = dep.strip()
+            if not token:
+                continue
+
+            if ' when=' in token:
+                layer_part, condition = token.split(' when=', 1)
+                layer_name = layer_part.strip()
+                condition = condition.strip()
+
+                if re.search(r"\s", layer_name):
+                    raise ValueError(
+                        f"Invalid layer name '{layer_name}' in conditional requires"
+                    )
+                if not (doc_mode and '${' in layer_name):
+                    if not re.match(r'^[A-Za-z0-9_:\-]+$', layer_name):
+                        raise ValueError(
+                            f"Invalid layer name '{layer_name}' in conditional requires"
+                            f" - only alphanum, dash, underscore, colon allowed"
+                        )
+                _cond.validate(condition)
+                conditional.append((layer_name, condition))
+            else:
+                unconditional_tokens.append(token)
+
+        unconditional = EnvLayer._parse_dependency_list(','.join(unconditional_tokens), doc_mode) if unconditional_tokens else []
+        return unconditional, conditional
 
     @staticmethod
     def _parse_dependency_list(depends_str: str, doc_mode: bool = False) -> List[str]:
@@ -968,6 +1017,7 @@ class EnvLayer:
             "type": self.layer_type,
             "generator": self.generator,
             "depends": self.deps,
+            "conditional_deps": self.conditional_deps,
             "optional_depends": [],  # Not currently supported
             "conflicts": self.conflicts,
             "config_file": self.config_file,

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -600,6 +600,40 @@ class LayerManager:
         # checks direct-declaration conflicts and validates trait Requires:
         self._index_providers(build_order)
 
+        # Evaluate conditional Requires: (name when=<expr>) against the provider
+        # index built from unconditional layers. First-order only: a condition
+        # gated on a token only provided by another conditionally-pulled layer
+        # will not fire, since provider_index isn't rebuilt until after this pass.
+        import conditions as _cond
+        order_len_before = len(build_order)
+        for layer_name in list(build_order):
+            layer_info = self.get_layer_info(layer_name)
+            if not layer_info:
+                continue
+            for dep_name, condition in layer_info.get('conditional_deps', []):
+                try:
+                    fired = _cond.evaluate(condition, {}, self.provider_index)
+                except ValueError:
+                    fired = False
+                if not fired:
+                    continue
+                if dep_name not in self._name_to_versions:
+                    raise ValueError(
+                        f"Layer '{layer_name}' conditional dependency '{dep_name}' not found"
+                    )
+                # Insert dep and its transitive deps immediately before their requirer.
+                before = len(build_order)
+                add_layer_and_deps(dep_name)
+                new_layers = build_order[before:]
+                if new_layers:
+                    del build_order[before:]
+                    pos = build_order.index(layer_name)
+                    for i, new_layer in enumerate(new_layers):
+                        build_order.insert(pos + i, new_layer)
+
+        if len(build_order) > order_len_before:
+            self._index_providers(build_order)
+
         # Apply AfterProvider ordering constraints
         build_order = self._apply_provider_ordering(build_order)
 
@@ -1286,6 +1320,11 @@ def _layer_main(args):
                         _show_deps(manager.get_dependencies(dep), seen, indent + 1)
 
                 _show_deps(layer_info['depends'], set())
+
+            if layer_info.get('conditional_deps'):
+                print("Conditional-Depends:")
+                for dep_name, condition in layer_info['conditional_deps']:
+                    print(f"  - {dep_name} when={condition}")
 
             if layer_info['optional_depends']:
                 print(f"Optional-Depends: {', '.join(layer_info['optional_depends'])}")

--- a/test/layer/conditional-requires-consumer.yaml
+++ b/test/layer/conditional-requires-consumer.yaml
@@ -1,0 +1,8 @@
+# METABEGIN
+# X-Env-Layer-Name: test-cond-requires-consumer
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: hw:pcie
+# X-Env-Layer-Requires: test-cond-requires-dep when=has('hw:pcie')
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/conditional-requires-dep.yaml
+++ b/test/layer/conditional-requires-dep.yaml
@@ -1,0 +1,6 @@
+# METABEGIN
+# X-Env-Layer-Name: test-cond-requires-dep
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/conditional-requires-firstorder-dep.yaml
+++ b/test/layer/conditional-requires-firstorder-dep.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-cond-requires-firstorder-dep
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: hw:pcie
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/conditional-requires-firstorder-target.yaml
+++ b/test/layer/conditional-requires-firstorder-target.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-cond-requires-firstorder-target
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: test-cond-requires-firstorder-dep when=has('hw:pcie')
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/conditional-requires-notfire-consumer.yaml
+++ b/test/layer/conditional-requires-notfire-consumer.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-cond-requires-notfire-consumer
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: test-cond-requires-dep when=has('hw:bluetooth')
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/invalid-conditional-requires-bad-condition.yaml
+++ b/test/layer/invalid-conditional-requires-bad-condition.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-invalid-conditional-requires-bad-condition
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: some-layer when=has(
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/invalid-conditional-requires-bad-name.yaml
+++ b/test/layer/invalid-conditional-requires-bad-name.yaml
@@ -1,0 +1,7 @@
+# METABEGIN
+# X-Env-Layer-Name: test-invalid-conditional-requires-bad-name
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Requires: bad name when=has('hw:pcie')
+# X-Env-Layer-Category: test
+# METAEND
+---

--- a/test/layer/run-tests.sh
+++ b/test/layer/run-tests.sh
@@ -804,6 +804,73 @@ run_test "provider-trait-invalid-override-not-masked-by-layer-cascade" \
 
 cleanup_env
 
+# Conditional X-Env-Layer-Requires: "name when=<expr>" - has() gated layer pull.
+# These use the real built-in trait/ tree (IGROOT/SRCROOT set to the repo root)
+# so has('hw:pcie') exercises a real trait token, same convention as the
+# provider-trait-* block above.
+run_test "conditional-requires-fires" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/conditional-requires-consumer.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/conditional-requires-dep.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-cond-requires-consumer \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     grep -q "^test-cond-requires-dep:" "$TMP_ORDER" && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_ORDER" "$TMP_DIR"' \
+    0 \
+    "A conditional Requires: gated on has('hw:pcie') should pull in its dependency when the consumer itself unconditionally provides hw:pcie"
+
+cleanup_env
+run_test "conditional-requires-not-fires" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/conditional-requires-notfire-consumer.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/conditional-requires-dep.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-cond-requires-notfire-consumer \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     ! grep -q "^test-cond-requires-dep:" "$TMP_ORDER" && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_ORDER" "$TMP_DIR"' \
+    0 \
+    "A conditional Requires: gated on an absent trait (has('hw:bluetooth')) should not pull in its dependency"
+
+cleanup_env
+run_test "conditional-requires-first-order-only" \
+    'TMP_ENV=$(mktemp) && TMP_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && TMP_DIR=$(mktemp -d) && \
+     cp '"${LAYERS}"'/conditional-requires-firstorder-target.yaml "$TMP_DIR"/ && \
+     cp '"${LAYERS}"'/conditional-requires-firstorder-dep.yaml "$TMP_DIR"/ && \
+     printf "IGROOT=%s\nSRCROOT=%s\n" "${IGTOP}" "${IGTOP}" > "$TMP_ENV" && \
+     ig pipeline --env-in "$TMP_ENV" --layers test-cond-requires-firstorder-target \
+        --path "$TMP_DIR" --env-out "$TMP_OUT" --plan-out "$TMP_ORDER" >/dev/null && \
+     ! grep -q "^test-cond-requires-firstorder-dep:" "$TMP_ORDER" && \
+     rm -rf "$TMP_ENV" "$TMP_OUT" "$TMP_ORDER" "$TMP_DIR"' \
+    0 \
+    "A conditional Requires: gated on a token only provided by the very dependency it would pull in must not fire - single pass, no fixed point"
+
+cleanup_env
+
+# Single-file conditional-Requires: syntax errors (parse-time rejection)
+run_test "invalid-conditional-requires-bad-name-parse" \
+    "ig metadata --parse ${LAYERS}/invalid-conditional-requires-bad-name.yaml" \
+    1 \
+    "A conditional requires layer name containing whitespace should fail to parse"
+
+run_test "invalid-conditional-requires-bad-name-validate" \
+    "ig metadata --validate ${LAYERS}/invalid-conditional-requires-bad-name.yaml" \
+    1 \
+    "A conditional requires layer name containing whitespace should fail to validate"
+
+run_test "invalid-conditional-requires-bad-condition-parse" \
+    "ig metadata --parse ${LAYERS}/invalid-conditional-requires-bad-condition.yaml" \
+    1 \
+    "A malformed when= condition expression should fail to parse"
+
+run_test "invalid-conditional-requires-bad-condition-validate" \
+    "ig metadata --validate ${LAYERS}/invalid-conditional-requires-bad-condition.yaml" \
+    1 \
+    "A malformed when= condition expression should fail to validate"
+
+cleanup_env
+
 run_test "pipeline-build-order" \
     'TMP_ENV=$(mktemp) && TMP_ENV_OUT=$(mktemp) && TMP_ORDER=$(mktemp) && \
      make_pipeline_env "$TMP_ENV" && \


### PR DESCRIPTION
1. `X-Env-Layer-Requires` now accepts an optional `name when=<expr>` form so that layers can be conditionally included based on provider index contents. This allows layers to be included based on trait presence. For example:
```
X-Env-Layer-Requires: rpi-boot-firmware when=has('boot:rpi:vc-firmware')
```
So in a configuration that does not have `boot:rpi:vc-firmware` enabled (eg pi5/cm5), layer `rpi-boot-firmware` would not be pulled in.

2. Small tweak to the config parser so that list form includes can be supported. For example:
```
include:
  - device/cm5.yaml
  - device/cm5io.yaml
```
Standard YAML merge rules apply - later entries override earlier ones. The including file overrides all included content.