### PR TITLE
wireless-regulatory: default regdom to DFS-UNSET

### DIFF
--- a/layer/net-wireless/regulatory.yaml
+++ b/layer/net-wireless/regulatory.yaml
@@ -2,12 +2,12 @@
 # X-Env-Layer-Name: wireless-regulatory
 # X-Env-Layer-Category: connectivity
 # X-Env-Layer-Desc: Wireless regulatory database
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 1.2.0
 # X-Env-Layer-Provides: wireless-regdb
 #
 # X-Env-VarPrefix: ieee80211
 #
-# X-Env-Var-regdom: GB
+# X-Env-Var-regdom: 00
 # X-Env-Var-regdom-Desc: ISO 3166-1 alpha-2 wireless country code definition
 #  to set the Regulatory Domain global default. This will be written to
 #  /etc/modprobe.d/cfg80211_regdomain.conf. Additional phy settings may be


### PR DESCRIPTION
Code 00 is a safe global default. GB is not.

Refs #212