### PR TITLE
contrib: add sample cloud-init skeleton

### DIFF
--- a/contrib/src/cloud-init/NoCloud-USB/meta-data
+++ b/contrib/src/cloud-init/NoCloud-USB/meta-data
@@ -1,0 +1,2 @@
+instance_id: an-example-iid
+local-hostname: raspberrypi

--- a/contrib/src/cloud-init/NoCloud-USB/network-config
+++ b/contrib/src/cloud-init/NoCloud-USB/network-config
@@ -1,0 +1,34 @@
+# This file contains a netplan-compatible configuration which cloud-init will
+# apply on first-boot (note: it will *not* update the config after the first
+# boot). Please refer to the cloud-init documentation and the netplan reference
+# for full details:
+#
+# https://netplan.io/reference
+# https://cloudinit.readthedocs.io/en/latest/topics/network-config.html
+# https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html
+#
+# Please note that the YAML format employed by this file is sensitive to
+# differences in whitespace; if you are editing this file in an editor (like
+# Notepad) which uses literal tabs, take care to only use spaces for
+# indentation. See the following link for more details:
+#
+# https://en.wikipedia.org/wiki/YAML
+#
+# Additionally, please be aware that if your boot sequence depends on active
+# networking (e.g. if your cloud-init configuration pulls packages or SSH
+# keys from the network), you *must* mark at least one interface as required
+# ("optional: false") below. Otherwise, particularly on faster boards,
+# cloud-init will start attempting to use the network before it is ready
+
+# Some additional examples are commented out below
+
+network:
+  version: 2
+  renderer: NetworkManager
+
+  ethernets:
+    eth0:
+      match:
+        name: eth0
+      dhcp4: false
+      optional: true

--- a/contrib/src/cloud-init/NoCloud-USB/user-data
+++ b/contrib/src/cloud-init/NoCloud-USB/user-data
@@ -1,0 +1,114 @@
+#cloud-config
+
+# This is the user-data configuration file for cloud-init. By default this sets
+# up an initial user called "ubuntu" with password "ubuntu", which must be
+# changed at first login. However, many additional actions can be initiated on
+# first boot from this file. The cloud-init documentation has more details:
+#
+# https://cloudinit.readthedocs.io/
+#
+# Please note that the YAML format employed by this file is sensitive to
+# differences in whitespace; if you are editing this file in an editor (like
+# Notepad) which uses literal tabs, take care to only use spaces for
+# indentation. See the following link for more details:
+#
+# https://en.wikipedia.org/wiki/YAML
+#
+# Some additional examples are provided in comments below the default
+# configuration.
+
+## Set the system's hostname. Please note that, unless you have a local DNS
+## setup where the hostname is derived from DHCP requests (as with dnsmasq),
+## setting the hostname here will not make the machine reachable by this name.
+## You may also wish to install avahi-daemon (see the "packages:" key below)
+## to make your machine reachable by the .local domain
+hostname: raspberrypi
+# manage_etc_hosts: true
+
+## Set up the keyboard layout. See localectl(1), in particular the various
+## list-x11-* sub-commands, to determine the available models, layouts,
+## variants, and options
+#keyboard:
+#  model: pc105
+#  layout: gb
+#  variant:
+#  options: ctrl:nocaps
+
+# Controls password authentication with the SSH daemon; the default here can
+# prevent logging into SSH with a password. Changing this is a security risk
+# and you should at the very least ensure a different default password is
+# specified above
+#ssh_pwauth: false
+
+## On first boot, use ssh-import-id to give the specific users SSH access to
+## the default user
+#ssh_import_id:
+#- lp:my_launchpad_username
+#- gh:my_github_username
+
+## Add users and groups to the system, and import keys with the ssh-import-id
+## utility
+#groups:
+#- robot: [robot]
+#- robotics: [robot]
+#- pi
+#
+#users:
+#- default
+#- name: robot
+#  gecos: Mr. Robot
+#  primary_group: robot
+#  groups: users
+#  ssh_import_id: foobar
+#  lock_passwd: false
+#  passwd: $5$hkui88$nvZgIle31cNpryjRfO9uArF7DYiBcWEnjqq7L1AQNN3
+
+users:
+  - name: pi
+    lock_passwd: false
+    plain_text_passwd: raspberrypi # plain_text_passwd not recommended for production
+
+## Update apt database and upgrade packages on first boot
+#package_update: true
+#package_upgrade: true
+
+## Install additional packages on first boot
+#packages:
+#- avahi-daemon
+#- rng-tools
+#- python3-gpiozero
+#- [python3-serial, 3.5-1]
+
+## Write arbitrary files to the file-system (including binaries!)
+#write_files:
+#- path: /etc/default/console-setup
+#  content: |
+#    # Consult the console-setup(5) manual page.
+#    ACTIVE_CONSOLES="/dev/tty[1-6]"
+#    CHARMAP="UTF-8"
+#    VIDEOMODE=
+#    FONT="Lat15-Terminus18x10.psf.gz"
+#    FONTFACE=
+#    FONTSIZE=
+#    CODESET="Lat15"
+#  permissions: '0644'
+#  owner: root:root
+#- encoding: gzip
+#  path: /root/Makefile
+#  content: !!binary |
+#    H4sICF2DTWIAA01ha2VmaWxlAFNWCM8syVBILMjPyU/PTC1WKMlXiPB2dlFQNjSx5MpNteLi
+#    dLDiSoRQxYl5KeWZyRkgXrSCkoqKRmaKgm6pppKCbmqhgoFCrIKamkK1QmpyRr6Ckn92YqWS
+#    NdC80uQMBZhOa4VahZoaqIrwjMQSewXfxOxUhcwShcr80qLi1Jw0RSUuAIYfEJmVAAAA
+#  owner: root:root
+#  permissions: '0644'
+
+# mounts:
+# - [ /dev/nvme0n1p1, /srv, auto, "defaults,noexec", "0", "2"]
+
+## Run arbitrary commands at rc.local like time and disable cloud-init for
+# subsequent boots
+
+runcmd:
+#- [ ls, -l, / ]
+#- [ sh, -xc, "echo $(date) ': hello world!'" ]
+- [ touch, /etc/cloud/cloud-init.disabled]

