### PR TITLE
webkiosk: Don't persist Chromium run-time data

### DIFF
--- a/examples/webkiosk/kiosk.service.tpl
+++ b/examples/webkiosk/kiosk.service.tpl
@@ -8,7 +8,9 @@ After=multi-user.target
 [Service]
 User=$KIOSK_USER
 TTYPath=/dev/tty1
-Environment="XDG_RUNTIME_DIR=$KIOSK_RUNDIR"
+RuntimeDirectory=$KIOSK_RUNDIR_NAME
+RuntimeDirectoryMode=0700
+Environment="XDG_RUNTIME_DIR=/run/$KIOSK_RUNDIR_NAME"
 Restart=always
 ExecStart=/usr/bin/cage -- $KIOSK_APP
 StandardError=journal

--- a/examples/webkiosk/layer/mykiosk.yaml
+++ b/examples/webkiosk/layer/mykiosk.yaml
@@ -1,6 +1,6 @@
 # METABEGIN
 # X-Env-Layer-Name: example-kiosk
-# X-Env-Layer-Version: 1.1.0
+# X-Env-Layer-Version: 2.0.0
 # X-Env-Layer-Category: example
 # X-Env-Layer-Desc: Example webkiosk layer showing how to define configuration
 #  variables, declare packages and create a start up script. We depend on the
@@ -24,8 +24,9 @@ mmdebstrap:
   customize-hooks:
     - |
       export KIOSK_USER="$IGconf_device_user1"
-      export KIOSK_RUNDIR="/home/$IGconf_device_user1"
+      export KIOSK_RUNDIR_NAME="kiosk"
       export KIOSK_URL="$IGconf_kiosk_url"
-      export KIOSK_APP="/usr/bin/chromium $KIOSK_URL https://time.is/London --kiosk --noerrdialogs --disable-infobars --no-first-run --enable-features=OverlayScrollbar --start-maximized"
+      #export KIOSK_APP="/usr/bin/chromium $KIOSK_URL --kiosk --noerrdialogs --disable-infobars --no-first-run --force-dark-mode --enable-features=OverlayScrollbar,WebUIDarkMode --start-maximized --user-data-dir=/run/$KIOSK_RUNDIR_NAME/chromium"
+      export KIOSK_APP="/usr/bin/chromium $KIOSK_URL --kiosk --noerrdialogs --disable-infobars --no-first-run --enable-features=OverlayScrollbar --start-maximized --user-data-dir=/run/$KIOSK_RUNDIR_NAME/chromium"
       envsubst < kiosk.service.tpl > $1/etc/systemd/system/kiosk.service
     - $BDEBSTRAP_HOOKS/enable-units "$1" kiosk


### PR DESCRIPTION
We cannot guarantee that Chromium will remove its lock file on a slot flip or reboot. mykiosk.yaml set KIOSK_RUNDIR to the kiosk user's home dir which meant that XDG_RUNTIME_DIR was the user's home dir, therefore persisting all Chromium's data across slot flips. Chromium fails to start if there is a stale lock file.

Fix this by routing KIOSK_RUNDIR to tmpfs, therefore making XDG_RUNTIME_DIR tmpfs and not persisting any Chromium profile data on any boot cycle. The app starts fresh each time.

Leave a handy line in the layer to build for dark mode if desired.