### PR TITLE
device: Inject traits and add config fragments

### DIFF
--- a/config/device/cm4-lite.yaml
+++ b/config/device/cm4-lite.yaml
@@ -1,0 +1,9 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm4
+  variant: lite
+
+trait:
+  hw:storage:emmc: false
+  hw:storage:sd: true

--- a/config/device/cm4.yaml
+++ b/config/device/cm4.yaml
@@ -1,0 +1,4 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm4

--- a/config/device/cm4io.yaml
+++ b/config/device/cm4io.yaml
@@ -1,0 +1,8 @@
+# Specifically describes the official Raspberry Pi CM4 IO carrier board.
+# A custom/OEM carrier almost certainly differs - ethernet, PCIe routing
+# etc are properties of the carrier, not the module itself (see trait.adoc).
+# Use this file as a template, not a drop-in: declare your carrier's traits
+# in your own config.
+trait:
+  hw:ethernet: true
+  hw:pcie:socket: true

--- a/config/device/cm4s-lite.yaml
+++ b/config/device/cm4s-lite.yaml
@@ -1,0 +1,11 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm4
+  variant: Slite
+
+trait:
+  hw:storage:emmc: false
+  hw:storage:sd: true
+  hw:wlan: false
+  hw:bluetooth: false

--- a/config/device/cm4s.yaml
+++ b/config/device/cm4s.yaml
@@ -1,0 +1,11 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm4
+  variant: S
+
+trait:
+  hw:storage:emmc: true
+  hw:storage:sd: false
+  hw:wlan: false
+  hw:bluetooth: false

--- a/config/device/cm5-io.yaml
+++ b/config/device/cm5-io.yaml
@@ -1,0 +1,7 @@
+include:
+  - device/cm5.yaml
+  - device/cm5io.yaml
+
+# Example - configuration enables NVMe storage via the M.2 M-key expansion slot
+trait:
+  hw:storage:nvme: true

--- a/config/device/cm5-lite-io.yaml
+++ b/config/device/cm5-lite-io.yaml
@@ -1,0 +1,3 @@
+include:
+  - device/cm5-lite.yaml
+  - device/cm5io.yaml

--- a/config/device/cm5-lite.yaml
+++ b/config/device/cm5-lite.yaml
@@ -1,0 +1,9 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm5
+  variant: lite
+
+trait:
+  hw:storage:emmc: false
+  hw:storage:sd: true

--- a/config/device/cm5-nowireless.yaml
+++ b/config/device/cm5-nowireless.yaml
@@ -1,0 +1,8 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm5
+
+trait:
+  hw:wlan: false
+  hw:bluetooth: false

--- a/config/device/cm5.yaml
+++ b/config/device/cm5.yaml
@@ -1,0 +1,4 @@
+# External interfaces may depend on carrier board. Include a carrier
+# config that declares traits for those available (eg. hw:ethernet).
+device:
+  layer: rpi-cm5

--- a/config/device/cm5io.yaml
+++ b/config/device/cm5io.yaml
@@ -1,0 +1,8 @@
+# Specifically describes the official Raspberry Pi CM5 IO carrier board.
+# A custom/OEM carrier almost certainly differs - ethernet, PCIe routing
+# etc are properties of the carrier, not the module itself (see trait.adoc).
+# Use this file as a template, not a drop-in: declare your carrier's traits
+# in your own config.
+trait:
+  hw:ethernet: true
+  hw:pcie:m2: true

--- a/config/device/pi3.yaml
+++ b/config/device/pi3.yaml
@@ -1,0 +1,2 @@
+device:
+  layer: rpi3

--- a/config/device/pi4.yaml
+++ b/config/device/pi4.yaml
@@ -1,0 +1,2 @@
+device:
+  layer: rpi4

--- a/config/device/pi5.yaml
+++ b/config/device/pi5.yaml
@@ -1,0 +1,8 @@
+device:
+  layer: rpi5
+
+# Example - configuration targets a device with an M.2 HAT fitted that has
+# NVMe storage available.
+trait:
+  hw:storage:nvme: true
+  hw:pcie:m2: true

--- a/config/device/zero2w.yaml
+++ b/config/device/zero2w.yaml
@@ -1,0 +1,2 @@
+device:
+  layer: rpizero2w

