### PR TITLE
Unify build artefact basename, fix postimage

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -34,35 +34,33 @@ SRCROOT:rootfs-overlay"
 )
 
 
-# Extra positional args a phase hands to everything it runs. The first is the
-# directory the phase operates on, and so the overlay destination.
+# Extra positional args a phase hands to everything it runs.
 phase_args() {
    local phase=$1
-   shift || true
 
+   PHASE_ARGS=()
    case $phase in
       postbuild)
-         set -- "$@" "${IGconf_target_path:?"required for $phase"}"
+         PHASE_ARGS+=("${IGconf_target_path:?"required for $phase"}")
          ;;
       preimage)
-         set -- "$@" "${IGconf_target_path:?"required for $phase"}"
-         set -- "$@" "${IGconf_image_outputdir:?"required for $phase"}"
+         PHASE_ARGS+=("${IGconf_target_path:?"required for $phase"}")
+         PHASE_ARGS+=("${IGconf_image_outputdir:?"required for $phase"}")
          ;;
       postimage)
-         set -- "$@" "${IGconf_image_outputdir:?"required for $phase"}"
+         PHASE_ARGS+=("${IGconf_image_outputdir:?"required for $phase"}")
          ;;
       sbom)
-         set -- "$@" "${IGconf_target_path:?"required for $phase"}"
-         set -- "$@" "${IGconf_target_dir:?"required for $phase"}"
+         PHASE_ARGS+=("${IGconf_target_path:?"required for $phase"}")
+         PHASE_ARGS+=("${IGconf_target_dir:?"required for $phase"}")
          ;;
       deploy)
-         [[ -n ${IGconf_deploy_dir:-} ]] && set -- "$@" "$IGconf_deploy_dir"
+         PHASE_ARGS+=("${IGconf_deploy_dir:?"required for $phase"}")
+         [[ -d $IGconf_deploy_dir ]] ||
+            die "runner: $phase: $IGconf_deploy_dir does not exist"
          ;;
       *)
    esac
