### PR TITLE
wireless-regulatory: validate regdom with regex

### DIFF
--- a/layer/net-wireless/regulatory.yaml
+++ b/layer/net-wireless/regulatory.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: wireless-regulatory
 # X-Env-Layer-Category: connectivity
 # X-Env-Layer-Desc: Wireless regulatory database
-# X-Env-Layer-Version: 1.2.0
+# X-Env-Layer-Version: 1.3.0
 # X-Env-Layer-Provides: wireless-regdb
 #
 # X-Env-VarPrefix: ieee80211
@@ -13,7 +13,7 @@
 #  /etc/modprobe.d/cfg80211_regdomain.conf. Additional phy settings may be
 #  required.
 # X-Env-Var-regdom-Required: n
-# X-Env-Var-regdom-Valid: string
+# X-Env-Var-regdom-Valid: regex:^[A-Z0-9]{2}$
 # X-Env-Var-regdom-Set: y
 #
 # METAEND


### PR DESCRIPTION
The string validator allows bogus country codes like 5B or A1 but also means that a setting of 00 via config file lands as 0 in /etc/modprobe.d/cfg80211_regdomain.conf because PyYAML's resolver treats a bare scalar that looks like a leading-zero octal literal, as an integer. We can better enforce the Regulatory Domain using a regex to stop this happening, and also hard fail on bogus values.

Refs #305
https://wireless.docs.kernel.org/en/latest/en/developers/regulatory.html