### PR TITLE
pkg: update util-linux url

### DIFF
--- a/package/util-linux/util-linux-2.41.3.meta
+++ b/package/util-linux/util-linux-2.41.3.meta
@@ -1,1 +1,1 @@
-util-linux-2.41.3.tar.xz sha256:3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz
+util-linux-2.41.3.tar.xz sha256:3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b https://cdn.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz


### PR DESCRIPTION
Move to kernel.org's CDN to hopefully avoid various GitHub CI errors where curl fails to establish a connection to mirrors.edge.kernel.org.