-   # No output at all when the phase adds nothing, otherwise a lone format
-   # pass would emit one empty argument
-   [[ $# -eq 0 ]] || printf '%s\0' "$@"
 }
 
 
@@ -173,11 +171,9 @@ run_phase() {
 }
 
 
-args=()
-while IFS= read -r -d '' arg ; do
-   args+=("$arg")
-done < <(phase_args "$PHASE")
-args+=("$@")
+declare -a PHASE_ARGS
+phase_args "$PHASE"
+args=("${PHASE_ARGS[@]}" "$@")
 
 msg "runner: in $PHASE"
 run_phase "$PHASE" "${args[@]}"

--- a/builtin/hooks/deploy99-manifest
+++ b/builtin/hooks/deploy99-manifest
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+# Inventory of the deploy directory
+
+deploy_dir=$1
+
+echo "Creating manifest..."
+{
+  echo "{"
+  echo "  \"deployment_info\": {"
+  echo "    \"version\": \"${IGconf_artefact_version:-}\","
+  echo "    \"date\": \"$(date -Iseconds)\""
+  echo "  },"
+  echo "  \"files\": ["
+
+  first=true
+  for f in "$deploy_dir"/*; do
+    [[ -f "$f" ]] || continue
+    [[ "$(basename "$f")" == "deployed.json" ]] && continue
+    [[ "$first" == true ]] || echo ","
+    first=false
+
+    size=$(stat -c %s "$f")
+    mime_type=$(file -b --mime-type "$f" 2>/dev/null || echo "unknown")
+
+    echo "    {"
+    echo "      \"name\": \"$(basename "$f")\","
+    echo "      \"size\": $size,"
+    echo "      \"mime_type\": \"$mime_type\","
+    echo "      \"sha1\": \"$(sha1sum "$f" | cut -d' ' -f1)\""
+    echo "    }"
+  done
+
+  echo "  ]"
+  echo "}"
+} > "$deploy_dir/deployed.json"

--- a/builtin/hooks/postimage10-align
+++ b/builtin/hooks/postimage10-align
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+# Output images must be a multiple of the device sector size
+for f in "${1}/${IGconf_image_name}"*.${IGconf_image_suffix} ; do
+   [[ -f "$f" ]] || continue
+   truncate -s %"${IGconf_device_sector_size}" "$f"
+done

--- a/builtin/hooks/postimage50-idp
+++ b/builtin/hooks/postimage50-idp
@@ -3,14 +3,13 @@
 set -eu
 
 
-fstabs=()
 opts=()
 pmap_installed=false
 
 pmap="${IGconf_image_outputdir}/provisionmap.json"
 
+# Validate an installed Provisioning Map against its schema
 if [ -f "$pmap" ] ; then
-   # Validate installed Provisioning Map against its schema
    pmap --schema "$IGconf_image_pmap_schema" --file "$pmap" ||
       die "IDP: Installed Provisioning Map failed validation."
    pmap_installed=true
@@ -19,15 +18,8 @@ else
    warn "IDP: No Provisioning Map installed. Raspberry Pi provisioning flow unsupported."
 fi
 
+# Only genimage output is supported for IDP flow
 if [ "${IGconf_image_provider:-}" = "genimage" ] && [ -f ${1}/genimage.cfg ] ; then
-   fstabs+=("${1}"/fstab*)
-   for f in "${fstabs[@]}" ; do
-      if [ -f "$f" ] ; then
-         opts+=('-f' $f)
-      fi
-   done
-
-   # Generate the IDP doc
    image2json -g ${1}/genimage.cfg "${opts[@]}" > ${1}/image.json ||
       die "IDP: Doc generation failed."
 
@@ -41,14 +33,3 @@ if [ "${IGconf_image_provider:-}" = "genimage" ] && [ -f ${1}/genimage.cfg ] ; t
          die "IDP: Merged PMAP failed validation."
    fi
 fi
-
-
-files=()
-
-for f in "${1}/${IGconf_image_name}"*.${IGconf_image_suffix} ; do
-   files+=($f)
-   [[ -f "$f" ]] || continue
-
-   # Ensure that the output image is a multiple of the selected sector size
-   truncate -s %${IGconf_device_sector_size} $f
-done

--- a/examples/ota/README.md
+++ b/examples/ota/README.md
@@ -6,7 +6,7 @@ This is a skeleton system that:
 * Installs Raspberry Pi Connect Lite
 * Installs and configures Raspberry Pi experimental OTA functionality
 
-One of the by-products of the build is `update.tar.zst` located under `work/image-myapp/` which can be deployed to the device via Raspberry Pi Connect to update it.
+The build produces an OTA bundle named after the image, `<image.name>.update.tar.zst`, which is placed in the deploy directory alongside the disk image and IDP archive. It can be deployed to the device via Raspberry Pi Connect to update it.
 
 A device can auto-signin with Raspberry Pi Connect on first boot in one of two ways:
 

--- a/image/gpt/ab_userdata/image.d/hooks/deploy05-update
+++ b/image/gpt/ab_userdata/image.d/hooks/deploy05-update
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu
+
+# The OTA bundle is packed by a prior script and is already a compressed archive
+upd="${IGconf_image_outputdir}/${IGconf_image_name:-image}.update.tar.zst"
+[[ -f "$upd" ]] || exit 0
+cp -v "$upd" "${1}"

--- a/image/gpt/ab_userdata/image.d/hooks/postimage05-pack-update
+++ b/image/gpt/ab_userdata/image.d/hooks/postimage05-pack-update
@@ -12,5 +12,5 @@ mkdir -p $upd
 ln -sf ../system.sparse ${upd}/system
 ln -sf ../boot.sparse ${upd}/boot
 
-msg "Packing..."
-cd $upd && tar -I zstd -h -cf  ${1}/update.tar.zst -- *
+msg "Packing for OTA..."
+cd $upd && tar -I zstd -h -cf  ${1}/"${IGconf_image_name:-image}".update.tar.zst -- *

--- a/layer/base/core-essential.yaml
+++ b/layer/base/core-essential.yaml
@@ -4,7 +4,7 @@
 # X-Env-Layer-Desc:  Serves as the mandatory foundation for all rpi-image-gen
 #  builds, and is automatically included in every configuration to provide
 #  essential build infrastructure.
-# X-Env-Layer-Version: 2.0.0
-# X-Env-Layer-Requires: artefact-base,sys-build-base,target-config
+# X-Env-Layer-Version: 2.1.0
+# X-Env-Layer-Requires: artefact-base,sys-build-base,target-config,deploy-base
 # METAEND
 ---

--- a/layer/base/deploy-base.d/hooks/deploy05-raw
+++ b/layer/base/deploy-base.d/hooks/deploy05-raw
@@ -2,6 +2,10 @@
 
 set -eu
 
+# Traditional only: whole disk image, filesystem artefact, build metadata.
+# Per-partition sparse images and image.json are payloads of the IDP bundle and
+# deployed separately.
+
 files=()
 
 # Image assets
@@ -12,15 +16,6 @@ if [[ -n "${IGconf_image_outputdir:-}" ]] ; then
          files+=("$f")
       done
    fi
-
-   pat="${IGconf_image_outputdir}"/*.sparse
-   if compgen -G "$pat" > /dev/null 2>&1; then
-      for f in $pat ; do
-         files+=("$f")
-      done
-   fi
-
-   files+=("${IGconf_image_outputdir}/image.json")
 fi
 
 # Filesystem assets
@@ -31,49 +26,16 @@ files+=("${IGconf_target_dir}/config.yaml")
 
 
 echo "Installing assets..."
-mkdir -p "$IGconf_deploy_dir"
 for f in "${files[@]}" ; do
    [[ -f "$f" ]] || continue
    case "$IGconf_deploy_compression" in
       zstd)
-         zstd -v -f "$f" --sparse --output-dir-flat "$IGconf_deploy_dir"
+         zstd -v -f "$f" --sparse --output-dir-flat "${1}"
          ;;
       none)
-         cp -v --sparse=always "$f" "$IGconf_deploy_dir"
+         cp -v --sparse=always "$f" "${1}"
          ;;
       *)
          ;;
    esac
 done
-
-
-echo "Creating manifest..."
-{
-  echo "{"
-  echo "  \"deployment_info\": {"
-  echo "    \"version\": \"${IGconf_artefact_version:-}\","
-  echo "    \"date\": \"$(date -Iseconds)\""
-  echo "  },"
-  echo "  \"files\": ["
-
-  first=true
-  for f in "$IGconf_deploy_dir"/*; do
-    [[ -f "$f" ]] || continue
-    [[ "$(basename "$f")" == "deployed.json" ]] && continue
-    [[ "$first" == true ]] || echo ","
-    first=false
-
-    size=$(stat -c %s "$f")
-    mime_type=$(file -b --mime-type "$f" 2>/dev/null || echo "unknown")
-
-    echo "    {"
-    echo "      \"name\": \"$(basename "$f")\","
-    echo "      \"size\": $size,"
-    echo "      \"mime_type\": \"$mime_type\","
-    echo "      \"sha1\": \"$(sha1sum "$f" | cut -d' ' -f1)\""
-    echo "    }"
-  done
-
-  echo "  ]"
-  echo "}"
-} > "$IGconf_deploy_dir/deployed.json"

--- a/layer/base/deploy-base.d/hooks/deploy10-idp
+++ b/layer/base/deploy-base.d/hooks/deploy10-idp
@@ -2,22 +2,16 @@
 
 set -eu
 
-# Create a .tar.zst IDP archive suitable for upload to rpi-sb-provisioner.
-# Bundles uncompressed image.json + the per-partition sparse images it
-# references, at the top level of the tar. The whole-disk image is deliberately
-# excluded: consumers flash per-partition, resolving payloads through
-# image.json's .layout.partitionimages[].simage, and never read it. Globbing
-# *.sparse instead would bundle it too, roughly doubling the archive for
-# nothing.
-# Requires zstd, so only run when the compression scheme guarantees it is available.
-if [[ "$IGconf_deploy_compression" == "zstd" ]] && [[ -f "${IGconf_image_outputdir}/image.json" ]]; then
-    echo "Creating IDP archive..."
+outdir=${IGconf_image_outputdir:-}
+[[ -n "$outdir" && -f "$outdir/image.json" ]] || exit 0
 
-    # Take the payload list from image.json itself so the archive always holds
-    # exactly what the consumer resolves. A/B layouts legitimately reference one
-    # sparse image from several partitions (boot_a and boot_b both point at
-    # boot.vfat.sparse), hence the dedupe; sorted for a reproducible tar.
-    simages=$(python3 -c '
+echo "Creating IDP archive..."
+
+# Take the payload list from image.json itself so the archive always holds
+# exactly what the consumer resolves. A/B layouts legitimately reference one
+# sparse image from several partitions (boot_a and boot_b both point at
+# boot.vfat.sparse), hence the dedupe; sorted for a reproducible tar.
+simages=$(python3 -c '
 import json, sys
 
 with open(sys.argv[1]) as f:
@@ -29,20 +23,31 @@ names = {p["simage"] for p in pimages.values()
 if not names:
     sys.exit("image.json declares no partition sparse images")
 print("\n".join(sorted(names)))
-' "${IGconf_image_outputdir}/image.json")
+' "$outdir/image.json")
 
-    idp_files=("image.json")
-    while IFS= read -r s; do
-        [[ -n "$s" ]] || continue
-        # A referenced payload that is absent yields an archive the provisioner
-        # rejects as incomplete, so fail here rather than ship it.
-        [[ -f "${IGconf_image_outputdir}/${s}" ]] || \
-           { echo "IDP archive incomplete: image.json references missing $s" >&2; exit 1; }
-        idp_files+=("$s")
-    done <<< "$simages"
+idp_files=("image.json")
+while IFS= read -r s; do
+    [[ -n "$s" ]] || continue
+    # A referenced payload that is absent yields an archive the provisioner
+    # rejects as incomplete, so fail here rather than ship it.
+    [[ -f "$outdir/${s}" ]] || \
+       die "IDP archive incomplete: image.json references missing $s"
+    idp_files+=("$s")
+done <<< "$simages"
 
-    archive_name="${IGconf_image_name:-image}-${IGconf_artefact_version:-unknown}.tar.zst"
-    tar -C "${IGconf_image_outputdir}" -cf - "${idp_files[@]}" \
-        | zstd -f -o "$IGconf_deploy_dir/$archive_name"
-    echo "Created IDP archive: $IGconf_deploy_dir/$archive_name"
-fi
+
+# Create the bundle, preserving sparseness, compressing if enabled
+base="${IGconf_image_name:-image}.idp.tar"
+case "$IGconf_deploy_compression" in
+   zstd)
+      archive_name="${base}.zst"
+      tar -S -C "$outdir" -cf - "${idp_files[@]}" \
+         | zstd -f -o "${1}/$archive_name"
+      ;;
+   *)
+      archive_name="${base}"
+      tar -S -C "$outdir" -cf "${1}/$archive_name" \
+         "${idp_files[@]}"
+      ;;
+esac
+echo "Done: ${1}/$archive_name"

--- a/layer/base/deploy-base.yaml
+++ b/layer/base/deploy-base.yaml
@@ -2,7 +2,7 @@
 # X-Env-Layer-Name: deploy-base
 # X-Env-Layer-Category: build
 # X-Env-Layer-Desc: Deployment and organisation for build output artefacts
-# X-Env-Layer-Version: 2.0.0
+# X-Env-Layer-Version: 2.1.0
 # X-Env-Layer-Requires: artefact-base,sys-build-base
 #
 # X-Env-VarPrefix: deploy
@@ -29,3 +29,6 @@
 #
 # METAEND
 ---
+mmdebstrap:
+  setup-hooks:
+    - mkdir -p "$IGconf_deploy_dir"


### PR DESCRIPTION
This merge request unifies build output artefacts with a single basename and fixes a slew of other problems with generated files.
Fixes #316 