### PR TITLE
engine: add new list validator variable type

### DIFF
--- a/docs/layer/variable-validation.html
+++ b/docs/layer/variable-validation.html
@@ -180,6 +180,13 @@
             <br>    int:1024-65535      - Port numbers
             <br>    int:0-255           - Byte values
         </div>
+        <h3>list:value1,value2,value3 </h3>
+        <div class="example">
+            <strong>list:value1,value2,value3  - Comma-separated subset of the listed values (one or more, no duplicates)</strong>
+            <br>  Examples:
+            <br>    list:rsa,ecdsa,ed25519          - One or more SSH host key types
+            <br>    list:eth0,wlan0,usb0            - One or more network interfaces
+        </div>
         <h3>file                 </h3>
         <div class="example">
             <strong>file                  - Must be a path to an existing regular file (may be empty)</strong>

--- a/site/validators.py
+++ b/site/validators.py
@@ -142,6 +142,40 @@ KEYWORDS:
     keywords:dev,test,staging,prod         - Environment shortcuts"""
 
 
+class ListEnumValidator(BaseValidator):
+    def __init__(self, options: list[str]):
+        self.options = options
+
+    def validate(self, value: Optional[str]) -> list[str]:
+        if value is None:
+            return ["Value cannot be None"]
+        items = [x.strip() for x in value.split(",")]
+        if items == [""]:
+            return ["Value cannot be empty"]
+        errors = []
+        seen = set()
+        for item in items:
+            if not item:
+                errors.append("Value contains an empty entry")
+                continue
+            if item not in self.options:
+                errors.append(f"'{item}' is not one of: {', '.join(self.options)}")
+            elif item in seen:
+                errors.append(f"'{item}' is listed more than once")
+            seen.add(item)
+        return errors
+
+    def describe(self) -> str:
+        return f"Comma-separated subset of: {', '.join(self.options)}"
+
+    @classmethod
+    def get_help_text(cls) -> str:
+        return """list:value1,value2,value3  - Comma-separated subset of the listed values (one or more, no duplicates)
+  Examples:
+    list:rsa,ecdsa,ed25519          - One or more SSH host key types
+    list:eth0,wlan0,usb0            - One or more network interfaces"""
+
+
 class RegexValidator(BaseValidator):
     def __init__(self, pattern: str):
         self.pattern = pattern
@@ -339,6 +373,9 @@ def parse_validator(rule_str: str) -> BaseValidator:
     elif rule_str.startswith("keywords:"):
         options = [x.strip() for x in rule_str.split(":", 1)[1].split(",")]
         return EnumValidator(options)
+    elif rule_str.startswith("list:"):
+        options = [x.strip() for x in rule_str.split(":", 1)[1].split(",")]
+        return ListEnumValidator(options)
     elif rule_str == "file":
         return PathValidator('file')
     elif rule_str == "file-nzero":


### PR DESCRIPTION
A 'list:' type allows validation of a comma-separated subset of one or more specified values. Useful for declaring a defined set of supported values and automatically checking that one or more are supplied in the variable's declaration.
Update the auto-generated validation types doc.