--- a/contrib/src/cloud-init/README.md
+++ b/contrib/src/cloud-init/README.md
@@ -1,0 +1,14 @@
+# cloud-init for rpi-image-gen
+
+Sample skeleton for using cloud-init with rpi-image-gen.
+Partially borrowed from the `pi-gen` cloud-init configuration.
+
+## Usage
+
+1. Fill in the applicable details in the `config/pi-cloud-init.yaml`.
+2. Build and provision the image as usual.
+3. On a FAT32 formatted USB drive with exactly the label `CIDATA`, add
+   `meta-data`, `network-config`, and `user-data`. The details of
+   what should be in those files can be found at
+   <https://cloudinit.readthedocs.io/>, with sample files in this repo
+   under the directory `NoCloud-USB`.

--- a/contrib/src/cloud-init/config/pi-cloud-init.yaml
+++ b/contrib/src/cloud-init/config/pi-cloud-init.yaml
@@ -1,0 +1,11 @@
+device:
+  layer: rpi5
+  storage_type: sd
+
+image:
+  layer: image-rpios
+  boot_part_size: 1G
+  root_part_size: 1G
+
+layer:
+  everything: cloud-init

--- a/contrib/src/cloud-init/files/net-tweaks/00-network-manager-all.yaml
+++ b/contrib/src/cloud-init/files/net-tweaks/00-network-manager-all.yaml
@@ -1,0 +1,3 @@
+network:
+  version: 2
+  renderer: NetworkManager

--- a/contrib/src/cloud-init/files/sys-tweaks/99_raspberry-pi.cfg
+++ b/contrib/src/cloud-init/files/sys-tweaks/99_raspberry-pi.cfg
@@ -1,0 +1,24 @@
+# configure cloud-init with NoCloud
+
+datasource_list: [ NoCloud, None ]
+# datasource:
+#   NoCloud:
+#     seedfrom: file:///boot/firmware
+
+# Leave SSH key emission to console disabled so that
+# users can decide whether to enable it manually.
+ssh:
+  emit_keys_to_console: false
+no_ssh_fingerprints: true
+
+# Disable SSH host key generation
+# regenerate_ssh_host_keys.service will take care 
+# of it on first boot
+ssh_deletekeys: false
+# Disable generation as it could be that the new keys
+# aren't available yet when the service runs.
+# also they are really only needed for the ssh service
+# which will only run after the keys are already present
+# so we don't schedule cloud-init after key generation
+# as that would delay first boot too much
+ssh_genkeytypes: []

--- a/contrib/src/cloud-init/layer/cloud-init.yaml
+++ b/contrib/src/cloud-init/layer/cloud-init.yaml
@@ -1,0 +1,25 @@
+# METABEGIN
+# X-Env-Layer-Name: cloud-init
+# X-Env-Layer-Category: provisioning
+# X-Env-Layer-Desc: Cloud init for rpi-image-gen
+# X-Env-Layer-Version: 1.0.0
+# X-Env-Layer-Provides: pi-cloud-init
+# METAEND
+---
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  variant: custom
+  packages:
+    - cloud-init
+    - hostname
+    - userconf-pi
+  setup-hooks:
+    - install -v -D -m 0644 -t $1/etc/cloud/cloud.cfg.d/ files/sys-tweaks/99_raspberry-pi.cfg
+    - install -v -D -m 0600 -t $1/etc/netplan/ files/net-tweaks/00-network-manager-all.yaml
+  customize-hooks:
+    - 'sed -i "s/name: pi/name: $IGconf_user1/" $1/etc/cloud/cloud.cfg'
+  aptopts:
+    - APT::Install-Suggests "false"
+    - APT::Install-Recommends "false"


### PR DESCRIPTION
This is a skeleton based on a working config, but has not been used as-is. It is being submitted solely for informational purposes.