### PR TITLE
image-rota: use bootfs mountpoint for BOOTCONFIG partition

### DIFF
--- a/image/gpt/ab_userdata/genimage.cfg.in.erofs
+++ b/image/gpt/ab_userdata/genimage.cfg.in.erofs
@@ -78,10 +78,10 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
 image bootconfig.vfat {
    vfat {
       label = "BOOTCONFIG"
-      file "autoboot.txt" { image = "autoboot.txt" }
       extraargs = "-s 1 -S <SECTOR_SIZE>"
    }
    size = 32M
+   mountpoint = "/bootfs"
 }
 
 image boot.vfat {

--- a/image/gpt/ab_userdata/genimage.cfg.in.ext4
+++ b/image/gpt/ab_userdata/genimage.cfg.in.ext4
@@ -78,10 +78,10 @@ image <IMAGE_NAME>.<IMAGE_SUFFIX> {
 image bootconfig.vfat {
    vfat {
       label = "BOOTCONFIG"
-      file "autoboot.txt" { image = "autoboot.txt" }
       extraargs = "-s 1 -S <SECTOR_SIZE>"
    }
    size = 32M
+   mountpoint = "/bootfs"
 }
 
 image boot.vfat {

--- a/image/gpt/ab_userdata/image.yaml
+++ b/image/gpt/ab_userdata/image.yaml
@@ -3,7 +3,7 @@
 # X-Env-Layer-Category: image
 # X-Env-Layer-Desc: Immutable GPT A/B layout for rotational OTA updates,
 #  boot/system redundancy, and a shared persistent data partition.
-# X-Env-Layer-Version: 5.5.1
+# X-Env-Layer-Version: 5.6.0
 # X-Env-Layer-Requires: image-base,device-base,rpi-ab-slot-mapper,systemd-min
 # X-Env-Layer-Provides: image
 #
@@ -81,3 +81,5 @@ mmdebstrap:
     - e2fsprogs
     - initramfs-tools
     - rsync
+  customize-hooks:
+    - mkdir -p $1/bootfs

--- a/image/gpt/ab_userdata/pre-image.sh
+++ b/image/gpt/ab_userdata/pre-image.sh
@@ -30,7 +30,7 @@ VERITY_ARGS_SYSTEM="\
 # Set up the partition layout for tryboot support. Partition numbering
 # relates directly to the layout in genimage.cfg.in
 
-cat << EOF > "${genimg_in}/autoboot.txt"
+cat << EOF > "${fs}/bootfs/autoboot.txt"
 [all]
 tryboot_a_b=1
 boot_partition=2


### PR DESCRIPTION
Uses /bootfs mountpoint instead of hardcoded file autoboot.txt to allow other layers to seed files in the boot partition