### PR TITLE
runner: Preserve safe modes when applying filesystem overlays

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -96,7 +96,12 @@ apply_overlays() {
    for spec in ${FS_OVERLAYS[$phase]}; do
       if src=$(map_path "$spec") && [[ -d $src ]]; then
          msg "runner: overlay [$src -> $dest]"
-         rsync -a --exclude='.keep' --exclude='.empty' -- "$src"/ "$dest"/
+         # --chmod=go-w: an overlay is a directory in the build environment, and
+         # rsync -a would copy its modes verbatim - including onto "$dest"
+         # itself. A source tree with group/world-writable directories (some CI
+         # runners check out that way) therefore produces a rootfs with a
+         # world-writable /, /usr, /usr/sbin and /etc.
+         rsync -a --chmod=go-w --exclude='.keep' --exclude='.empty' -- "$src"/ "$dest"/
          local rc=$?
          [[ $rc -eq 0 ]] || die "runner: error applying overlay ($rc)"
       fi

--- a/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
+++ b/image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops
@@ -10,7 +10,10 @@ chroot $1 apt install -y mmc-utils
 do_install() {
    [ -d "$1" ] || return 0
    [ -d "$2" ] || return 0
-   rsync -av "$1/" "$2/"
+   # --chmod=go-w for the same reason as bin/runner's apply_overlays: these
+   # sources live in the build environment, and rsync -a would stamp their modes
+   # onto the target, destination directory included.
+   rsync -av --chmod=go-w "$1/" "$2/"
   }
 
 do_install ../device/emmc/initramfs-tools "$1/etc/initramfs-tools"


### PR DESCRIPTION
## Problem

`apply_overlays()` in `bin/runner` copies overlay trees with `rsync -a`, which reproduces the source's permissions — including on the destination directory itself. Overlay sources live in the build environment, so if that checkout has group- or world-writable directories, those modes land in the image:

```
/           0777
/etc        0777
/usr        0777
/usr/sbin   0777
/usr/lib    0777
/bootfs     0777
…
```

Some CI runners check out exactly that way (GitLab Runner's helper container does; the job's own umask is 0022, which is why it does not reproduce locally where the source is a 0755 bind mount).

`image/gpt/ab_userdata/bdebstrap/customize03-emmc-ops` copies the eMMC initramfs/dracut assets the same way and has the same issue.

## Why it is easy to miss

The image builds cleanly and the modes are only visible if you go looking. It surfaced for us as a *package failing to configure* instead:

```
Setting up avahi-daemon (0.8-16) ...
Insecure directory in $ENV{PATH} while running with -T switch
  at /usr/share/perl5/Debian/AdduserLogging.pm line 161
dpkg: error processing package avahi-daemon (--configure):
 installed avahi-daemon package post-installation script subprocess returned error exit status 25
```

`adduser(8)` sets `PATH=/bin:/usr/bin:/sbin:/usr/sbin` and then execs `logger` under `perl -T`; taint mode refuses to exec when any directory in `PATH` is world-writable. So every maintainer script that creates a user fails, and takes its dependents with it. Reproducible on a stock `debian:trixie` container with nothing but `chmod 777 /usr/bin` before installing such a package.

Without a user-creating package in the image there is no error at all — the permissive rootfs just ships.

## Fix

Pass `--chmod=go-w` so the transfer cannot widen permissions. This matches what `layer/rpi/device/ab-slots.yaml` and `layer/rpi/device/storage-binder.yaml` already do for their own rsync calls (`--chmod=F755,D755`); `go-w` is used here instead because a generic overlay should keep whatever modes it declares, minus the ability to be group/world-writable.

Verified: with the patch applied, a full A/B erofs image builds with `/`, `/usr`, `/usr/sbin` and `/etc` at 0755, the previously failing packages configure normally, and the resulting image is otherwise byte-identical.