--- a/device/cm4/device.yaml
+++ b/device/cm4/device.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc: Raspberry Pi CM4 specific device layer
 # X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:cm4
 #
 # X-Env-VarPrefix: device
 #
@@ -17,17 +17,27 @@
 # X-Env-Var-variant: 8G
 # X-Env-Var-variant-Desc: Device variant
 # X-Env-Var-variant-Required: n
-# X-Env-Var-variant-Valid: 8G,16G,32G,lite
+# X-Env-Var-variant-Valid: 8G,16G,32G,lite,S,Slite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
-# X-Env-Var-variant-Triggers: when=IGconf_device_variant == 'lite' set IGconf_device_storage_type=sd policy=lazy
+# X-Env-Var-variant-Conflicts:
+#  IGconf_device_variant == 'lite' and has('hw:storage:emmc')
+#  IGconf_device_variant == 'Slite' and has('hw:storage:emmc')
+#  has('hw:storage:emmc') and has('hw:storage:sd')
+# X-Env-Var-variant-Triggers:
+#  when=has('hw:storage:sd') set IGconf_device_storage_type=sd policy=lazy
+#  when=has('hw:storage:sd') set IGconf_device_variant=lite policy=lazy
+#  when=has('hw:storage:emmc') set IGconf_device_storage_type=emmc policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
 #  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
+# X-Env-Var-storage_type-Valid: emmc,sd,nvme
 # X-Env-Var-storage_type-Set: lazy
+# X-Env-Var-storage_type-Conflicts:
+#  IGconf_device_storage_type == 'sd' and not has('hw:storage:sd')
+#  IGconf_device_storage_type == 'emmc' and not has('hw:storage:emmc')
+#  IGconf_device_storage_type == 'nvme' and not has('hw:storage:nvme')
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory

--- a/device/cm5/device.yaml
+++ b/device/cm5/device.yaml
@@ -2,9 +2,9 @@
 # X-Env-Layer-Name: rpi-cm5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi CM5 specific device layer
-# X-Env-Layer-Version: 2.0.1
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: rpi-device-base,rpi-linux-2712
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:cm5
 #
 # X-Env-VarPrefix: device
 #
@@ -19,15 +19,24 @@
 # X-Env-Var-variant-Required: n
 # X-Env-Var-variant-Valid: 16G,32G,64G,lite
 # X-Env-Var-variant-Set: lazy
-# X-Env-Var-variant-Conflicts: IGconf_device_variant == 'lite' and IGconf_device_storage_type == 'emmc'
-# X-Env-Var-variant-Triggers: when=IGconf_device_variant == 'lite' set IGconf_device_storage_type=sd policy=lazy
+# X-Env-Var-variant-Conflicts:
+#  IGconf_device_variant == 'lite' and has('hw:storage:emmc')
+#  has('hw:storage:emmc') and has('hw:storage:sd')
+# X-Env-Var-variant-Triggers:
+#  when=has('hw:storage:sd') set IGconf_device_storage_type=sd policy=lazy
+#  when=has('hw:storage:sd') set IGconf_device_variant=lite policy=lazy
+#  when=has('hw:storage:emmc') set IGconf_device_storage_type=emmc policy=lazy
 #
 # X-Env-Var-storage_type: emmc
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
 #  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: emmc,sd,nvme,usb
+# X-Env-Var-storage_type-Valid: emmc,sd,nvme
 # X-Env-Var-storage_type-Set: lazy
+# X-Env-Var-storage_type-Conflicts:
+#  IGconf_device_storage_type == 'nvme' and not has('hw:storage:nvme')
+#  IGconf_device_storage_type == 'sd' and not has('hw:storage:sd')
+#  IGconf_device_storage_type == 'emmc' and not has('hw:storage:emmc')
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory

--- a/device/pi3/device.yaml
+++ b/device/pi3/device.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc: Raspberry Pi 3 specific device layer
 # X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:pi3
 #
 # X-Env-VarPrefix: device
 #

--- a/device/pi4/device.yaml
+++ b/device/pi4/device.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc: Raspberry Pi 4 specific device layer
 # X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:pi4
 #
 # X-Env-VarPrefix: device
 #

