### PR TITLE
sys-apps: dedupe systemd resolved install, declare provider tokens

### DIFF
--- a/layer/sys-apps/systemd-net-min.yaml
+++ b/layer/sys-apps/systemd-net-min.yaml
@@ -1,18 +1,14 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-net-min
 # X-Env-Layer-Desc: Systemd networking via networkd and resolved services
-# X-Env-Layer-Version: 3.0.0
-# X-Env-Layer-Provides: network-activator
-# X-Env-Layer-Requires: systemd-min
+# X-Env-Layer-Version: 4.0.0
+# X-Env-Layer-Provides: network-activator,systemd-networkd
+# X-Env-Layer-Requires: systemd-min,systemd-resolved
 # METAEND
 ---
 mmdebstrap:
-  packages:
-    - systemd-resolved
   customize-hooks:
     - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-networkd
-    - $BDEBSTRAP_HOOKS/enable-units "$1" systemd-resolved
     - mkdir -p $1/etc/systemd/network
     - ln -sf /dev/null $1/etc/systemd/network/99-default.link
     - ln -sf /dev/null $1/etc/systemd/network/73-usb-net-by-mac.link
-    - '[ -e "$1/run/systemd/resolve/stub-resolv.conf" ] || install -Dm644 /etc/resolv.conf "$1/run/systemd/resolve/stub-resolv.conf"'

--- a/layer/sys-apps/systemd-resolved.yaml
+++ b/layer/sys-apps/systemd-resolved.yaml
@@ -1,7 +1,8 @@
 # METABEGIN
 # X-Env-Layer-Name: systemd-resolved
 # X-Env-Layer-Desc: systemd's built-in DNS client
-# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Version: 1.0.1
+# X-Env-Layer-Provides: dns-daemon
 # X-Env-Layer-Requires: systemd-min
 # METAEND
 ---


### PR DESCRIPTION
systemd-net-min no longer installs systemd-resolved or duplicates its enable unit/stub resolv.conf hooks - it now just depends on the systemd-resolved layer instead. Both layers declare provider tokens so consumers can key off the implementation/capability as needed.