### PR TITLE
image-rota: slot-shared-generator must enable all units

### DIFF
--- a/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
+++ b/image/gpt/ab_userdata/device/rootfs-overlay/usr/lib/systemd/system-generators/slot-shared-generator
@@ -53,9 +53,8 @@ Options=bind
 [Install]
 WantedBy=local-fs.target
 EOF
+        # Create .wants symlinks for local-fs.target
+        mkdir -p "${OUT_DIR}/local-fs.target.wants"
+        ln -sf "${OUT_DIR}/${unit_name}" "${OUT_DIR}/local-fs.target.wants/${unit_name}"
     done
 done
-
-   # Create .wants symlinks for local-fs.target
-   mkdir -p "${OUT_DIR}/local-fs.target.wants"
-   ln -sf "${OUT_DIR}/${unit_name}" "${OUT_DIR}/local-fs.target.wants/${unit_name}"


### PR DESCRIPTION
Move .wants symlink creation into the per-path loop so it runs per generated unit, rather than only once for the last unit. This also fixes the generator exiting non-zero under set -eu if no valid Path= entries exist.
Fixes #286