### PR TITLE
per-layer work dir, doc improvements

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -126,7 +126,7 @@ run_dir_hooks() {
 
 # Per-layer phased execution
 run_layer_step() {
-   local layer=$1 version=$2 stempath=$3 phase=$4; shift 4
+   local layer=$1 version=$2 stempath=$3 resolved=$4 workdir=$5 phase=$6; shift 6
    local dest=${1:-}
    local ldir vmajor vminor vpatch
 
@@ -141,6 +141,7 @@ run_layer_step() {
    IFS='.' read -r vmajor vminor vpatch <<< "$version"
 
    LAYER_NAME=$layer LAYER_VERSION=$version LAYER_DIR=$ldir \
+   LAYER_WORKDIR=$workdir LAYER_FILE=$resolved \
    LAYER_VERSION_MAJOR=$vmajor LAYER_VERSION_MINOR=$vminor \
    LAYER_VERSION_PATCH=$vpatch \
    run_dir_hooks "${stempath}.d/hooks" "$phase" "${stempath}.d/env" "$@"

--- a/builtin/hooks/customize60-dracut
+++ b/builtin/hooks/customize60-dracut
@@ -14,7 +14,7 @@ echo "RPI_BOOT_MEDIA=\"${IGconf_device_storage_type}\"" \
    > "$1/etc/dracut.conf.d/60-rpi-common.conf"
 
 sweep_dracut_conf() {
-   local layer=$1 version=$2 stempath=$3 dest=$4
+   local layer=$1 version=$2 stempath=$3 _=$4 _=$5 dest=$6
    local dir="${stempath}.d/device/dracut.conf.d"
    [[ -d $dir ]] || return 0
    msg "dracut(conf): installing for $layer $version"
@@ -23,7 +23,7 @@ sweep_dracut_conf() {
 foreach_layer_in_plan sweep_dracut_conf "$1/etc/dracut.conf.d/"
 
 sweep_dracut_modules() {
-   local layer=$1 version=$2 stempath=$3 dest=$4
+   local layer=$1 version=$2 stempath=$3 _=$4 _=$5 dest=$6
    local dir="${stempath}.d/device/dracut.modules.d"
    [[ -d $dir ]] || return 0
    msg "dracut(mod): installing for $layer $version"

--- a/builtin/hooks/customize60-initramfs-tools
+++ b/builtin/hooks/customize60-initramfs-tools
@@ -14,7 +14,7 @@ echo "RPI_BOOT_MEDIA=\"${IGconf_device_storage_type}\"" \
    > "$1/etc/initramfs-tools/conf.d/rpi-common"
 
 sweep_initramfs_tools() {
-   local layer=$1 version=$2 stempath=$3 dest=$4
+   local layer=$1 version=$2 stempath=$3 _=$4 _=$5 dest=$6
    local dir="${stempath}.d/device/initramfs-tools"
    [[ -d $dir ]] || return 0
    msg "initramfs-tools: installing for $layer $version"

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -34,6 +34,8 @@ def md2html(content: str, format: str = 'asciidoc') -> str:
                 '-a', 'table-frame=all',    # Table frame
                 '-a', 'table-grid=all',     # Table grid
                 '-a', 'table-stripes=even', # Table striping
+                '-a', 'sectanchors',        # Hoverable heading anchors
+                '-a', 'sectlinks',          # Headings link to themselves
                 '-'
             ], input=content, capture_output=True, text=True, check=True)
             html_output = result.stdout
@@ -81,7 +83,7 @@ def main():
     templates_dir = script_dir.parent / 'templates' / 'docs' / 'html'
 
     # jinja init
-    env = Environment(loader=FileSystemLoader(str(templates_dir)))
+    env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
 
     # Load layers
     layer_paths = [
@@ -257,13 +259,34 @@ def main():
         layer_index_template = env.get_template('layer-index.html')
         layer_index_html = layer_index_template.render(
             content=layer_index_content,
-            layers=layers_info
+            layers=[]  # Layer list lives on the layer reference page
         )
 
         # Write layer index page
         layer_index_file = layer_dir / 'index.html'
         layer_index_file.write_text(layer_index_html)
         print(f"Generated: {layer_index_file}")
+
+
+        # Generate layer reference page - the index of all available layers
+        layer_ref_md = script_dir / 'layer_reference.adoc'
+        if layer_ref_md.exists():
+            md_content = layer_ref_md.read_text()
+            layer_ref_content = md2html(md_content)
+        else:
+            raise Exception("No content for layer reference!")
+
+        # Render layer reference page
+        layer_ref_template = env.get_template('index.html')
+        layer_ref_html = layer_ref_template.render(
+            content=layer_ref_content,
+            layers=layers_info
+        )
+
+        # Write layer reference page
+        layer_ref_file = doc_dir / 'layer_reference.html'
+        layer_ref_file.write_text(layer_ref_html)
+        print(f"Generated: {layer_ref_file}")
 
         # Generate validation help page
         help_template = env.get_template('variable-validation.html')

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -19,6 +19,7 @@ Documentation can be served locally using `rpi-image-gen docs`, which starts a w
 - link:./execution/index.adoc[execution/] Execution flow overview
 - link:./config/index.adoc[config/] Configuration system
 - link:./layer/index.adoc[layer/] Layer information and metadata
+- link:./layer_reference.html[layer reference] Index of all available layers
 - link:./trait.adoc[trait] Trait token registry - hardware, system and boot mechanism facts
 - link:./provisioning/index.adoc[provisioning/] Device provisioning information
 

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -6,6 +6,9 @@
 
 link:../index.adoc[← Back to Main Documentation]
 
+TIP: For an index of every layer shipped with rpi-image-gen, see the
+link:../layer_reference.html[Layer Reference].
+
 == What are Layers?
 
 Layers are modular, composable components that define specific aspects of your Raspberry Pi build. Each layer encapsulates a specific and focussed piece of functionality and can declare dependencies on other layers, creating a flexible build system. Layers have been loosely grouped into categories with a super-set being as follows.

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -261,6 +261,8 @@ Variable values support dynamic placeholders:
 
 `${UUID}`: A UUID derived from the layer's name and version. Deterministic - the same layer always gets the same UUID, stable across builds rather than freshly random each run.
 
+`${WORKDIR}`: The layer's own persistent, uniquely namespaced work directory for per-layer build operations.
+
 [[conditional-expressions]]
 === Conditional Expressions
 
@@ -443,7 +445,7 @@ Examples:
 The environment variables declared by a layer customise build behaviour:
 
 - **Validation**: Each variable includes validation rules (types, ranges, patterns)
-- **Placeholders**: Support for dynamic values like `${DIRECTORY}`, `${FILENAME}`, `${STEM}`, `${NAME}`, `${VERSION}` and `${UUID}`
+- **Placeholders**: Support for dynamic values like `${DIRECTORY}`, `${FILENAME}`, `${STEM}`, `${NAME}`, `${VERSION}`, `${UUID}` and `${WORKDIR}`
 - **Set Policies**: Control when and how variables are applied during layer resolution
 - **Documentation**: Integrated help and validation error messages
 

--- a/docs/layer/index.adoc
+++ b/docs/layer/index.adoc
@@ -40,6 +40,17 @@ Each layer is a YAML file containing:
 - **Dependencies**: Automatic resolution of layer prerequisites
 - **Customisation**: Override defaults through environment variables set via the config file
 
+== Hooks and Overlays
+
+Beyond its YAML, a layer may ship standalone hook scripts and filesystem overlays alongside it, under a `<layer-stem>.d/` directory next to `<layer-stem>.yaml`:
+
+- **`<layer-stem>.d/hooks/`**: Scripts named `<phase>*` (eg `customize05-enable-units`), run by `bin/runner` at the matching build phase, in lexicographic order.
+- **`<layer-stem>.d/<phase>.overlay/`**: A tree synchronised into the filesystem build in progress at the matching phase, eg `customize.overlay/`.
+
+See link:../execution/index.adoc#hooks[Hooks] and link:../execution/index.adoc#overlays[Overlays] in the execution documentation for the full mechanism, phase list, and environment variables a hook can rely on.
+
+A layer's generated documentation page lists any hooks and overlays it actually ships, per phase.
+
 == X-Env Metadata
 Layers use a custom X-Env metadata schema that strictly follows the DEB822 format (https://repolib.readthedocs.io/en/latest/deb822-format.html) embedded within YAML comment blocks. The metadata is delimited by `# METABEGIN` and `# METAEND` markers and parsed using the standard `python3-debian` DEB822 parser. By using metadata fields a layer can define attributes, dependencies, and configuration variables. The metadata is parsed separately from the standard YAML content.
 

--- a/docs/layer_reference.adoc
+++ b/docs/layer_reference.adoc
@@ -1,0 +1,15 @@
+= rpi-image-gen - Layer Reference
+:toc: left
+:toclevels: 2
+:sectlinks:
+:sectanchors:
+
+link:./index.adoc[← Back to Main Documentation]
+
+An index of every layer shipped with rpi-image-gen, grouped by category. Select a layer to see its
+attributes, variables, dependencies, hooks and overlays.
+
+For an explanation of what layers are, how they are composed and the metadata they declare, see
+link:./layer/index.adoc[Layer Documentation].
+
+== Layer Library

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -244,6 +244,10 @@ map_path() {
          [[ -n ${IGconf_image_assetdir:-} ]] || return 1
          base=${IGconf_image_assetdir}
          ;;
+      WORKROOT)
+         [[ -n ${IGconf_sys_workroot:-} ]] || return 1
+         base=${IGconf_sys_workroot}
+         ;;
       DYN*)
          [[ -n ${DYNROOT:-} ]] || return 1
          base="${DYNROOT}/${tag#DYN}"
@@ -275,11 +279,10 @@ export -f map_path
 # handoff.
 # $1 = layer name
 # $2 = layer version
-# $3 = layer's static YAML path
+# $3 = layer's stempath (resolved - see foreach_layer_in_plan)
 # $4 = path to write the synthesised file to
 synth_layer_pre() {
-   local name=$1 version=$2 layer=$3 out=$4
-   local stempath=${layer%.yaml}
+   local name=$1 version=$2 stempath=$3 out=$4
    local hooks=() overlay
 
    # Overlays this layer applies during customize, in this order.
@@ -310,7 +313,7 @@ export -f synth_layer_pre
 # handoff.
 # $1 = layer name
 # $2 = layer version
-# $3 = layer's static YAML path
+# $3 = layer's stempath (resolved - see foreach_layer_in_plan)
 # $4 = path to write the synthesised file to
 synth_layer_post() {
    :
@@ -328,10 +331,10 @@ import sys, pathlib, yaml
 for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
     if not raw or raw.startswith("#"):
         continue
-    parts = raw.split(":", 3)
-    if len(parts) != 4 or not parts[0] or not parts[3]:
+    parts = raw.split(":", 4)
+    if len(parts) != 5 or not parts[0] or not parts[3]:
         continue
-    layer, version, static, resolved = parts
+    layer, version, static, resolved, workdir = parts
     try:
         data = yaml.safe_load(open(resolved, "rb"))
     except Exception as e:
@@ -345,21 +348,23 @@ export -f mmdebstrap_layer_paths
 
 
 # foreach_layer_in_plan: calls callback once per layer in plan order:
-# Expects: callback layer version stempath [extra args]
-# stempath is the layer's static filename path with .yaml stripped so
-# directly usable to derive its companion dir path <stempath>.d.
+# Expects: callback layer version stempath resolved workdir [extra args]
+# stempath and workdir are already resolved (map_path) to real paths -
+# callbacks never need to know either can be a tagged spec. resolved is
+# passed as-is, matching mmdebstrap_layer_paths's own output, for callers
+# doing mmset-style lookups against it.
 # Uses the caller's own $PLAN when in scope (bin/runner's own calls), else
 # derives it.
 foreach_layer_in_plan() {
    local callback=${1:?"foreach_layer_in_plan: callback required"}; shift
    local plan=${PLAN:-${IGconf_sys_bootstrapdir:?"foreach_layer_in_plan: IGconf_sys_bootstrapdir not set"}/layer.plan}
-   local layer version static resolved stempath
+   local layer version static resolved workdir stempath
 
    [[ -f $plan ]] || return 0
-   while IFS=: read -r layer version static resolved; do
+   while IFS=: read -r layer version static resolved workdir; do
       [[ -n $layer && $layer != \#* ]] || continue
-      stempath="${static%.yaml}"
-      "$callback" "$layer" "$version" "$stempath" "$@"
+      stempath="$(map_path "${static%.yaml}")"
+      "$callback" "$layer" "$version" "$stempath" "$resolved" "$(map_path "$workdir")" "$@"
    done < "$plan"
 }
 export -f foreach_layer_in_plan

--- a/rpi-image-gen
+++ b/rpi-image-gen
@@ -367,14 +367,16 @@ prepare_build_config()
 
    msg "\nMMDEBSTRAP"
    local total=0 added=0
+   local PLAN="${ctx[LAYER_PLAN]}"
 
    # Sanity check resolved layers from the plan
-   while IFS=: read -r layer version static resolved; do
-      [[ -n $layer && -n $resolved ]] || continue
-      [[ $layer == \#* ]] && continue
+   _sanity_check_layer() {
+      local layer=$1 resolved=$4
+      [[ -n $resolved ]] || return 0
       ((total++))
       [[ -f $resolved ]] || die "Layer $layer ($resolved) not found"
-   done < "${ctx[LAYER_PLAN]}"
+   }
+   foreach_layer_in_plan _sanity_check_layer
 
    # Layers declaring an mmdebstrap mapping contribute their own config
    local mmpaths
@@ -390,32 +392,34 @@ prepare_build_config()
    # Construct the bdebstrap ordered chain, including synthesised layers.
    # Every layer is offered pre/post synth, whether or not it has an mmdebstrap
    # mapping of its own, so that a config-only layer can still ship an overlay.
-   local idx=0
-   while IFS=: read -r layer version static resolved; do
-      [[ -n $layer && $layer != \#* ]] || continue
-      ((idx++))
+   # Use the per-layer workdir for pre/post synth, created but never wiped, so
+   # build artefacts survive across builds.
+   _build_layer_config() {
+      local layer=$1 version=$2 stempath=$3 resolved=$4 workdir=$5
+      local cfg=()
 
-      local stem cfg=()
-      stem="$(basename "${static%.yaml}")-${idx}"
-      local prefile="${TMPDIR}/${stem}.pre.yaml" postfile="${TMPDIR}/${stem}.post.yaml"
+      mkdir -p "$workdir"
 
-      synth_layer_pre "$layer" "$version" "$static" "$prefile" \
-         || die "Layer $layer ($static): pre-synth failed"
+      local prefile="${workdir}/pre.yaml" postfile="${workdir}/post.yaml"
+
+      synth_layer_pre "$layer" "$version" "$stempath" "$prefile" \
+         || die "Layer $layer ($stempath): pre-synth failed"
       [[ -f $prefile ]] && cfg+=( --config "$prefile" )
 
       [[ -n ${mmset[$resolved]:-} ]] && cfg+=( --config "$resolved" )
 
-      synth_layer_post "$layer" "$version" "$static" "$postfile" \
-         || die "Layer $layer ($static): post-synth failed"
+      synth_layer_post "$layer" "$version" "$stempath" "$postfile" \
+         || die "Layer $layer ($stempath): post-synth failed"
       [[ -f $postfile ]] && cfg+=( --config "$postfile" )
 
-      [[ ${#cfg[@]} -gt 0 ]] || continue
+      [[ ${#cfg[@]} -gt 0 ]] || return 0
       ((added++))
 
       _bdebstrap+=( "${cfg[@]}" )
 
       msg "Loaded $layer${version:+ ${version}}"
-   done < "${ctx[LAYER_PLAN]}"
+   }
+   foreach_layer_in_plan _build_layer_config
 
    local skipped=$((total - added))
    msg "Loaded ${added}/${total}, skipped $skipped"
@@ -520,21 +524,40 @@ deploy() {
 
 ###############################################################################
 # Clean
+#   Output directories
+#   Host build artefacts
 ###############################################################################
 clean_worktree() {
    msg "\nCLEAN"
    : "${ctx[FINALENV]?FINALENV is not set}"
 
+   local -a keys=(
+      IGconf_target_path
+      IGconf_image_outputdir
+      IGconf_image_deploydir
+      IGconf_sys_buildroot
+      IGconf_sys_workroot
+   )
    local key val
-   for key in IGconf_target_path IGconf_image_outputdir IGconf_image_deploydir; do
+   for key in "${keys[@]}"; do
       val=$(get_var "$key" "${ctx[FINALENV]}") || continue
-      [[ -e $val ]] || continue
-      ask "Remove $key [$val]?" y || continue
-      if [[ $key == IGconf_target_path ]]; then
-         run ns rm -rf -- "$val"
-      else
-         rm -rf -- "$val"
-      fi
+      case $key in
+         IGconf_target_path)
+            [[ -e $val ]] || continue
+            ask "Remove $key [$val]?" y && run ns rm -rf -- "$val"
+            ;;
+         IGconf_sys_workroot)
+            local gnutype
+            gnutype=$(get_var DEB_BUILD_GNU_TYPE "${ctx[FINALENV]}") || continue
+            val="${val}/${gnutype}"
+            [[ -e $val ]] || continue
+            ask "Remove host support packages [$val]?" y && rm -rf -- "$val"
+            ;;
+         *)
+            [[ -e $val ]] || continue
+            ask "Remove $key [$val]?" y && rm -rf -- "$val"
+            ;;
+      esac
    done
 }
 

--- a/site/env_types.py
+++ b/site/env_types.py
@@ -14,6 +14,21 @@ def _layer_uuid(name: str, version: str) -> str:
     return str(uuid.uuid5(_LAYER_UUID_NAMESPACE, f"{name}:{version}")) if name else ""
 
 
+def _layer_workdir_suffix(name: str, version: str) -> str:
+    """Per-layer path suffix beneath @WORKROOT (no anchor prefix) - what the
+    plan needs, since @WORKROOT may require real shell evaluation this
+    engine can't do. name-version is unambiguous: version is validated
+    elsewhere to strict major.minor.patch, so it never contains '-'."""
+    return f"build/layer/{name}-{version}" if name else ""
+
+
+def _layer_workdir(name: str, version: str) -> str:
+    """Per-(name, version) work directory template, anchored to @WORKROOT;
+    shared by ${WORKDIR} and EnvLayer.workdir."""
+    suffix = _layer_workdir_suffix(name, version)
+    return f"${{@WORKROOT}}/{suffix}" if suffix else ""
+
+
 # X-Env field helpers
 class XEnv:
     """Helper for constructing X-Env field names consistently."""
@@ -784,6 +799,8 @@ class EnvLayer:
         self.description = description
         self.version = version
         self.uuid = _layer_uuid(name, version)
+        self.workdir = _layer_workdir(name, version)
+        self.workdir_suffix = _layer_workdir_suffix(name, version)
         self.category = category
         self.deps = deps or []
         self.conditional_deps: List[Tuple[str, str]] = conditional_deps or []  # [(layer_name, condition)]
@@ -1024,6 +1041,8 @@ class EnvLayer:
             "description": self.description,
             "version": self.version,
             "uuid": self.uuid,
+            "workdir": self.workdir,
+            "workdir_suffix": self.workdir_suffix,
             "category": self.category,
             "type": self.layer_type,
             "generator": self.generator,
@@ -1153,6 +1172,7 @@ class MetadataContainer:
             "NAME": layer_name,
             "VERSION": layer_version,
             "UUID": _layer_uuid(layer_name, layer_version),
+            "WORKDIR": _layer_workdir(layer_name, layer_version),
         }
 
     def _substitute_placeholders(self, text: str, placeholders: Dict[str, str]) -> str:

--- a/site/layer_manager.py
+++ b/site/layer_manager.py
@@ -883,18 +883,36 @@ class LayerManager:
 
         return None
 
-    # Overlay directories a layer may ship under its <stem>.d/, in the order
-    # they are applied. rootfs-overlay is a compat spelling of
-    # customize.overlay and so is applied ahead of it.
-    OVERLAY_DIRS = ('rootfs-overlay', 'customize.overlay',
-                    'postbuild.overlay', 'preimage.overlay')
+    # Phases bin/runner invokes, in the order they run.
+    PHASES = ('prebuild', 'setup', 'extract', 'essential', 'customize',
+              'cleanup', 'postbuild', 'sbom', 'preimage', 'postimage',
+              'finalize', 'deploy')
 
-    def _get_overlays(self, layer_name: str, key=None) -> list:
+    # Compat spellings of customize.overlay, checked only for that phase.
+    CUSTOMIZE_OVERLAY_COMPAT = ('rootfs-overlay', 'overlay')
+
+    def _layer_assetdir(self, layer_name: str, key=None):
         layer_path = self.layer_files.get(key if key is not None else self._resolve_key(layer_name))
         if not layer_path:
+            return None
+        return Path(layer_path).parent / f'{Path(layer_path).stem}.d'
+
+    def _get_phase_content(self, layer_name: str, key=None) -> list:
+        """Per-phase overlay/hooks a layer ships under its <stem>.d/."""
+        assetdir = self._layer_assetdir(layer_name, key)
+        if not assetdir:
             return []
-        assetdir = Path(layer_path).parent / f'{Path(layer_path).stem}.d'
-        return [name for name in self.OVERLAY_DIRS if (assetdir / name).is_dir()]
+        hooksdir = assetdir / 'hooks'
+        content = []
+        for phase in self.PHASES:
+            overlay = f'{phase}.overlay' if (assetdir / f'{phase}.overlay').is_dir() else None
+            if not overlay and phase == 'customize':
+                overlay = next((n for n in self.CUSTOMIZE_OVERLAY_COMPAT
+                                 if (assetdir / n).is_dir()), None)
+            hooks = sorted(p.name for p in hooksdir.glob(f'{phase}*')) if hooksdir.is_dir() else []
+            if overlay or hooks:
+                content.append({'phase': phase, 'overlay': overlay, 'hooks': hooks})
+        return content
 
     def get_layer_documentation_data(self, layer_name: str):
         """Extract structured layer data for documentation generation"""
@@ -995,7 +1013,7 @@ class LayerManager:
             'dependencies': dependencies,
             'reverse_dependencies': reverse_dependencies,
             'anchors': anchors,
-            'overlays': self._get_overlays(layer_name)
+            'phases': self._get_phase_content(layer_name)
         }
 
     def _get_companion_doc(self, layer_name: str, format: str = 'markdown') -> str:
@@ -1291,9 +1309,18 @@ def _layer_main(args):
             layer_path = manager.layer_files.get(lkey, "<unknown>")
             rel_layer_path = manager.layer_relpaths.get(lkey, layer_path)
             print(f"Path: {rel_layer_path}")
-            overlays = manager._get_overlays(layer_name, key=lkey)
-            if overlays:
-                print(f"Overlay: {', '.join(overlays)}")
+            phases = manager._get_phase_content(layer_name, key=lkey)
+            overlay_phases = [p for p in phases if p['overlay']]
+            if overlay_phases:
+                print("Overlays:")
+                for p in overlay_phases:
+                    print(f"  - {p['phase']}: {p['overlay']}")
+
+            hook_phases = [p for p in phases if p['hooks']]
+            if hook_phases:
+                print("Hooks:")
+                for p in hook_phases:
+                    print(f"  - {p['phase']}: {', '.join(p['hooks'])}")
 
             mmdebstrap = manager._get_mmdebstrap_config(layer_name, key=lkey)
             if mmdebstrap:

--- a/site/pipeline.py
+++ b/site/pipeline.py
@@ -195,6 +195,9 @@ def _log_providers(manager: LayerManager, build_order: List[str]) -> None:
 
 
 def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) -> None:
+    # A WORKROOT: tag, not ${WORKDIR}'s "${@WORKROOT}/..." anchor form -
+    # @WORKROOT may need real shell evaluation this process can't do; bash
+    # resolves the tag via map_path, same as DEVICE_ASSET/IMAGE_ASSET.
     try:
         with open(path, "w", encoding="utf-8") as handle:
             for layer in build_order:
@@ -202,7 +205,8 @@ def _write_layer_plan(path: str, build_order: List[str], manager: LayerManager) 
                 version = info.get("version", "")
                 static = manager.layer_source_files.get(manager._resolve_key(layer), "")
                 resolved = manager.layer_files.get(manager._resolve_key(layer), "")
-                handle.write(f'{layer}:{version}:{static}:{resolved}\n')
+                workdir = f"WORKROOT:{info.get('workdir_suffix', '')}"
+                handle.write(f'{layer}:{version}:{static}:{resolved}:{workdir}\n')
         print(f"Layer plan written to: {path}")
     except Exception as exc:
         print(f"Error writing layer plan to {path}: {exc}")

--- a/site/validators.py
+++ b/site/validators.py
@@ -452,7 +452,8 @@ def get_validator_documentation_data() -> dict:
             {'name': '${FILEPATH}', 'description': 'absolute path to the file'},
             {'name': '${NAME}', 'description': "the layer's X-Env-Layer-Name"},
             {'name': '${VERSION}', 'description': "the layer's X-Env-Layer-Version"},
-            {'name': '${UUID}', 'description': "UUID derived from the layer's name and version, stable across builds"}
+            {'name': '${UUID}', 'description': "UUID derived from the layer's name and version, stable across builds"},
+            {'name': '${WORKDIR}', 'description': "the layer's own persistent, uniquely namespaced work directory for per-layer build operations"}
         ]
     }
 
@@ -512,6 +513,7 @@ def get_validation_help() -> str:
         "  ${NAME}       - the layer's X-Env-Layer-Name",
         "  ${VERSION}    - the layer's X-Env-Layer-Version",
         "  ${UUID}       - UUID derived from the layer's name and version, stable across builds",
+        "  ${WORKDIR}    - the layer's own persistent, uniquely namespaced work directory",
         "  Escape with \\${...} to keep the literal text.\n",
 
         "SET POLICY (X-Env-Var-*-Set):",

--- a/templates/docs/html/index.html
+++ b/templates/docs/html/index.html
@@ -129,14 +129,13 @@
     </div>
 
     {% if layers %}
-    <h2>Available Layers</h2>
     {% set categories = layers|groupby('category') %}
     {% for category, category_layers in categories %}
     <h3>{{ category }}</h3>
     <div class="layer-list">
         {% for layer in category_layers %}
         <div class="layer-item">
-            <a href="{{ layer.filename }}">{{ layer.name }}</a><span class="layer-desc">- {{ layer.description }}</span>
+            <a href="{{ layer.filename }}">{{ layer.name }}</a><span class="layer-desc" title="{{ layer.description }}">- {{ layer.description|truncate(100, False, '…') }}</span>
         </div>
         {% endfor %}
     </div>

--- a/templates/docs/html/layer-index.html
+++ b/templates/docs/html/layer-index.html
@@ -138,17 +138,5 @@
         {{ content|safe }}
     </div>
 
-    <h2>Available Layers</h2>
-    {% set categories = layers|groupby('category') %}
-    {% for category, category_layers in categories %}
-    <h3>{{ category }}</h3>
-    <div class="layer-list">
-        {% for layer in category_layers %}
-        <div class="layer-item">
-            <a href="{{ layer.name }}.html">{{ layer.name }}</a><span class="layer-desc">- {{ layer.description|truncate(120, True, '...') }}</span>
-        </div>
-        {% endfor %}
-    </div>
-    {% endfor %}
 </body>
 </html>

--- a/templates/docs/html/layer.html
+++ b/templates/docs/html/layer.html
@@ -375,15 +375,56 @@
     </div>
     {%- endif %}
 
+    {%- if layer.phases|selectattr('overlay')|list %}
+    <div class="section">
+        <h2>Overlays</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th style="width: 1%; white-space: nowrap;">Phase</th>
+                    <th>Overlay</th>
+                </tr>
+            </thead>
+            <tbody>
+                {%- for p in layer.phases if p.overlay %}
+                <tr>
+                    <td><code>{{ p.phase }}</code></td>
+                    <td><code>{{ p.overlay }}</code></td>
+                </tr>
+                {%- endfor %}
+            </tbody>
+        </table>
+    </div>
+    {%- endif %}
+
+    {%- if layer.phases|selectattr('hooks')|list %}
+    <div class="section">
+        <h2>Hooks</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th style="width: 1%; white-space: nowrap;">Phase</th>
+                    <th>Hooks</th>
+                </tr>
+            </thead>
+            <tbody>
+                {%- for p in layer.phases if p.hooks %}
+                <tr>
+                    <td><code>{{ p.phase }}</code></td>
+                    <td>{{ p.hooks|join(', ') }}</td>
+                </tr>
+                {%- endfor %}
+            </tbody>
+        </table>
+    </div>
+    {%- endif %}
+
     <div class="section">
         <h2>Attributes</h2>
         <p><strong>File:</strong> <code>{{ layer.file_path }}</code></p>
         <p><strong>Type:</strong> <code>{{ layer.layer_info.type }}</code></p>
         {%- if layer.layer_info.type == 'dynamic' and layer.layer_info.generator %}
         <p><strong>Generator:</strong> <code>{{ layer.layer_info.generator }}</code></p>
-        {%- endif %}
-        {%- if layer.overlays %}
-        <p><strong>Overlay:</strong> {{ layer.overlays|join(', ') }}</p>
         {%- endif %}
         {%- if layer.layer_info.conflicts %}
         <p><strong>Conflicts:</strong> {{ layer.layer_info.conflicts|join(', ') }}</p>

--- a/templates/docs/html/layer.html
+++ b/templates/docs/html/layer.html
@@ -32,6 +32,7 @@
         .dep-badge:hover { background: #1e7e34; }
         /* Main content headers styling */
         h1, h2, h3, h4, h5, h6 { color: #333; margin-top: 20px; margin-bottom: 10px; }
+        h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { color: #333; text-decoration: none; }
         /* Companion documentation content styling */
         .companion-content h1, .companion-content h2, .companion-content h3, .companion-content h4, .companion-content h5, .companion-content h6 { color: #333; margin-top: 20px; margin-bottom: 10px; }
         .companion-content p { margin: 10px 0; }


### PR DESCRIPTION
Add support for a per-layer work directory, available to layer metadata via new placeholder `${WORKDIR}` and to hooks as environment variable `${LAYER_WORKDIR}`. Each layer's work dir is created automatically before bdebstrap execution takes place and is not wiped across builds (delete manually or use the `clean` command to erase).

A work directory directory provides a general scratch pad location for layers to use, eg for build/compilation operations. It's also now where the auto-generated pre/post YAML fragments live (ie, which support per-layer `customize` phase filesystem overlays).

Layers are already keyed by name + version, with a clash resulting in a hard error. This same key enables us to create a unique and clearly named path for each work dir under `IGconf_sys_workroot`. The engine emits a tagged, rather than relative, path for these directories (eg `WORKROOT:build/layer/image-rota-5.6.0`) because at the point the engine finishes execution, `IGconf_sys_workroot` has not been resolved. `lib/common.sh::map_path()` allows the tag to be mapped at run-time when the build commences, and so the full on-disk path is available then.

#311 requested that the layer reference page be standalone - it was becoming unwieldy to have as part of the layer's own docs page and had no quick nav. Both now solved.