### PR TITLE
chroot wrapper and pkg build fixups

### DIFF
--- a/bin/uchroot
+++ b/bin/uchroot
@@ -3,7 +3,9 @@
 # safe userspec chroot wrapper as local user IGconf_device_user1 with shell
 # command execution.
 # This user is created by rpi-user-credentials as a valid regular local user
-# with home dir. The command is 
+# with home dir. UID/GID are read from the chroot's own /etc/passwd and passed
+# to chroot --userspec as numeric +UID:+GID to avoid NSS name lookup (and any
+# cross-root library loading hazards).
 set -u
 
 if [ $# -eq 0 ]; then
@@ -30,9 +32,10 @@ if [ -r "${dir}/etc/passwd" ]; then
       # home is 6th field
       home_dir=$(echo "$spec" | cut -d: -f6)
       if [ -d "${dir}${home_dir}" ]; then
-         # GID is 4th field
+         # UID/GID are 3rd/4th field
+         user_uid=$(echo "$spec" | cut -d: -f3)
          user_gid=$(echo "$spec" | cut -d: -f4)
-         userspec="${IGconf_device_user1}:${user_gid}"
+         userspec="+${user_uid}:+${user_gid}"
 
          USER="$IGconf_device_user1" \
          LOGNAME="$IGconf_device_user1" \

--- a/bin/vfetch
+++ b/bin/vfetch
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # File fetch with verification and cache support
 # Usage:
-#   [IGconf_sys_cachedir=/path/to/cache] <script> <metadata.file> </path/to/output.file>
+#   [IGconf_sys_cachedir=/path/to/cache] <script> <metadata.file> </path/to/output.file> [offline: y|n]
 #
 # Metadata - mirrors supported, use consistent name:
 #   <name> <algo:hex> <url or local path>
@@ -25,7 +25,7 @@ die (){
 }
 
 
-meta="${1:-}"; dest="${2:-}"
+meta="${1:-}"; dest="${2:-}"; offline="${3:-n}"
 [[ -n "$meta" && -n "$dest" ]] || die "Expected args: <metadata.file> </path/to/output.file>"
 
 
@@ -110,6 +110,7 @@ done < "${meta}"
 
 [[ -n "${target_name}" ]] || die "No metadata entries in $meta"
 
+[[ "$offline" == "y" ]] && die "Offline: no verified cache for ${target_name}, no network fetch"
 
 # Pass 2: download each candidate and verify with its own expected digest
 while IFS= read -r line || [[ -n "${line}" ]]; do

--- a/package/shared/pkg.mk
+++ b/package/shared/pkg.mk
@@ -37,6 +37,9 @@ PKG_CONFIGURE_OPTS ?=
 PKG_LIB_SHARED     ?= lib$(patsubst lib%,%,$(PKG_NAME))*.so*
 PKG_MAKE_OPTS      ?=
 
+# Set to y for offline builds - no network access during package build
+IG_OFFLINE ?= n
+
 PKG_USE_HOST_PKGCONFIG ?= 0
 ifeq ($(PKG_USE_HOST_PKGCONFIG),1)
 ifneq ($(PKG_BUILD_GNU_TYPE),$(PKG_HOST_GNU_TYPE))
@@ -95,7 +98,7 @@ $(PKG_BUILD_LOG):
 
 $(PKG_ARCHIVE_PATH): $(PKG_META_PATH) | $(PKG_WORK_DIR) $(PKG_BUILD_LOG)
 	$(call msg,GET)
-	@$(call run,vfetch $(PKG_META_PATH) $@)
+	@$(call run,vfetch $(PKG_META_PATH) $@ $(IG_OFFLINE))
 
 $(PKG_SOURCE_ROOT): $(PKG_ARCHIVE_PATH) $(PKG_PATCHES)
 	$(call msg,UNPACK)
@@ -129,6 +132,7 @@ ifeq ($(PKG_BUILD_SCHEME),pysrc)
 define installwheel
 	$(call run,env $(PKG_ENVIRONMENT) \
 		python3 -m pip install \
+			$(PIP_ARGS) \
 			--find-links $(PIP_WHEELS) \
 			--root=$(1) \
 			--prefix="$(PKG_PREFIX)" \
@@ -143,13 +147,19 @@ PIP_WHEELS := $(PKG_CACHE_ROOT)/pip-wheels
 PKG_ENVIRONMENT += PIP_CACHE_DIR=$(PIP_CACHE)
 PKG_ENVIRONMENT += PIP_PREFER_BINARY=1
 
+ifeq ($(IG_OFFLINE),y)
+PIP_ARGS += --no-index --find-links $(PIP_WHEELS) --no-build-isolation
+PKG_ENVIRONMENT += PIP_NO_INDEX=1
+PKG_ENVIRONMENT += PIP_FIND_LINKS=$(PIP_WHEELS)
+endif
+
 $(PKG_CACHE_ROOT) $(PIP_CACHE) $(PIP_WHEELS):
 	@mkdir -p $@
 
 $(PKG_BUILD_STAMP): $(PKG_SOURCE_STAMP) | $(PIP_CACHE) $(PIP_WHEELS)
 	$(call msg,BUILD)
 	@$(call run,env $(PKG_ENVIRONMENT) \
-		python3 -m pip wheel --wheel-dir $(PIP_WHEELS) $(PKG_SOURCE_PATH))
+		python3 -m pip wheel $(PIP_ARGS) --wheel-dir $(PIP_WHEELS) $(PKG_SOURCE_PATH))
 	@touch $@
 
 $(PKG_INSTALL_STAMP): $(PKG_BUILD_STAMP) | $(PKG_DESTDIR) $(PKG_RUNTIME_DESTDIR)


### PR DESCRIPTION
- Prevent NSS lookups by forcing numeric UID when doing `chroot --userspec`
- Add support of (cached) offline pkg builds, tweaking `pip` args as necessary

These are required to fix two issues highlighted by a customer.