--- a/device/pi5/device.yaml
+++ b/device/pi5/device.yaml
@@ -2,9 +2,9 @@
 # X-Env-Layer-Name: rpi5
 # X-Env-Layer-Category: device
 # X-Env-Layer-Desc: Raspberry Pi 5 specific device layer
-# X-Env-Layer-Version: 2.0.1
+# X-Env-Layer-Version: 3.0.0
 # X-Env-Layer-Requires: rpi-device-base,rpi-linux-2712
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:pi5
 #
 # X-Env-VarPrefix: device
 #
@@ -18,8 +18,10 @@
 # X-Env-Var-storage_type-Desc: Storage media the image is intended for, as seen
 #  by the OS.
 # X-Env-Var-storage_type-Required: n
-# X-Env-Var-storage_type-Valid: sd,nvme,usb
+# X-Env-Var-storage_type-Valid: sd,nvme
 # X-Env-Var-storage_type-Set: y
+# X-Env-Var-storage_type-Conflicts:
+#  IGconf_device_storage_type == 'nvme' and not has('hw:storage:nvme')
 #
 # X-Env-Var-assetdir: ${DIRECTORY}
 # X-Env-Var-assetdir-Desc: Device specific asset directory

--- a/device/zero2w/device.yaml
+++ b/device/zero2w/device.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc: Raspberry Pi Zero 2 W specific device layer
 # X-Env-Layer-Version: 2.0.1
 # X-Env-Layer-Requires: rpi-generic64
-# X-Env-Layer-Provides: rpi-device
+# X-Env-Layer-Provides: rpi-device,hw:device:rpi:zero2w
 #
 # X-Env-VarPrefix: device
 #

--- a/layer/rpi/device/arm64/linux-image-2712.yaml
+++ b/layer/rpi/device/arm64/linux-image-2712.yaml
@@ -2,8 +2,9 @@
 # X-Env-Layer-Name: rpi-linux-2712
 # X-Env-Layer-Category: kernel
 # X-Env-Layer-Desc: Raspberry Pi 2712 kernel
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: linux-base
+# X-Env-Layer-RequiresProvider: hw:device:rpi,hw:soc:bcm2712
 #
 # X-Env-VarPrefix: linux
 #

--- a/layer/rpi/device/arm64/linux-image-v8.yaml
+++ b/layer/rpi/device/arm64/linux-image-v8.yaml
@@ -2,8 +2,9 @@
 # X-Env-Layer-Name: rpi-linux-v8
 # X-Env-Layer-Category: kernel
 # X-Env-Layer-Desc: Raspberry Pi v8 kernel
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: linux-base
+# X-Env-Layer-RequiresProvider: hw:device:rpi,hw:isa:armv8
 # METAEND
 ---
 env:

--- a/layer/rpi/device/provisioning/luks2.yaml
+++ b/layer/rpi/device/provisioning/luks2.yaml
@@ -8,7 +8,7 @@
 #  Downstream layer implementation-dependent.
 # X-Env-Layer-Requires:
 # X-Env-Layer-RequiresProvider: rpi-device
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 #
 # X-Env-VarPrefix: device
 #
@@ -18,8 +18,8 @@
 # X-Env-Var-luks2_cipher-Valid: string
 # X-Env-Var-luks2_cipher-Set: lazy
 # X-Env-Var-luks2_cipher-Triggers:
-#  when=IGconf_device_class in ['pi5','cm5'] set IGconf_device_luks2_cipher=aes-xts-plain64 policy=lazy
-#  when=IGconf_device_class in ['pi4','cm4','pi3','zero2w'] set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
+#  when=has('hw:crypto:aes-accel') set IGconf_device_luks2_cipher=aes-xts-plain64 policy=lazy
+#  when=not has('hw:crypto') set IGconf_device_luks2_cipher=xchacha12,aes-adiantum-plain64 policy=lazy
 #
 # X-Env-Var-luks2_hash: sha256
 # X-Env-Var-luks2_hash-Desc: The hash algorithm used for LUKS2 metadata integrity.


### PR DESCRIPTION
Initial introduction of trait tokens across various layers, primarily device related.
Config fragments added to illustrate using traits to describe platforms/features although not consumed by any top level config files yet.