### PR TITLE
image-rpios: Always set MBR disk signature

### DIFF
--- a/docs/layer/image-rpios.html
+++ b/docs/layer/image-rpios.html
@@ -123,7 +123,7 @@
     <div class="header">
         <h1>image-rpios</h1>
         <span class="badge">image</span>
-        <span class="badge">v2.2.1</span>
+        <span class="badge">v2.3.0</span>
         <p>Raspberry Pi OS style image layout with MBR, vfat
  boot partition, and a root partition that can be ext4 or btrfs.</p>
     </div>
@@ -192,6 +192,17 @@
                     <td>Path to an existing directory</td>
                     <td>
                         <a href="variable-validation.html#set-policies" class="badge policy-immediate" title="Click for policy and validation help">immediate</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><code>IGconf_image_disksig</code></td>
+                    <td>MBR disk signature supplied as a 32-bit hexadecimal number, or 'random'</td>
+                    <td>
+                           <code>random</code>
+                    </td>
+                    <td>Must match regex pattern: ^(random|0x[0-9a-fA-F]{8})$</td>
+                    <td>
+                        <a href="variable-validation.html#set-policies" class="badge policy-lazy" title="Click for policy and validation help">lazy</a>
                     </td>
                 </tr>
                 <tr>

--- a/image/mbr/simple_dual/genimage.cfg.in.btrfs
+++ b/image/mbr/simple_dual/genimage.cfg.in.btrfs
@@ -21,6 +21,7 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       align = 8M
       partition-table-type = "mbr"
       fill = true
+      disk-signature = "<DISK_SIGNATURE>"
    }
 
    partition boot {

--- a/image/mbr/simple_dual/genimage.cfg.in.ext4
+++ b/image/mbr/simple_dual/genimage.cfg.in.ext4
@@ -21,6 +21,7 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
       align = 8M
       partition-table-type = "mbr"
       fill = true
+      disk-signature = "<DISK_SIGNATURE>"
    }
 
    partition boot {

--- a/image/mbr/simple_dual/image.yaml
+++ b/image/mbr/simple_dual/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Raspberry Pi OS style image layout with MBR, vfat
 #  boot partition, and a root partition that can be ext4 or btrfs.
-# X-Env-Layer-Version: 2.2.1
+# X-Env-Layer-Version: 2.3.0
 # X-Env-Layer-Requires: image-base,rpi-storage-binder
 # X-Env-Layer-Provides: image
 #
@@ -35,6 +35,12 @@
 # X-Env-Var-assetdir-Required: n
 # X-Env-Var-assetdir-Valid: dir
 # X-Env-Var-assetdir-Set: y
+#
+# X-Env-Var-disksig: random
+# X-Env-Var-disksig-Desc: MBR disk signature supplied as a 32-bit hexadecimal number, or 'random'
+# X-Env-Var-disksig-Required: n
+# X-Env-Var-disksig-Valid: regex:^(random|0x[0-9a-fA-F]{8})$
+# X-Env-Var-disksig-Set: lazy
 #
 # X-Env-Var-pmap: clear
 # X-Env-Var-pmap-Desc: Provisioning Map identifier for this image layout.

--- a/image/mbr/simple_dual/pre-image.sh
+++ b/image/mbr/simple_dual/pre-image.sh
@@ -29,4 +29,5 @@ cat genimage.cfg.in.$IGconf_image_rootfs_type | sed \
    -e "s|<VFAT_EXTRAARGS>|$VFAT_ARGS_STR|g" \
    -e "s|<BOOT_UUID>|$BOOT_UUID|g" \
    -e "s|<ROOT_UUID>|$ROOT_UUID|g" \
+   -e "s|<DISK_SIGNATURE>|$IGconf_image_disksig|g" \
    > ${genimg_in}/genimage.cfg


### PR DESCRIPTION
Add a new config variable which can be used to set a pre-defined signature for the MBR in the disk image. If not set specifically, a random signature will be applied.